### PR TITLE
[1.2] Only return prefix modes from ModeParser::ModeString()

### DIFF
--- a/src/mode.cpp
+++ b/src/mode.cpp
@@ -1008,7 +1008,7 @@ std::string ModeParser::ModeString(User* user, Channel* channel, bool nick_suffi
 	{
 		unsigned char pos = (mode-65) | MASK_CHANNEL;
 		ModeHandler* mh = modehandlers[pos];
-		if ((mh) && (mh->GetNumParams(true)) && (mh->GetNumParams(false)))
+		if ((mh) && (mh->GetPrefixRank() > 0))
 		{
 			ModePair ret;
 			ret = mh->ModeSet(NULL, user, channel, user->nick);


### PR DESCRIPTION
Previously it returned all mode chars regardless if they were actually prefix modes, e.g. +k, +g etc. if they were set on a user's nick.
This bug has manifested itself in different places all resulting in extra MODE lines being sent to users on a channel, for example spanningtree sent an FJOIN #chan 111 +nt k,000AAAAAA if the key was 000AAAAAA's nick, which in addition to confusing services made remote servers send a MODE #chan +k <nick> to their clients on #chan.
The same applied for all listmodes allowing an exact nick as a parameter, like +g, and also occured when doing a host cycle, delay joining a user and so on.
