### PR TITLE
[2.0] Fix compile error caused by unistd.h not existing on Windows.

### DIFF
--- a/include/inspircd.h
+++ b/include/inspircd.h
@@ -55,7 +55,9 @@
 #include <cstring>
 #include <climits>
 #include <cstdio>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 
 #include <sstream>
 #include <string>


### PR DESCRIPTION
This issue was introduced by 485d103.
