### PR TITLE
[2.0] Registration timeouts and modules

### DIFF
--- a/include/inspircd.h
+++ b/include/inspircd.h
@@ -295,9 +295,10 @@ class CoreExport InspIRCd
 
 	/** Returns true when all modules have done pre-registration checks on a user
 	 * @param user The user to verify
+	 * @param suspend_timeout is set to true by modules to prevent Registration Timeout
 	 * @return True if all modules have finished checking this user
 	 */
-	bool AllModulesReportReady(LocalUser* user);
+	bool AllModulesReportReady(LocalUser* user, bool& suspend_timeout);
 
 	/** The current time, updated in the mainloop
 	 */

--- a/include/modules.h
+++ b/include/modules.h
@@ -986,9 +986,10 @@ class CoreExport Module : public classbase, public usecountbase
 	 * timeout is reached, the user is disconnected even if modules report that the user is
 	 * not ready to connect.
 	 * @param user The user to check
+	 * @param suspend_timeout false by default, set to true to block "registration timeout" from occuring.
 	 * @return true to indicate readiness, false if otherwise
 	 */
-	virtual ModResult OnCheckReady(LocalUser* user);
+	virtual ModResult OnCheckReady(LocalUser* user, bool& suspend_timeout);
 
 	/** Called whenever a user is about to register their connection (e.g. before the user
 	 * is sent the MOTD etc). Modules can use this method if they are performing a function

--- a/src/inspircd.cpp
+++ b/src/inspircd.cpp
@@ -844,10 +844,10 @@ int InspIRCd::Run()
  * (until this returns true, a user will block in the waiting state, waiting to connect up to the
  * registration timeout maximum seconds)
  */
-bool InspIRCd::AllModulesReportReady(LocalUser* user)
+bool InspIRCd::AllModulesReportReady(LocalUser* user, bool& suspend_timeout)
 {
 	ModResult res;
-	FIRST_MOD_RESULT(OnCheckReady, res, (user));
+	FIRST_MOD_RESULT(OnCheckReady, res, (user, suspend_timeout));
 	return (res == MOD_RES_PASSTHRU);
 }
 

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -115,7 +115,7 @@ void		Module::OnBackgroundTimer(time_t) { }
 ModResult	Module::OnPreCommand(std::string&, std::vector<std::string>&, LocalUser*, bool, const std::string&) { return MOD_RES_PASSTHRU; }
 void		Module::OnPostCommand(const std::string&, const std::vector<std::string>&, LocalUser*, CmdResult, const std::string&) { }
 void		Module::OnUserInit(LocalUser*) { }
-ModResult	Module::OnCheckReady(LocalUser*) { return MOD_RES_PASSTHRU; }
+ModResult	Module::OnCheckReady(LocalUser*, bool&) { return MOD_RES_PASSTHRU; }
 ModResult	Module::OnUserRegister(LocalUser*) { return MOD_RES_PASSTHRU; }
 ModResult	Module::OnUserPreKick(User*, Membership*, const std::string&) { return MOD_RES_PASSTHRU; }
 void		Module::OnUserKick(User*, Membership*, const std::string&, CUList&) { }

--- a/src/modules/extra/m_ldapauth.cpp
+++ b/src/modules/extra/m_ldapauth.cpp
@@ -256,9 +256,17 @@ public:
 		}
 	}
 
-	ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user, bool& suspend_timeout)
 	{
-		return ldapAuthed.get(user) ? MOD_RES_PASSTHRU : MOD_RES_DENY;
+		if (ldapAuthed.get(user))
+		{
+			return MOD_RES_PASSTHRU;
+		}
+		else
+		{
+			suspend_timeout = true;
+			return MOD_RES_DENY;
+		}
 	}
 
 	Version GetVersion()

