### PR TITLE
Add <connect:maxconnwarn>

### DIFF
--- a/docs/inspircd.conf.example
+++ b/docs/inspircd.conf.example
@@ -268,6 +268,9 @@
          # globalmax: Maximum global (network-wide) connections per IP (or CIDR mask, see below).
          globalmax="3"
 
+         # maxconnwarn: Enable warnings when localmax or globalmax is hit (defaults to on)
+         maxconnwarn="off"
+
          # useident: Defines if users in this class MUST respond to a ident query or not.
          useident="no"
 

--- a/include/users.h
+++ b/include/users.h
@@ -121,6 +121,10 @@ struct CoreExport ConnectClass : public refcountbase
 	 */
 	unsigned long maxglobal;
 
+	/** True if max connections for this class is hit and a warning is wanted
+	 */
+	bool maxconnwarn;
+
 	/** Max channels for this class
 	 */
 	unsigned int maxchans;

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -375,6 +375,7 @@ void ServerConfig::CrossCheckConnectBlocks(ServerConfig* current)
 			me->maxlocal = tag->getInt("localmax", me->maxlocal);
 			me->maxglobal = tag->getInt("globalmax", me->maxglobal);
 			me->maxchans = tag->getInt("maxchans", me->maxchans);
+			me->maxconnwarn = tag->getBool("maxconnwarn", me->maxconnwarn);
 			me->limit = tag->getInt("limit", me->limit);
 
 			ClassMap::iterator oldMask = oldBlocksByMask.find(typeMask);

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -734,13 +734,15 @@ void LocalUser::CheckClass()
 	else if ((a->GetMaxLocal()) && (ServerInstance->Users->LocalCloneCount(this) > a->GetMaxLocal()))
 	{
 		ServerInstance->Users->QuitUser(this, "No more connections allowed from your host via this connect class (local)");
-		ServerInstance->SNO->WriteToSnoMask('a', "WARNING: maximum LOCAL connections (%ld) exceeded for IP %s", a->GetMaxLocal(), this->GetIPString());
+		if (a->maxconnwarn)
+			ServerInstance->SNO->WriteToSnoMask('a', "WARNING: maximum LOCAL connections (%ld) exceeded for IP %s", a->GetMaxLocal(), this->GetIPString());
 		return;
 	}
 	else if ((a->GetMaxGlobal()) && (ServerInstance->Users->GlobalCloneCount(this) > a->GetMaxGlobal()))
 	{
 		ServerInstance->Users->QuitUser(this, "No more connections allowed from your host via this connect class (global)");
-		ServerInstance->SNO->WriteToSnoMask('a', "WARNING: maximum GLOBAL connections (%ld) exceeded for IP %s", a->GetMaxGlobal(), this->GetIPString());
+		if (a->maxconnwarn)
+			ServerInstance->SNO->WriteToSnoMask('a', "WARNING: maximum GLOBAL connections (%ld) exceeded for IP %s", a->GetMaxGlobal(), this->GetIPString());
 		return;
 	}
 
@@ -1693,7 +1695,7 @@ const std::string& FakeUser::GetFullRealHost()
 ConnectClass::ConnectClass(ConfigTag* tag, char t, const std::string& mask)
 	: config(tag), type(t), fakelag(true), name("unnamed"), registration_timeout(0), host(mask),
 	pingtime(0), softsendqmax(0), hardsendqmax(0), recvqmax(0),
-	penaltythreshold(0), commandrate(0), maxlocal(0), maxglobal(0), maxchans(0), limit(0)
+	penaltythreshold(0), commandrate(0), maxlocal(0), maxglobal(0), maxconnwarn(true), maxchans(0), limit(0)
 {
 }
 
@@ -1702,7 +1704,7 @@ ConnectClass::ConnectClass(ConfigTag* tag, char t, const std::string& mask, cons
 	registration_timeout(parent.registration_timeout), host(mask), pingtime(parent.pingtime),
 	softsendqmax(parent.softsendqmax), hardsendqmax(parent.hardsendqmax), recvqmax(parent.recvqmax),
 	penaltythreshold(parent.penaltythreshold), commandrate(parent.commandrate),
-	maxlocal(parent.maxlocal), maxglobal(parent.maxglobal), maxchans(parent.maxchans),
+	maxlocal(parent.maxlocal), maxglobal(parent.maxglobal), maxconnwarn(parent.maxconnwarn), maxchans(parent.maxchans),
 	limit(parent.limit)
 {
 }
@@ -1723,6 +1725,7 @@ void ConnectClass::Update(const ConnectClass* src)
 	commandrate = src->commandrate;
 	maxlocal = src->maxlocal;
 	maxglobal = src->maxglobal;
+	maxconnwarn = src->maxconnwarn;
 	maxchans = src->maxchans;
 	limit = src->limit;
 }


### PR DESCRIPTION
Created the maxconnwarn variable in the connect block, so you can make
connect blocks that only warns about max connections if you want to.
This reduces noise from connecting clients that have low maxlocal and/or
maxglobal. It is enabled by default.
