### PR TITLE
Replace [cC]olour with [cC]olor

### DIFF
--- a/docs/inspircd.helpop-full.example
+++ b/docs/inspircd.helpop-full.example
@@ -799,7 +799,7 @@ Closes all unregistered connections to the local server.">
               (IRCop only, requires invisible module).
  R            Blocks private messages from unregistered users
               (requires services account module).
- S            Strips mIRC colour/bold/underline codes out of private
+ S            Strips mIRC color/bold/underline codes out of private
               messages to the user (requires stripcolor module).
  W            Receives notification when a user uses WHOIS on them
               (IRCop only, requires showwhois module).">
@@ -826,7 +826,7 @@ Closes all unregistered connections to the local server.">
                     users to join while the channel is invite-only
                     (requires inviteexception module).
 
- c                  Blocks messages containing mIRC colour codes
+ c                  Blocks messages containing mIRC color codes
                     (requires blockcolor module).
  d [time]           Blocks messages to a channel from new users
                     until they have been in the channel for [time]
@@ -899,7 +899,7 @@ Closes all unregistered connections to the local server.">
                     (requires nokicks module)
  R                  Blocks unregistered users from joining (requires
                     services account module).
- S                  Strips mIRC colour codes from messages to the
+ S                  Strips mIRC color codes from messages to the
                     channel (requirs stripcolor module).
  T                  Blocks /NOTICEs to the channel from users who are
                     not at least halfop (requires nonotice module).
@@ -1024,7 +1024,7 @@ Matching extbans:
 
 Acting extbans:
 
- c:<ban>       Blocks any messages that contain colour codes from
+ c:<ban>       Blocks any messages that contain color codes from
                matching users (requires blockcolor module).
  m:<ban>       Blocks messages from matching users (requires muteban
                module). Users with +v or above are not affected.

--- a/docs/inspircd.helpop.example
+++ b/docs/inspircd.helpop.example
@@ -107,7 +107,7 @@ LOCKSERV       UNLOCKSERV   JUMPSERVER">
               (IRCop only, requires invisible module).
  R            Blocks private messages from unregistered users
               (requires services account module).
- S            Strips mIRC colour/bold/underline codes out of private
+ S            Strips mIRC color/bold/underline codes out of private
               messages to the user (requires stripcolor module).
  W            Receives notification when a user uses WHOIS on them
               (IRCop only, requires showwhois module).">
@@ -134,7 +134,7 @@ LOCKSERV       UNLOCKSERV   JUMPSERVER">
                     users to join while the channel is invite-only
                     (requires inviteexception module).
 
- c                  Blocks messages containing mIRC colour codes
+ c                  Blocks messages containing mIRC color codes
                     (requires blockcolor module).
  f [*][lines]:[sec] Kicks on text flood equal to or above the
                     specified rate. With *, the user is banned
@@ -206,7 +206,7 @@ LOCKSERV       UNLOCKSERV   JUMPSERVER">
                     (requires nokicks module)
  R                  Blocks unregistered users from joining (requires
                     services account module).
- S                  Strips mIRC colour codes from messages to the
+ S                  Strips mIRC color codes from messages to the
                     channel (requirs stripcolor module).
  T                  Blocks /NOTICEs to the channel from users who are
                     not at least halfop (requires nonotice module).
@@ -254,7 +254,7 @@ help channel if you have any questions.">
 <helpop key="extbans" value="Extended Bans
 ----------
 
- c:n!u@h      Blocks any messages that contain colour codes from
+ c:n!u@h      Blocks any messages that contain color codes from
               matching users (requires blockcolor module).
  j:#channel   Prevents anyone in #channel from joining the channel
               (requires channelban module).

--- a/docs/modules.conf.example
+++ b/docs/modules.conf.example
@@ -265,7 +265,7 @@
 #           capsmap="ABCDEFGHIJKLMNOPQRSTUVWXYZ! ">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Block colour module: Blocking colour-coded messages with cmode +c
+# Block color module: Blocking color-coded messages with cmode +c
 #<module name="m_blockcolor.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
@@ -393,7 +393,7 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Channel Names module: Allows disabling channels which have certain
-# characters in the channel name such as bold, colourcodes, etc which
+# characters in the channel name such as bold, colorcodes, etc which
 # can be quite annoying and allow users to on occasion have a channel
 # that looks like the name of another channel on the network.
 #<module name="m_channames.so">
@@ -1624,7 +1624,7 @@
 # your configuration file!                                            #
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Strip colour module: Adds the channel mode +S
+# Strip color module: Adds the channel mode +S
 #<module name="m_stripcolor.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#

--- a/docs/modules/modules.conf.charybdis
+++ b/docs/modules/modules.conf.charybdis
@@ -71,7 +71,7 @@
 <module name="m_chancreate.so">
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Channel Names module: Allows disabling channels which have certain
-# characters in the channel name such as bold, colourcodes, etc which
+# characters in the channel name such as bold, colorcodes, etc which
 # can be quite annoying and allow users to on occasion have a channel
 # that looks like the name of another channel on the network.
 <module name="m_channames.so">

--- a/src/modules/m_blockcolor.cpp
+++ b/src/modules/m_blockcolor.cpp
@@ -23,13 +23,13 @@ class BlockColor : public SimpleChannelModeHandler
 	BlockColor(Module* Creator) : SimpleChannelModeHandler(Creator, "blockcolor", 'c') { }
 };
 
-class ModuleBlockColour : public Module
+class ModuleBlockColor : public Module
 {
 	bool AllowChanOps;
 	BlockColor bc;
  public:
 
-	ModuleBlockColour() : bc(this)
+	ModuleBlockColor() : bc(this)
 	{
 		if (!ServerInstance->Modes->AddMode(&bc))
 			throw ModuleException("Could not add new modes!");
@@ -64,7 +64,7 @@ class ModuleBlockColour : public Module
 						case 21:
 						case 22:
 						case 31:
-							user->WriteNumeric(404, "%s %s :Can't send colours to channel (+c set)",user->nick.c_str(), c->name.c_str());
+							user->WriteNumeric(404, "%s %s :Can't send colors to channel (+c set)",user->nick.c_str(), c->name.c_str());
 							return MOD_RES_DENY;
 						break;
 					}
@@ -79,7 +79,7 @@ class ModuleBlockColour : public Module
 		return OnUserPreMessage(user,dest,target_type,text,status,exempt_list);
 	}
 
-	virtual ~ModuleBlockColour()
+	virtual ~ModuleBlockColor()
 	{
 	}
 
@@ -89,4 +89,4 @@ class ModuleBlockColour : public Module
 	}
 };
 
-MODULE_INIT(ModuleBlockColour)
+MODULE_INIT(ModuleBlockColor)

--- a/src/modules/m_stripcolor.cpp
+++ b/src/modules/m_stripcolor.cpp
@@ -13,7 +13,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides channel +S mode (strip ansi colour) */
+/* $ModDesc: Provides channel +S mode (strip ansi color) */
 
 /** Handles channel mode +S
  */
@@ -137,7 +137,7 @@ class ModuleStripColor : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides channel +S mode (strip ansi colour)", VF_VENDOR);
+		return Version("Provides channel +S mode (strip ansi color)", VF_VENDOR);
 	}
 
 };


### PR DESCRIPTION
Making things consistent, the modules are named '...color', let's keep
on using that instead of 'colour'.