--- a/src/modules/m_cap.cpp
+++ b/src/modules/m_cap.cpp
@@ -153,7 +153,13 @@ class ModuleCAP : public Module
 	{
 		/* Users in CAP state get held until CAP END */
 		if (cmd.reghold.get(user))
+		{
+			if (ServerInstance->Time() > (cur->age + curr->MyClass->GetRegTimeout()))
+			{
+				ServerInstance->Users->QuitUser(user, "Registration timeout");
+			}
 			return MOD_RES_DENY;
+		}
 
 		return MOD_RES_PASSTHRU;
 	}

--- a/src/modules/m_cap.cpp
+++ b/src/modules/m_cap.cpp
@@ -149,15 +149,12 @@ class ModuleCAP : public Module
 		ServerInstance->Modules->Attach(eventlist, this, 1);
 	}
 
-	ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user, bool& suspend_timeout)
 	{
 		/* Users in CAP state get held until CAP END */
 		if (cmd.reghold.get(user))
 		{
-			if (ServerInstance->Time() > (user->age + user->MyClass->GetRegTimeout()))
-			{
-				ServerInstance->Users->QuitUser(user, "Registration timeout");
-			}
+			suspend_timeout = false;
 			return MOD_RES_DENY;
 		}
 

--- a/src/modules/m_cap.cpp
+++ b/src/modules/m_cap.cpp
@@ -154,7 +154,7 @@ class ModuleCAP : public Module
 		/* Users in CAP state get held until CAP END */
 		if (cmd.reghold.get(user))
 		{
-			if (ServerInstance->Time() > (cur->age + curr->MyClass->GetRegTimeout()))
+			if (ServerInstance->Time() > (user->age + user->MyClass->GetRegTimeout()))
 			{
 				ServerInstance->Users->QuitUser(user, "Registration timeout");
 			}

--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -241,10 +241,13 @@ public:
 		}
 	}
 
-	ModResult OnCheckReady(LocalUser *user)
+	ModResult OnCheckReady(LocalUser *user, bool& suspend_timeout)
 	{
 		if (waiting.get(user))
+		{
+			suspend_timeout = true;
 			return MOD_RES_DENY;
+		}
 		return MOD_RES_PASSTHRU;
 	}
 

--- a/src/modules/m_conn_waitpong.cpp
+++ b/src/modules/m_conn_waitpong.cpp
@@ -90,6 +90,10 @@ class ModuleWaitPong : public Module
 					return MOD_RES_DENY;
 				}
 			}
+			else if (ServerInstance->Time() > (cur->age + curr->MyClass->GetRegTimeout()))
+			{
+				ServerInstance->Users->QuitUser(user, "Registration timeout");
+			}
 		}
 		return MOD_RES_PASSTHRU;
 	}

--- a/src/modules/m_conn_waitpong.cpp
+++ b/src/modules/m_conn_waitpong.cpp
@@ -90,18 +90,24 @@ class ModuleWaitPong : public Module
 					return MOD_RES_DENY;
 				}
 			}
-			else if (ServerInstance->Time() > (cur->age + curr->MyClass->GetRegTimeout()))
-			{
-				ServerInstance->Users->QuitUser(user, "Registration timeout");
-				return MOD_RES_DENY;
-			}
 		}
 		return MOD_RES_PASSTHRU;
 	}
 
 	ModResult OnCheckReady(LocalUser* user)
 	{
-		return ext.get(user) ? MOD_RES_DENY : MOD_RES_PASSTHRU;
+		if (ext.get(user))
+		{
+			if (ServerInstance->Time() > (user->age + user->MyClass->GetRegTimeout()))
+			{
+				ServerInstance->Users->QuitUser(user, "Registration timeout");
+			}
+			return MOD_RES_DENY;
+		}
+		else
+		{
+			return MOD_RES_PASSTHRU;
+		}
 	}
 
 	~ModuleWaitPong()

