### PR TITLE
[2.0] InviteBase needs to be a CoreExport on Windows.

### DIFF
--- a/include/membership.h
+++ b/include/membership.h
@@ -35,7 +35,7 @@ class CoreExport Membership : public Extensible
 	unsigned int getRank();
 };
 
-class InviteBase
+class CoreExport InviteBase
 {
  protected:
 	InviteList invites;


### PR DESCRIPTION
This issue was introduced by #235.
