### PR TITLE
[2.1] m_check: Include IP and gecos in host/IP-mask lookup results

### DIFF
--- a/src/modules/m_check.cpp
+++ b/src/modules/m_check.cpp
@@ -216,13 +216,13 @@ class CommandCheck : public Command
 				if (InspIRCd::Match(a->second->host, parameters[0], ascii_case_insensitive_map) || InspIRCd::Match(a->second->dhost, parameters[0], ascii_case_insensitive_map))
 				{
 					/* host or vhost matches mask */
-					user->SendText(checkstr + " match " + ConvToStr(++x) + " " + a->second->GetFullRealHost());
+					user->SendText(checkstr + " match " + ConvToStr(++x) + " " + a->second->GetFullRealHost() + " " + a->second->GetIPString() + " " + a->second->fullname);
 				}
 				/* IP address */
 				else if (InspIRCd::MatchCIDR(a->second->GetIPString(), parameters[0]))
 				{
 					/* same IP. */
-					user->SendText(checkstr + " match " + ConvToStr(++x) + " " + a->second->GetFullRealHost());
+					user->SendText(checkstr + " match " + ConvToStr(++x) + " " + a->second->GetFullRealHost() + " " + a->second->GetIPString() + " " + a->second->fullname);
 				}
 			}
 


### PR DESCRIPTION
Following a conversation about the parsability of '/STATS L' and '/STATS l' for bots or scripts (and even for humans actually) when users can have both the '[' and ']' characters in both their nickname and username, which is a nightmare to parse because of that, and rather than make a new module for this, I decided to simply add the IP (and while I was at it, also the gecos) to the output of a host/IP-mask lookup when using /CHECK.

This should not break any existing scripts or bots that use /CHECK, and if it does, they should be easily fixed.
