### PR TITLE
[2.0] Backported user mode +L from 2.1

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1340,8 +1340,17 @@
 #<randquote file="randquotes.conf">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Redirect module: Adds channel redirection (mode +L)
+# Redirect module: Adds channel redirection (mode +L)                 #
+# Optional: <redirect:antiredirect> to add usermode +L to stop forced #
+# redirection and instead print an error.                             #
+#                                                                     #
+# Note: You can not update this with a simple rehash, it requires     #
+# reloading the module for it to take effect.                         #
+# This also breaks linking to servers that do not have the option.    #
+# This defaults to false for the 2.0 version, it will be enabled in   #
+# all the future versions.                                            #
 #<module name="m_redirect.so">
+#<redirect antiredirect="true">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Regular Expression Provider for Glob or wildcard (?/*) matching.


### PR DESCRIPTION
This provides user mode +L to stop force redirection given by channel mode +L and instead print an error.
