### PR TITLE
[2.1] Don't send a MODE on join when the join was silenced by a module

### DIFF
--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -628,7 +628,7 @@ void Channel::WriteAllExcept(User* user, bool serversource, char status, CUList 
 	if (!text)
 		return;
 
-	int offset = snprintf(textbuffer,MAXBUF,":%s ", user->GetFullHost().c_str());
+	int offset = snprintf(textbuffer,MAXBUF,":%s ", serversource ? ServerInstance->Config->ServerName.c_str() : user->GetFullHost().c_str());
 
 	va_start(argsPtr, text);
 	vsnprintf(textbuffer + offset, MAXBUF - offset, text, argsPtr);


### PR DESCRIPTION
Also fix printf-style WriteAllExcept not obeying serversource parameter
