### PR TITLE
[2.0] Give m_censor the option to filter text globally

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -315,6 +315,16 @@
 # http://wiki.inspircd.org/Modules/censor                             #
 #
 #<include file="conf/censor.conf">
+#
+# Optional - By enabling the following you will be filtering globally #
+# This means that regardless of which server the text originally came #
+# from, you will parse and filter for badwords. This is NOT NEEDED if #
+# you load this module on every server on your network. This can and  #
+# likely will cause problems for larger networks with many users and  #
+# servers.                                                            #
+# An example need for this would be filtering text from a Janus link. #
+#
+#<censor filterglobal="false">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # CGI:IRC module: Adds support for automatic host changing in CGI:IRC

--- a/src/modules/m_censor.cpp
+++ b/src/modules/m_censor.cpp
@@ -1,6 +1,7 @@
 /*
  * InspIRCd -- Internet Relay Chat Daemon
  *
+ *   Copyright (C) 2012 Shawn Smith <ShawnSmith0828@gmail.com>
  *   Copyright (C) 2009 Daniel De Graaf <danieldg@inspircd.org>
  *   Copyright (C) 2004, 2008-2009 Craig Edwards <craigedwards@brainbox.cc>
  *   Copyright (C) 2007 Dennis Friis <peavey@inspircd.org>
@@ -51,6 +52,7 @@ class ModuleCensor : public Module
 	censor_t censors;
 	CensorUser cu;
 	CensorChannel cc;
+	bool FilterGlobal;
 
  public:
 	ModuleCensor() : cu(this), cc(this) { }
@@ -74,7 +76,7 @@ class ModuleCensor : public Module
 	// format of a config entry is <badword text="shit" replace="poo">
 	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
 	{
-		if (!IS_LOCAL(user))
+		if (!IS_LOCAL(user) && !FilterGlobal)
 			return MOD_RES_PASSTHRU;
 
 		bool active = false;
@@ -132,6 +134,9 @@ class ModuleCensor : public Module
 			irc::string replace = (MyConf.ReadValue("badword","replace",index)).c_str();
 			censors[pattern] = replace;
 		}
+
+		ConfigTag* tag = ServerInstance->Config->ConfValue("censor");
+		FilterGlobal = tag->getBool("filterglobal", false);
 	}
 
 	virtual Version GetVersion()


### PR DESCRIPTION
The issue of Janus links bypassing the filters set by m_censor came up and this _should_ fix it.

This is untested because I do not have a multi-server testnet to test this on. It does compile and filtering locally still works correctly, no crashes or unexpected behavior.

I did make a note in the example configuration that this would likely cause strain on larger networks due to each server having to process every line of text that's sent out, regardless of origin.
