### PR TITLE
[2.0] m_ssl_openssl: Show cipher used on connect and allow available ciphers to be customized.

### DIFF
--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -198,6 +198,13 @@ class ModuleSSLOpenSSL : public Module
 			throw ModuleException("Unknown hash type " + hash);
 		use_sha = (hash == "sha1");
 
+		std::string ciphers = conf->getString("ciphers", "ALL");
+		if ((!SSL_CTX_set_cipher_list(ctx, ciphers.c_str())) || (!SSL_CTX_set_cipher_list(clictx, ciphers.c_str())))
+		{
+			ServerInstance->Logs->Log("m_ssl_openssl",DEFAULT, "m_ssl_openssl.so: Can't set cipher list to %s.", ciphers.c_str());
+			ERR_print_errors_cb(error_callback, this);
+		}
+
 
 		/* Load our keys and certificates
 		 * NOTE: OpenSSL's error logging API sucks, don't blame us for this clusterfuck.


### PR DESCRIPTION
This makes m_ssl_openssl show the cipher used when connected, instead of only a fingerprint when one is available, just like m_ssl_gnutls.

This pull request also closes issue #228, allowing the list of available ciphers to be customized.
This adds a new option called 'ciphers' to the openssl configuration block.
Example: ciphers="TLSv1+HIGH+DH:!SSLv2:!aNULL:!eNULL:!NULL:!ADH:!3DES:!AES128:@STRENGTH"
The patch for this one was contributed almost 10 months ago via IRC, by spender.
