### PR TITLE
[2.0] helpop: revert 05e6330 and make it the other way around

### DIFF
--- a/docs/inspircd.helpop-full.example
+++ b/docs/inspircd.helpop-full.example
@@ -2,7 +2,7 @@
 #  Helpop Standard  #
 #####################
 
-<alias text="HELPOP" replace="HELP $2-">
+<alias text="HELP" replace="HELPOP $2-">
 
 <helpop key="start" value="InspIRCd Help System
 
@@ -10,12 +10,12 @@ This system provides help for commands and modes.
 Specify your question or a command name as the
 parameter for this command.
 
-/HELP CUSER    -      To see a list of user commands
-/HELP COPER    -      To see a list of oper commands
-/HELP UMODES   -      To see a list of user modes
-/HELP CHMODES  -      To see a list of channel modes
-/HELP SNOMASKS -      To see a list of oper snotice masks
-/HELP EXTBANS  -      To see a list of extended bans">
+/HELPOP CUSER    -      To see a list of user commands
+/HELPOP COPER    -      To see a list of oper commands
+/HELPOP UMODES   -      To see a list of user modes
+/HELPOP CHMODES  -      To see a list of channel modes
+/HELPOP SNOMASKS -      To see a list of oper snotice masks
+/HELPOP EXTBANS  -      To see a list of extended bans">
 
 <helpop key="nohelp" value="There is no help for the topic
 you searched for. Please try again.">
@@ -205,8 +205,8 @@ A user may only set modes upon themselves, and may not set the
 +o usermode, and a user may only change channel modes of
 channels where they are at least a halfoperator.
 
-For a list of all user and channel modes, enter /HELP UMODES or
-/HELP CHMODES.">
+For a list of all user and channel modes, enter /HELPOP UMODES or
+/HELPOP CHMODES.">
 
 <helpop key="topic" value="/TOPIC [channel] {topic}
 

--- a/docs/inspircd.helpop.example
+++ b/docs/inspircd.helpop.example
@@ -9,7 +9,7 @@
 #   -- w00t 16/dec/2006
 #
 
-<alias text="HELPOP" replace="HELP $2-">
+<alias text="HELP" replace="HELPOP $2-">
 
 <helpop key="start" value="InspIRCd Help System
 
@@ -17,12 +17,12 @@ This system provides help for commands and modes.
 Specify your question or a command name as the
 parameter for this command.
 
-/HELP CUSER    -      To see a list of user commands
-/HELP COPER    -      To see a list of oper commands
-/HELP UMODES   -      To see a list of user modes
-/HELP CHMODES  -      To see a list of channel modes
-/HELP SNOMASKS -      To see a list of oper snotice masks
-/HELP EXTBANS  -      To see a list of extended bans">
+/HELPOP CUSER    -      To see a list of user commands
+/HELPOP COPER    -      To see a list of oper commands
+/HELPOP UMODES   -      To see a list of user modes
+/HELPOP CHMODES  -      To see a list of channel modes
+/HELPOP SNOMASKS -      To see a list of oper snotice masks
+/HELPOP EXTBANS  -      To see a list of extended bans">
 
 <helpop key="nohelp" value="There is no help for the topic
 you searched for. Please try again.">

--- a/src/modules/m_helpop.cpp
+++ b/src/modules/m_helpop.cpp
@@ -53,7 +53,7 @@ class Helpop : public ModeHandler
 class CommandHelpop : public Command
 {
  public:
-	CommandHelpop(Module* Creator) : Command(Creator, "HELP", 0)
+	CommandHelpop(Module* Creator) : Command(Creator, "HELPOP", 0)
 	{
 		syntax = "<any-text>";
 	}
@@ -176,7 +176,7 @@ class ModuleHelpop : public Module
 
 		Version GetVersion()
 		{
-			return Version("/help command, works like Unreal helpop", VF_VENDOR);
+			return Version("Provides the /HELPOP command, works like UnrealIRCd's helpop", VF_VENDOR);
 		}
 };
 


### PR DESCRIPTION
Revert 05e6330fbd6e9a427c09cf90e2cada10656c48f7 and reference HELPOP instead (afterall, the module is called helpop and references itself as that in the code/output too, and most clients override /help), also make the alias work the other way around. This also has the side effect to fix that /helpop doesn't work if m_alias is not loaded.
