### PR TITLE
Replace hardcoded paths with configurable ones

### DIFF
--- a/configure
+++ b/configure
@@ -61,7 +61,7 @@ our ($opt_use_gnutls, $opt_rebuild, $opt_use_openssl, $opt_nointeractive, $opt_p
     $opt_noipv6, $opt_maxbuf, $opt_disable_debug, $opt_freebsd_port,
 	$opt_system, $opt_uid);
 
-our ($opt_cc, $opt_base_dir, $opt_config_dir, $opt_module_dir, $opt_binary_dir);
+our ($opt_cc, $opt_base_dir, $opt_config_dir, $opt_module_dir, $opt_binary_dir, $opt_data_dir, $opt_log_dir);
 
 sub list_extras ();
 
@@ -93,6 +93,8 @@ GetOptions (
 	'config-dir=s' => \$opt_config_dir,
 	'module-dir=s' => \$opt_module_dir,
 	'binary-dir=s' => \$opt_binary_dir,
+	'data-dir=s' => \$opt_data_dir,
+	'log-dir=s' => \$opt_log_dir,
 	'disable-debuginfo' => sub { $opt_disable_debug = 1 },
 	'help'	=> sub { showhelp(); },
 	'update' => sub { update(); },
@@ -120,6 +122,8 @@ our $interactive = !(
 	(defined $opt_module_dir) ||
 	(defined $opt_base_dir) ||
 	(defined $opt_binary_dir) ||
+	(defined $opt_data_dir) ||
+	(defined $opt_log_dir) ||
 	(defined $opt_nointeractive) ||
 	(defined $opt_cc) ||
 	(defined $opt_noipv6) ||
@@ -157,12 +161,16 @@ if (defined $opt_system || defined $opt_uid) {
 	$config{MODULE_DIR}	 = '/usr/lib/inspircd';
 	$config{BINARY_DIR}	 = '/usr/sbin/';
 	$config{BUILD_DIR}	 = resolve_directory($config{ME}."/build");         # Build Directory
+	$config{DATA_DIR}	 = '/var/inspircd';
+	$config{LOG_DIR}	 = '/var/log/inspircd';
 } else {
 	$config{UID} = $<;
 	$config{CONFIG_DIR}	 = resolve_directory($config{BASE_DIR}."/conf");	# Configuration Directory
 	$config{MODULE_DIR}	 = resolve_directory($config{BASE_DIR}."/modules");	# Modules Directory
 	$config{BINARY_DIR}	 = resolve_directory($config{BASE_DIR}."/bin");		# Binary Directory
 	$config{BUILD_DIR}	 = resolve_directory($config{ME}."/build");         # Build Directory
+	$config{DATA_DIR}	 = resolve_directory($config{BASE_DIR}."/data");	# Data directory
+	$config{LOG_DIR}	 = resolve_directory($config{BASE_DIR}."/logs");	# Log directory
 }
 
 if (defined $opt_config_dir) {
@@ -173,6 +181,12 @@ if (defined $opt_module_dir) {
 }
 if (defined $opt_binary_dir) {
 	$config{BINARY_DIR} = $opt_binary_dir;
+}
+if (defined $opt_data_dir) {
+	$config{DATA_DIR} = $opt_data_dir;
+}
+if (defined $opt_log_dir) {
+	$config{LOG_DIR} = $opt_log_dir;
 }
 chomp($config{HAS_GNUTLS}   = `pkg-config --modversion gnutls 2>/dev/null | cut -c 1,2,3`); # GNUTLS Version.
 
@@ -531,14 +545,18 @@ should NOT be used. You should probably specify a newer compiler.\n\n";
 	if ($tmpbase ne $config{BASE_DIR}) {
 		$config{CONFIG_DIR}	 = resolve_directory($config{BASE_DIR}."/conf");	   # Configuration Dir
 		$config{MODULE_DIR}	 = resolve_directory($config{BASE_DIR}."/modules");	# Modules Directory
+		$config{DATA_DIR}	 = resolve_directory($config{BASE_DIR}."/data");	# Data Directory
+		$config{LOG_DIR}	 = resolve_directory($config{BASE_DIR}."/logs");	# Log Directory
 		$config{BINARY_DIR}	 = resolve_directory($config{BASE_DIR}."/bin");	    # Binary Directory
 	}
 
 	dir_check("are the configuration files", "CONFIG_DIR");
 	dir_check("are the modules to be compiled to", "MODULE_DIR");
 	dir_check("is the IRCd binary to be placed", "BINARY_DIR");
+	dir_check("are variable data files to be located in", "DATA_DIR");
+	dir_check("are the logs to be stored in", "LOG_DIR");
 	dir_check("do you want the build to take place", "BUILD_DIR");
-
+		
 	my $chose_hiperf = 0;
 	if ($has_kqueue) {
 		yesno('USE_KQUEUE',"You are running a BSD operating system, and kqueue\nwas detected. Would you like to enable kqueue support?\nThis is likely to increase performance.\nIf you are unsure, answer yes.\n\nEnable kqueue?");
@@ -867,6 +885,8 @@ sub writefiles {
 #define DllExport /**/
 
 #define CONFIG_PATH "$config{CONFIG_DIR}"
+#define DATA_PATH "$config{DATA_DIR}"
+#define LOG_PATH "$config{LOG_DIR}"
 #define MOD_PATH "$config{MODULE_DIR}"
 #define SOMAXCONN_S "$config{_SOMAXCONN}"
 #define ENTRYPOINT int main(int argc, char** argv)
@@ -998,7 +1018,7 @@ EOF
 		$config{BUILD_DIR} ||= resolve_directory($config{ME}."/build");
 
 		for my $var (qw(
-			CC SYSTEM BASE_DIR CONFIG_DIR MODULE_DIR BINARY_DIR BUILD_DIR UID
+			CC SYSTEM BASE_DIR CONFIG_DIR MODULE_DIR BINARY_DIR BUILD_DIR DATA_DIR UID
 			STARTSCRIPT DESTINATION SOCKETENGINE
 		)) {
 			s/\@$var\@/$config{$var}/g;

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1823,6 +1823,9 @@
 # be a lot less bans to apply - as most of them will already be there.
 #<module name="m_xline_db.so">
 
+# Specify the filename for the xline database here
+#<xlinedb filename="data/xline.db">
+
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 #    ____                _   _____ _     _       ____  _ _   _        #
 #   |  _ \ ___  __ _  __| | |_   _| |__ (_)___  | __ )(_) |_| |       #

--- a/make/configure.pm
+++ b/make/configure.pm
@@ -281,6 +281,10 @@ InspIRCd 1.0.x, are also allowed.
                                [$PWD]
   --config-dir=[directory]     Config file directory for config and SSL certs
                                [$PWD/conf]
+  --log-dir=[directory]	       Log file directory for logs
+			       [$PWD/logs]
+  --data-dir=[directory]       Data directory for variable data, such as the permchannel configuration and the XLine database
+			       [$PWD/data]
   --module-dir=[directory]     Modules directory for loadable modules
                                [$PWD/modules]
   --binary-dir=[directory]     Binaries directory for core binary

--- a/make/template/inspircd
+++ b/make/template/inspircd
@@ -26,7 +26,7 @@ use Fcntl;
 my $basepath	=	"@BASE_DIR@";
 my $confpath	=	"@CONFIG_DIR@/";
 my $binpath	=	"@BINARY_DIR@";
-my $runpath	=	"@BASE_DIR@";
+my $runpath	=	"@DATA_DIR@";
 my $valgrindlogpath	=	"$basepath/valgrindlogs";
 my $executable	=	"@EXECUTABLE@";
 my $version	=	"@VERSION@";
@@ -382,7 +382,7 @@ sub getpidfile
 	}
 
 	# End of includes / No includes found. Using default.
-	$pidfile = $runpath . "/data/inspircd.pid";
+	$pidfile = $runpath . "/inspircd.pid";
 }
 
 sub getstatus {

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -42,6 +42,7 @@ PICLDFLAGS = -fPIC -shared -rdynamic $(LDFLAGS)
 BASE = "$(DESTDIR)@BASE_DIR@"
 CONPATH = "$(DESTDIR)@CONFIG_DIR@"
 MODPATH = "$(DESTDIR)@MODULE_DIR@"
+DATPATH = "$(DESTDIR)@DATA_DIR@"
 BINPATH = "$(DESTDIR)@BINARY_DIR@"
 INSTUID = @UID@
 INSTMODE_DIR = 0755
@@ -236,6 +237,7 @@ install: target
 	@echo '  Configuration:' $(CONPATH)
 	@echo '  Binaries:' $(BINPATH)
 	@echo '  Modules:' $(MODPATH)
+	@echo '  Data:' $(DATPATH)
 	@echo 'To start the ircd, run:' $(BASE)/inspircd start
 	@echo 'Remember to create your config file:' $(CONPATH)/inspircd.conf
 	@echo 'Examples are available at:' $(CONPATH)/examples/

--- a/src/helperfuncs.cpp
+++ b/src/helperfuncs.cpp
@@ -293,7 +293,7 @@ bool InspIRCd::OpenLog(char**, int)
 	if (!Config->cmdline.writelog) return true; // Skip opening default log if -nolog
 
 	if (Config->cmdline.startup_log.empty())
-		Config->cmdline.startup_log = "logs/startup.log";
+		Config->cmdline.startup_log = LOG_PATH "/startup.log";
 	FILE* startup = fopen(Config->cmdline.startup_log.c_str(), "a+");
 
 	if (!startup)

--- a/src/inspircd.cpp
+++ b/src/inspircd.cpp
@@ -287,7 +287,7 @@ void InspIRCd::WritePID(const std::string &filename)
 {
 	std::string fname(filename);
 	if (fname.empty())
-		fname = "data/inspircd.pid";
+		fname = DATA_PATH "/inspircd.pid";
 	std::ofstream outfile(fname.c_str());
 	if (outfile.is_open())
 	{

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -263,10 +263,10 @@ class ModuleSSLGnuTLS : public Module
 
 		ConfigTag* Conf = ServerInstance->Config->ConfValue("gnutls");
 
-		cafile = Conf->getString("cafile", "conf/ca.pem");
-		crlfile	= Conf->getString("crlfile", "conf/crl.pem");
-		certfile = Conf->getString("certfile", "conf/cert.pem");
-		keyfile	= Conf->getString("keyfile", "conf/key.pem");
+		cafile = Conf->getString("cafile", CONFIG_PATH "/ca.pem");
+		crlfile	= Conf->getString("crlfile", CONFIG_PATH "/crl.pem");
+		certfile = Conf->getString("certfile", CONFIG_PATH "/cert.pem");
+		keyfile	= Conf->getString("keyfile", CONFIG_PATH "/key.pem");
 		dh_bits	= Conf->getInt("dhbits");
 		std::string hashname = Conf->getString("hash", "md5");
 

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -203,10 +203,10 @@ class ModuleSSLOpenSSL : public Module
 
 		ConfigTag* conf = ServerInstance->Config->ConfValue("openssl");
 
-		cafile	 = conf->getString("cafile", "conf/ca.pem");
-		certfile = conf->getString("certfile", "conf/cert.pem");
-		keyfile	 = conf->getString("keyfile", "conf/key.pem");
-		dhfile	 = conf->getString("dhfile", "conf/dhparams.pem");
+		cafile	 = conf->getString("cafile", CONFIG_PATH "/ca.pem");
+		certfile = conf->getString("certfile", CONFIG_PATH "/cert.pem");
+		keyfile	 = conf->getString("keyfile", CONFIG_PATH "/key.pem");
+		dhfile	 = conf->getString("dhfile", CONFIG_PATH "/dhparams.pem");
 		std::string hash = conf->getString("hash", "md5");
 		if (hash != "sha1" && hash != "md5")
 			throw ModuleException("Unknown hash type " + hash);

--- a/src/modules/m_xline_db.cpp
+++ b/src/modules/m_xline_db.cpp
@@ -21,6 +21,8 @@
 #include "inspircd.h"
 #include "xline.h"
 
+/* $ModConfig: <xlinedb filename="data/xline.db">
+ *  Specify the filename for the xline database here*/
 /* $ModDesc: Keeps a dynamic log of all XLines created, and stores them in a seperate conf file (xline.db). */
 
 class ModuleXLineDB : public Module
@@ -28,11 +30,21 @@ class ModuleXLineDB : public Module
 	std::vector<XLine *> xlines;
 	bool reading_db;			// If this is true, addlines are as a result of db reading, so don't bother flushing the db to disk.
 						// DO REMEMBER TO SET IT, otherwise it's annoying :P
+	std::string xlinedbpath;
  public:
 	ModuleXLineDB() 	{
 		Implementation eventlist[] = { I_OnAddLine, I_OnDelLine, I_OnExpireLine };
 		ServerInstance->Modules->Attach(eventlist, this, 3);
 
+		/* Load the configuration
+		 * Note:
+		 * 		this is on purpose not in the OnRehash() method. It would be non-trivial to change the database on-the-fly.
+		 * 		Imagine a scenario where the new file already exists. Merging the current XLines with the existing database is likely a bad idea
+		 * 		...and so is discarding all current in-memory XLines for the ones in the database.
+		 */
+		ConfigTag* Conf = ServerInstance->Config->ConfValue("xlinedb");
+		xlinedbpath = Conf->getString("filename", DATA_PATH "/xline.db");
+		
 		reading_db = true;
 		ReadDatabase();
 		reading_db = false;
@@ -99,7 +111,8 @@ class ModuleXLineDB : public Module
 		 *		-- w00t
 		 */
 		ServerInstance->Logs->Log("m_xline_db",DEBUG, "xlinedb: Opening temporary database");
-		f = fopen("data/xline.db.new", "w");
+		std::string xlinenewdbpath = xlinedbpath + ".new";
+		f = fopen(xlinenewdbpath.c_str(), "w");
 		if (!f)
 		{
 			ServerInstance->Logs->Log("m_xline_db",DEBUG, "xlinedb: Cannot create database! %s (%d)", strerror(errno), errno);
@@ -140,7 +153,7 @@ class ModuleXLineDB : public Module
 		}
 
 		// Use rename to move temporary to new db - this is guarenteed not to fuck up, even in case of a crash.
-		if (rename("data/xline.db.new", "data/xline.db") < 0)
+		if (rename(xlinenewdbpath.c_str(), xlinedbpath.c_str()) < 0)
 		{
 			ServerInstance->Logs->Log("m_xline_db",DEBUG, "xlinedb: Cannot move new to old database! %s (%d)", strerror(errno), errno);
 			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot replace old with new db: %s (%d)", strerror(errno), errno);
@@ -156,7 +169,7 @@ class ModuleXLineDB : public Module
 		char linebuf[MAXBUF];
 		unsigned int lineno = 0;
 
-		f = fopen("data/xline.db", "r");
+		f = fopen(xlinedbpath.c_str(), "r");
 		if (!f)
 		{
 			if (errno == ENOENT)

--- a/win/configure.cpp
+++ b/win/configure.cpp
@@ -301,6 +301,7 @@ void Run()
 	string base_path = get_string_option("In what directory do you wish to install the InspIRCd base?", "..");
 	string config_path = get_string_option("In what directory are the configuration files?", "conf");
 	string mod_path = get_string_option("In what directory are the modules to be compiled to?", "modules");
+	string data_path = get_string_option("In what directory is the variable data to be placed in?", "data");
 	string bin_dir = get_string_option("In what directory is the IRCd binary to be placed?", ".");
 
 	printf_c("\n\033[1;32mPre-build configuration is complete!\n\n");	sc(TNORMAL);
@@ -311,6 +312,7 @@ void Run()
 	printf_c("\033[0mBase install path:\033[1;32m        %s\n", base_path.c_str());
 	printf_c("\033[0mConfig path:\033[1;32m              %s\n", config_path.c_str());
 	printf_c("\033[0mModule path:\033[1;32m              %s\n", mod_path.c_str());
+	printf_c("\033[0mData path:\033[1;32m              %s\n", data_path.c_str());
 	printf_c("\033[0mSocket Engine:\033[1;32m            %s\n", "select");
 
 	printf("\n"); sc(TNORMAL);
@@ -322,6 +324,7 @@ void Run()
 	printf("\n");
 
 	// escape the pathes
+	escape_string(data_path);
 	escape_string(config_path);
 	escape_string(mod_path);
 
@@ -333,6 +336,7 @@ void Run()
 
 	fprintf(f, "#define CONFIG_PATH \"%s\"\n", config_path.c_str());
 	fprintf(f, "#define MOD_PATH \"%s\"\n", mod_path.c_str());
+	fprintf(f, "#define DATA_PATH \"%s\"\n", data_path.c_str());
 	fprintf(f, "#define SOMAXCONN_S \"128\"\n");
 	fprintf(f, "#define MAXBUF 514\n");
 


### PR DESCRIPTION
This patch aims to ease the packaging of InspIRCd for a system-wide installation scenario.

Changes in detail:
configure: Add the options --log-path and --data-path
m_ssl_gnutls, openssl: Change the hardcoded "conf/" to the existent CONFIG_PATH macro
m_xline_db: Make the location of xline.db configurable. It will use --data-path as default value, but this can be
changed using the configuration files.
