### PR TITLE
Usermode +z for secure-only queries.

### DIFF
--- a/src/modules/m_sslmodes.cpp
+++ b/src/modules/m_sslmodes.cpp
@@ -71,10 +71,21 @@ public:
 	{
 		bool isSet = dest->IsModeSet('z');
 
-		if ((adding && !isSet) || (!adding && isSet))
+		if (adding)
 		{
-			dest->SetMode('z', adding);
-			return MODEACTION_ALLOW;
+			if (isSet)
+			{
+				dest->SetMode('z', true);
+				return MODEACTION_ALLOW;
+			}
+		}
+		else
+		{
+			if (!isSet)
+			{
+				dest->SetMode('z', false);
+				return MODEACTION_ALLOW;
+			}
 		}
 
 		return MODEACTION_DENY;


### PR DESCRIPTION
If a user is +z they will be unable to receive messages from non-ssl users.

This does effect opers but it doesn't affect u-lined servers.
