### PR TITLE
configure: fix check for eventfd support.

### DIFF
--- a/make/check_eventfd.cpp
+++ b/make/check_eventfd.cpp
@@ -1,6 +1,11 @@
 #include <sys/eventfd.h>
 
 int main() {
-	int fd = eventfd(0, EFD_NONBLOCK);
+	eventfd_t efd_data;
+	int fd;
+
+	fd = eventfd(0, EFD_NONBLOCK);
+	eventfd_read(fd, &efd_data);
+
 	return (fd < 0);
 }


### PR DESCRIPTION
InspIRCd uses eventfd_read() which was not introduced until after eventfd was first
added to glibc.  uClibc, for example, still does not have support for eventfd_read().