--- a/src/modules/m_conn_waitpong.cpp
+++ b/src/modules/m_conn_waitpong.cpp
@@ -93,6 +93,7 @@ class ModuleWaitPong : public Module
 			else if (ServerInstance->Time() > (cur->age + curr->MyClass->GetRegTimeout()))
 			{
 				ServerInstance->Users->QuitUser(user, "Registration timeout");
+				return MOD_RES_DENY;
 			}
 		}
 		return MOD_RES_PASSTHRU;

--- a/src/modules/m_conn_waitpong.cpp
+++ b/src/modules/m_conn_waitpong.cpp
@@ -94,14 +94,11 @@ class ModuleWaitPong : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user, bool& suspend_timeout)
 	{
 		if (ext.get(user))
 		{
-			if (ServerInstance->Time() > (user->age + user->MyClass->GetRegTimeout()))
-			{
-				ServerInstance->Users->QuitUser(user, "Registration timeout");
-			}
+			suspend_timeout = false;
 			return MOD_RES_DENY;
 		}
 		else

--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -396,10 +396,13 @@ class ModuleDNSBL : public Module
 		return MOD_RES_DENY;
 	}
 	
-	ModResult OnCheckReady(LocalUser *user)
+	ModResult OnCheckReady(LocalUser *user, bool& suspend_timeout)
 	{
 		if (countExt.get(user))
+		{
+			suspend_timeout = true;
 			return MOD_RES_DENY;
+		}
 		return MOD_RES_PASSTHRU;
 	}
 

--- a/src/modules/m_ident.cpp
+++ b/src/modules/m_ident.cpp
@@ -329,7 +329,7 @@ class ModuleIdent : public Module
 	 * creating a Timer object and especially better than creating a
 	 * Timer per ident lookup!
 	 */
-	virtual ModResult OnCheckReady(LocalUser *user)
+	virtual ModResult OnCheckReady(LocalUser *user, bool& suspend_timeout)
 	{
 		/* Does user have an ident socket attached at all? */
 		IdentRequestSocket *isock = ext.get(user);
@@ -355,6 +355,7 @@ class ModuleIdent : public Module
 		{
 			// time still good, no result yet... hold the registration
 			ServerInstance->Logs->Log("m_ident",DEBUG, "No result yet");
+			suspend_timeout = true;
 			return MOD_RES_DENY;
 		}
 

--- a/src/modules/m_lockserv.cpp
+++ b/src/modules/m_lockserv.cpp
@@ -106,7 +106,7 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnCheckReady(LocalUser* user)
+	virtual ModResult OnCheckReady(LocalUser* user, bool& suspend_timeout)
 	{
 		return locked ? MOD_RES_DENY : MOD_RES_PASSTHRU;
 	}

--- a/src/modules/m_sqlauth.cpp
+++ b/src/modules/m_sqlauth.cpp
@@ -145,13 +145,14 @@ class ModuleSQLAuth : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user, bool& suspend_timeout)
 	{
 		switch (pendingExt.get(user))
 		{
 			case AUTH_STATE_NONE:
 				return MOD_RES_PASSTHRU;
 			case AUTH_STATE_BUSY:
+				suspend_timeout = true;
 				return MOD_RES_DENY;
 			case AUTH_STATE_FAIL:
 				ServerInstance->Users->QuitUser(user, killreason);

--- a/src/userprocess.cpp
+++ b/src/userprocess.cpp
@@ -107,7 +107,7 @@ void InspIRCd::DoBackgroundUserStuff()
 				break;
 		}
 
-		if (curr->registered != REG_ALL && (Time() > (curr->age + curr->MyClass->GetRegTimeout())))
+		if ((curr->registered & REG_NICKUSER) != REG_NICKUSER && (Time() > (curr->age + curr->MyClass->GetRegTimeout())))
 		{
 			/*
 			 * registration timeout -- didnt send USER/NICK/HOST


### PR DESCRIPTION
Allow m_dnsbl, m_ident, m_sqlauth, and similar modules to not cause 'registration timeouts' if they are being particularly slow.

One side effect is that modules blocking the registration process must now handle timing out clients on their own.