### PR TITLE
[2.1] Renames <type:modes> to :automodes> to fix m_opermodes.

### DIFF
--- a/docs/opers.conf.example
+++ b/docs/opers.conf.example
@@ -68,7 +68,8 @@
 	# modes: usermodes besides +o that are set on a oper of this type
 	# when they oper up. Used for snomasks and other things.
 	# Requires that m_opermodes.so be loaded.
-	modes="+s +cCqQ">
+	# Note: This was named 'modes' in previous versions.
+	automodes="+s +cCqQ">
 
 <type name="GlobalOp" classes="OperChat BanControl HostCloak ServerLink" vhost="ircop.omega.org.za">
 <type name="Helper" classes="HostCloak" vhost="helper.omega.org.za">

--- a/src/modules/m_opermodes.cpp
+++ b/src/modules/m_opermodes.cpp
@@ -49,9 +49,9 @@ class ModuleModesOnOper : public Module
 
 	virtual void OnPostOper(User* user, const std::string &opertype, const std::string &opername)
 	{
-		// whenever a user opers, go through the oper types, find their <type:modes>,
-		// and if they have one apply their modes. The mode string can contain +modes
-		// to add modes to the user or -modes to take modes from the user.
+		/* whenever a user opers, go through the oper types, find their <type:automodes>,
+			and if they have one apply their modes. The mode string can contain +modes
+			to add modes to the user or -modes to take modes from the user. */
 		std::string ThisOpersModes = user->oper->getConfig("automodes");
 		if (!ThisOpersModes.empty())
 		{


### PR DESCRIPTION
When Daniel did the rename from type:modes to type:automodes he forgot to update the config and comments. This fixes that.
