### PR TITLE
[2.1] Fix last character being chopped off in included (exec)files

### DIFF
--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -390,7 +390,7 @@ void ParseStack::DoReadFile(const std::string& key, const std::string& name, int
 	{
 		int len = strlen(linebuf);
 		if (len)
-			cache.push_back(std::string(linebuf, len - 1));
+			cache.push_back(std::string(linebuf, len));
 	}
 }
 


### PR DESCRIPTION
e.g. motd and rules
