### PR TITLE
[2.1] epoll: make sure EPOLLET flag does not get clobbered

### DIFF
--- a/src/socketengines/socketengine_epoll.cpp
+++ b/src/socketengines/socketengine_epoll.cpp
@@ -89,9 +89,9 @@ EPollEngine::~EPollEngine()
 	delete[] events;
 }
 
-static int mask_to_epoll(int event_mask)
+static unsigned mask_to_epoll(int event_mask)
 {
-	int rv = 0;
+	unsigned rv = 0;
 	if (event_mask & (FD_WANT_POLL_READ | FD_WANT_POLL_WRITE | FD_WANT_SINGLE_WRITE))
 	{
 		// we need to use standard polling on this FD
@@ -148,8 +148,8 @@ bool EPollEngine::AddFd(EventHandler* eh, int event_mask)
 
 void EPollEngine::OnSetEvent(EventHandler* eh, int old_mask, int new_mask)
 {
-	int old_events = mask_to_epoll(old_mask);
-	int new_events = mask_to_epoll(new_mask);
+	unsigned old_events = mask_to_epoll(old_mask);
+	unsigned new_events = mask_to_epoll(new_mask);
 	if (old_events != new_events)
 	{
 		// ok, we actually have something to tell the kernel about


### PR DESCRIPTION
EPOLLET is the highest bit, so storing EPOLLET in a signed value leads to
undefined behaviour.
