### PR TITLE
[2.0] md5: zero the whole MD5Context, not only part of it

### DIFF
--- a/src/modules/m_md5.cpp
+++ b/src/modules/m_md5.cpp
@@ -158,7 +158,7 @@ class MD5Provider : public HashProvider
 
 		byteSwap(ctx->buf, 4);
 		memcpy(digest, ctx->buf, 16);
-		memset(ctx, 0, sizeof(ctx));
+		memset(ctx, 0, sizeof(*ctx));
 	}
 
 	void MD5Transform(word32 buf[4], word32 const in[16])


### PR DESCRIPTION
The end of MD5Final attempts to zero out the MD5Context that was passed to it, but it only zeros out `sizeof(MD5Context *)`'s worth of it because the size given to memset is that of the pointer, not the MD5Context.
