### PR TITLE
[2.0] Removed version line references to other IRCds

### DIFF
--- a/src/modules/m_cycle.cpp
+++ b/src/modules/m_cycle.cpp
@@ -20,7 +20,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for unreal-style CYCLE command. */
+/* $ModDesc: Provides command CYCLE, acts as a server-side HOP command to part and rejoin a channel. */
 
 /** Handle /CYCLE
  */
@@ -97,7 +97,7 @@ class ModuleCycle : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides support for unreal-style CYCLE command.", VF_VENDOR);
+		return Version("Provides command CYCLE, acts as a server-side HOP command to part and rejoin a channel.", VF_VENDOR);
 	}
 
 };

--- a/src/modules/m_nokicks.cpp
+++ b/src/modules/m_nokicks.cpp
@@ -22,7 +22,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for unreal-style channel mode +Q */
+/* $ModDesc: Provides channel mode +Q to prevent kicks on the channel. */
 
 class NoKicks : public SimpleChannelModeHandler
 {
@@ -74,7 +74,7 @@ class ModuleNoKicks : public Module
 
 	Version GetVersion()
 	{
-		return Version("Provides support for unreal-style channel mode +Q", VF_VENDOR);
+		return Version("Provides channel mode +Q to prevent kicks on the channel.", VF_VENDOR);
 	}
 };
 

--- a/src/modules/m_sapart.cpp
+++ b/src/modules/m_sapart.cpp
@@ -21,7 +21,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for unreal-style SAPART command */
+/* $ModDesc: Provides command SAPART to force-part users from a channel. */
 
 /** Handle /SAPART
  */
@@ -116,7 +116,7 @@ class ModuleSapart : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("Provides support for unreal-style SAPART command", VF_OPTCOMMON | VF_VENDOR);
+		return Version("Provides command SAPART to force-part users from a channel.", VF_OPTCOMMON | VF_VENDOR);
 	}
 
 };

--- a/src/modules/m_servprotect.cpp
+++ b/src/modules/m_servprotect.cpp
@@ -21,7 +21,7 @@
 
 #include "inspircd.h"
 
-/* $ModDesc: Provides support for Austhex style +k / UnrealIRCD +S services mode */
+/* $ModDesc: Provides usermode +k to protect services from kicks, kills and mode changes. */
 
 /** Handles user mode +k
  */
@@ -64,7 +64,7 @@ class ModuleServProtectMode : public Module
 
 	Version GetVersion()
 	{
-		return Version("Provides support for Austhex style +k / UnrealIRCD +S services mode", VF_VENDOR);
+		return Version("Provides usermode +k to protect services from kicks, kills, and mode changes.", VF_VENDOR);
 	}
 
 	void OnWhois(User* src, User* dst)


### PR DESCRIPTION
This updates the few that I missed when I did pull #248, think I got them all now.
