### PR TITLE
[2.0] Updated some module version lines.

### DIFF
--- a/src/modules/m_blockcolor.cpp
+++ b/src/modules/m_blockcolor.cpp
@@ -23,7 +23,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for unreal-style channel mode +c */
+/* $ModDesc: Provides channel mode +c to block color */
 
 /** Handles the +c channel mode
  */
@@ -95,7 +95,7 @@ class ModuleBlockColor : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides support for unreal-style channel mode +c",VF_VENDOR);
+		return Version("Provides channel mode +c to block color",VF_VENDOR);
 	}
 };
 

--- a/src/modules/m_botmode.cpp
+++ b/src/modules/m_botmode.cpp
@@ -21,7 +21,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for unreal-style umode +B */
+/* $ModDesc: Provides user mode +B to mark the user as a bot */
 
 /** Handles user mode +B
  */
@@ -51,7 +51,7 @@ class ModuleBotMode : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides support for unreal-style umode +B",VF_VENDOR);
+		return Version("Provides user mode +B to mark the user as a bot",VF_VENDOR);
 	}
 
 	virtual void OnWhois(User* src, User* dst)

--- a/src/modules/m_callerid.cpp
+++ b/src/modules/m_callerid.cpp
@@ -22,7 +22,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Implementation of callerid (umode +g & /accept, ala hybrid etc) */
+/* $ModDesc: Implementation of callerid, usermode +g, /accept */
 
 class callerid_data
 {
@@ -347,7 +347,7 @@ public:
 
 	virtual Version GetVersion()
 	{
-		return Version("Implementation of callerid (umode +g & /accept, ala hybrid etc)", VF_COMMON | VF_VENDOR);
+		return Version("Implementation of callerid, usermode +g, /accept", VF_COMMON | VF_VENDOR);
 	}
 
 	virtual void On005Numeric(std::string& output)

--- a/src/modules/m_deaf.cpp
+++ b/src/modules/m_deaf.cpp
@@ -21,7 +21,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for ircu style usermode +d (deaf to channel messages and channel notices) */
+/* $ModDesc: Provides usermode +d to block channel messages and channel notices */
 
 /** User mode +d - filter out channel messages and channel notices
  */
@@ -163,7 +163,7 @@ class ModuleDeaf : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides support for ircu style usermode +d (deaf to channel messages and channel notices)", VF_VENDOR);
+		return Version("Provides usermode +d to block channel messages and channel notices", VF_VENDOR);
 	}
 
 };

--- a/src/modules/m_helpop.cpp
+++ b/src/modules/m_helpop.cpp
@@ -21,7 +21,7 @@
  */
 
 
-/* $ModDesc: Provides the /HELPOP command, works like UnrealIRCd's helpop */
+/* $ModDesc: Provides the /HELPOP command for useful information */
 
 #include "inspircd.h"
 
@@ -188,7 +188,7 @@ class ModuleHelpop : public Module
 
 		Version GetVersion()
 		{
-			return Version("Provides the /HELPOP command, works like UnrealIRCd's helpop", VF_VENDOR);
+			return Version("Provides the /HELPOP command for useful information", VF_VENDOR);
 		}
 };
 

--- a/src/modules/m_noctcp.cpp
+++ b/src/modules/m_noctcp.cpp
@@ -21,7 +21,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for unreal-style channel mode +C */
+/* $ModDesc: Provides channel mode +C to block CTCPs */
 
 class NoCTCP : public SimpleChannelModeHandler
 {
@@ -51,7 +51,7 @@ class ModuleNoCTCP : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides support for unreal-style channel mode +C", VF_VENDOR);
+		return Version("Provides channel mode +C to block CTCPs", VF_VENDOR);
 	}
 
 	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)

--- a/src/modules/m_nonotice.cpp
+++ b/src/modules/m_nonotice.cpp
@@ -21,7 +21,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for unreal-style channel mode +T */
+/* $ModDesc: Provides channel mode +T to block notices to the channel */
 
 class NoNotice : public SimpleChannelModeHandler
 {
@@ -80,7 +80,7 @@ class ModuleNoNotice : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides support for unreal-style channel mode +T", VF_VENDOR);
+		return Version("Provides channel mode +T to block notices to the channel", VF_VENDOR);
 	}
 };
 

--- a/src/modules/m_override.cpp
+++ b/src/modules/m_override.cpp
@@ -26,7 +26,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for unreal-style oper-override */
+/* $ModDesc: Provides support for allowing opers to override certain things. */
 
 class ModuleOverride : public Module
 {
@@ -194,7 +194,7 @@ class ModuleOverride : public Module
 
 	Version GetVersion()
 	{
-		return Version("Provides support for unreal-style oper-override",VF_VENDOR);
+		return Version("Provides support for allowing opers to override certain things",VF_VENDOR);
 	}
 };
 

--- a/src/modules/m_sajoin.cpp
+++ b/src/modules/m_sajoin.cpp
@@ -21,7 +21,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for unreal-style SAJOIN command */
+/* $ModDesc: Provides command SAJOIN to allow opers to force-join users to channels */
 
 /** Handle /SAJOIN
  */
@@ -117,7 +117,7 @@ class ModuleSajoin : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides support for unreal-style SAJOIN command", VF_OPTCOMMON | VF_VENDOR);
+		return Version("Provides command SAJOIN to allow opers to force-join users to channels", VF_OPTCOMMON | VF_VENDOR);
 	}
 
 };

--- a/src/modules/m_samode.cpp
+++ b/src/modules/m_samode.cpp
@@ -20,7 +20,7 @@
  */
 
 
-/* $ModDesc: Provides more advanced UnrealIRCd SAMODE command */
+/* $ModDesc: Provides command SAMODE to allow opers to change modes on channels and users */
 
 #include "inspircd.h"
 
@@ -64,7 +64,7 @@ class ModuleSaMode : public Module
 
 	Version GetVersion()
 	{
-		return Version("Provides more advanced UnrealIRCd SAMODE command", VF_VENDOR);
+		return Version("Provides command SAMODE to allow opers to change modes on channels and users", VF_VENDOR);
 	}
 
 	ModResult OnPreMode(User* source,User* dest,Channel* channel, const std::vector<std::string>& parameters)

--- a/src/modules/m_sslmodes.cpp
+++ b/src/modules/m_sslmodes.cpp
@@ -24,7 +24,7 @@
 #include "inspircd.h"
 #include "ssl.h"
 
-/* $ModDesc: Provides support for unreal-style channel mode +z */
+/* $ModDesc: Provides channel mode +z to allow for Secure/SSL only channels */
 
 /** Handle channel mode +z
  */
@@ -134,7 +134,7 @@ class ModuleSSLModes : public Module
 
 	Version GetVersion()
 	{
-		return Version("Provides support for unreal-style channel mode +z", VF_VENDOR);
+		return Version("Provides channel mode +z to allow for Secure/SSL only channels", VF_VENDOR);
 	}
 };
 


### PR DESCRIPTION
I noticed that a few of the modules we provide come with a description line that doesn't really explain what they do, just that they emulate something found on another IRCd.

Ex: One was `Provides support for unreal-style channel mode +c`

Now that can be very confusing for users who have never used unrealircd. So I've edited as many of those style descriptions as I could find and provided a bit more information on what each module actually does.

A side note: Why do we have /\* $ModDesc: */ when we also have GetVersion() that is almost always the exact same line?
