### PR TITLE
[2.1] Fix unused variables reported by the clang static analyzer.

### DIFF
--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -754,7 +754,6 @@ void Channel::UserList(User *user)
 			dlen = curlen = snprintf(list,MAXBUF,"%s %c %s :", user->nick.c_str(), this->IsModeSet('s') ? '@' : this->IsModeSet('p') ? '*' : '=', this->name.c_str());
 			ptr = list + dlen;
 
-			ptrlen = 0;
 			numusers = 0;
 		}
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -98,7 +98,6 @@ void InspIRCd::IncrementUID(int pos)
 			for (int i = 3; i < (UUID_LENGTH - 1); i++)
 			{
 				current_uid[i] = 'A';
-				pos  = UUID_LENGTH - 1;
 			}
 		}
 		else


### PR DESCRIPTION
This is the 2.1 version of #53. It is identical apart from the 2.0 pull apart from the fjoin.cpp removal which had already been done on 2.1.
