### PR TITLE
[2.0] Fix unused variables reported by the clang static analyzer.

### DIFF
--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -804,7 +804,6 @@ void Channel::UserList(User *user)
 			dlen = curlen = snprintf(list,MAXBUF,"%s %c %s :", user->nick.c_str(), this->IsModeSet('s') ? '@' : this->IsModeSet('p') ? '*' : '=', this->name.c_str());
 			ptr = list + dlen;
 
-			ptrlen = 0;
 			numusers = 0;
 		}
 

--- a/src/modules/m_spanningtree/fjoin.cpp
+++ b/src/modules/m_spanningtree/fjoin.cpp
@@ -93,7 +93,6 @@ CmdResult CommandFJoin::Handle(const std::vector<std::string>& params, User *src
 			parameterlist param_list;
 			if (Utils->AnnounceTSChange)
 				chan->WriteChannelWithServ(ServerInstance->Config->ServerName, "NOTICE %s :TS for %s changed from %lu to %lu", chan->name.c_str(), channel.c_str(), (unsigned long) ourTS, (unsigned long) TS);
-			ourTS = TS;
 			// while the name is equal in case-insensitive compare, it might differ in case; use the remote version
 			chan->name = channel;
 			chan->age = TS;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -100,7 +100,6 @@ void InspIRCd::IncrementUID(int pos)
 			for (int i = 3; i < (UUID_LENGTH - 1); i++)
 			{
 				current_uid[i] = 'A';
-				pos  = UUID_LENGTH - 1;
 			}
 		}
 		else


### PR DESCRIPTION
This commit fixes the following warnings:

```
src/channels.cpp:807:4: warning: Value stored to 'ptrlen' is never read
src/server.cpp:103:5: warning: Value stored to 'pos' is never read
src/modules/m_spanningtree/fjoin.cpp:96:4: warning: Value stored to 'ourTS' is never read
```
