### PR TITLE
[2.1] Changing the override documentation reference

### DIFF
--- a/docs/modules.conf.example
+++ b/docs/modules.conf.example
@@ -1164,8 +1164,8 @@
 #
 #-#-#-#-#-#-#-#-#-#-#   OVERRIDE CONFIGURATION   -#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #
-# m_override.so is too complex it describe here, see the wiki:        #
-# http://wiki.inspircd.org/Modules/override                           #
+# m_override.so is too complex to describe here. See the wiki:        #
+# https://github.com/inspircd/wiki/wiki/Override-Module               #
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Oper levels module: Gives each oper a level and prevents


### PR DESCRIPTION
Just updating the reference to the Wiki for m_override in modules.conf.example.

This could probably be applied against 2.0, 1.2, and earlier...
