### PR TITLE
[2.0] Fix crash in m_ssl_gnutls destructor when dh_params wasn't inited

### DIFF
--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -323,6 +323,9 @@ class ModuleSSLGnuTLS : public Module
 		// once a day, once a week or once a month. Depending on the
 		// security requirements.
 
+		if (!dh_alloc)
+			return;
+
 		int ret;
 
 		if((ret = gnutls_dh_params_generate2(dh_params, dh_bits)) < 0)


### PR DESCRIPTION
Fixes #181
