### PR TITLE
m_ssl_openssl fixed for windows.

### DIFF
--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -28,12 +28,10 @@
 #include "ssl.h"
 
 #ifdef WINDOWS
-# pragma comment(lib, "libcrypto.lib")
-# pragma comment(lib, "libssl.lib")
+# pragma comment(lib, "VC/static/libeay32MD.lib")
+# pragma comment(lib, "VC/static/ssleay32MD.lib")
 # pragma comment(lib, "user32.lib")
 # pragma comment(lib, "advapi32.lib")
-# pragma comment(lib, "libgcc.lib")
-# pragma comment(lib, "libmingwex.lib")
 # pragma comment(lib, "gdi32.lib")
 # undef MAX_DESCRIPTORS
 # define MAX_DESCRIPTORS 10000


### PR DESCRIPTION
What, exactly, is fixed:
Uses static libs now -- dynamic link libraries are iffy on some machines with openssl and gnutls.
This fixes the 'OpenSSL_Uplink(<blahblahblah>:( No OpenSSL_Addlink error, as well as making openssl actually usable on windows.
