### PR TITLE
[2.0] Process escape sequences for MOTD for issue #23

### DIFF
--- a/include/inspircd.h
+++ b/include/inspircd.h
@@ -444,6 +444,10 @@ class CoreExport InspIRCd
 	 */
 	LocalStringExt OperQuit;
 
+	/** Holds whether the MOTD has been parsed for color codes
+	*/
+	bool ProcessedMotdEscapes;
+
 	/** Get the current time
 	 * Because this only calls time() once every time around the mainloop,
 	 * it is much faster than calling time() directly.

--- a/src/commands/cmd_rehash.cpp
+++ b/src/commands/cmd_rehash.cpp
@@ -81,6 +81,7 @@ CmdResult CommandRehash::Handle (const std::vector<std::string>& parameters, Use
 		 * after the config thread has completed.
 		 */
 
+		ServerInstance->ProcessedMotdEscapes = false; // Reprocess our motd file --Justasic
 		ServerInstance->RehashUsersAndChans();
 		FOREACH_MOD(I_OnGarbageCollect, OnGarbageCollect());
 


### PR DESCRIPTION
Added C/C++ style escape codes for color codes in the MOTD along with @SaberUK's \x, \u, \b, \c codes.
