### PR TITLE
[2.0] Avoid sending empty channel list numeric on whois

### DIFF
--- a/src/users.cpp
+++ b/src/users.cpp
@@ -1541,7 +1541,7 @@ void User::SplitChanList(User* dest, const std::string &cl)
 		}
 	}
 
-	if (line.length())
+	if (line.length() != prefix.str().length())
 	{
 		ServerInstance->SendWhoisLine(this, dest, 319, "%s", line.c_str());
 	}


### PR DESCRIPTION
Fix empty 319 numeric sent in reply to a whois when the target is not in any channels (or joined channels but we just wrapped around the line limit and got no more chans to display :P)
