### PR TITLE
[2.1] Process escape sequences for MOTD for issue #23

### DIFF
--- a/include/inspircd.h
+++ b/include/inspircd.h
@@ -449,6 +449,10 @@ class CoreExport InspIRCd
 	 */
 	CrashState* TraceData;
 
+	/** Holds whether we've processed our MOTD escape codes
+	 */
+	bool ProcessedMotdEscapes;
+
 	/** Get the current time
 	 * Because this only calls time() once every time around the mainloop,
 	 * it is much faster than calling time() directly.

--- a/src/commands/cmd_rehash.cpp
+++ b/src/commands/cmd_rehash.cpp
@@ -94,7 +94,7 @@ CmdResult CommandRehash::Handle (const std::vector<std::string>& parameters, Use
 				ServerConfig::CleanFilename(ServerInstance->ConfigFileName.c_str()));
 
 		ServerInstance->DoGarbageCollect();
-
+		ServerInstance->ProcessedMotdEscapes = false; // Reprocess our motd file --Justasic
 		ServerInstance->PendingRehash = new ConfigReaderThread(user->uuid);
 		ServerInstance->Threads->Submit(ServerInstance->PendingRehash);
 


### PR DESCRIPTION
Added C/C++ style escape codes for color codes in the MOTD along with @SaberUK's \x, \u, \b, \c codes.
