### PR TITLE
[1.2] Fix double free in m_rline

### DIFF
--- a/src/modules/m_rline.cpp
+++ b/src/modules/m_rline.cpp
@@ -217,7 +217,6 @@ class ModuleRLine : public Module
 		ServerInstance->XLines->DelAll("R");
 		ServerInstance->XLines->UnregisterFactory(f);
 		delete f;
-		delete r;
 	}
 
 	virtual Version GetVersion()


### PR DESCRIPTION
In 1.2 the core deletes the commands upon module unload not the module
