### PR TITLE
m_spanningtree: Resolve issue #250.

### DIFF
--- a/src/modules/m_spanningtree/treesocket.h
+++ b/src/modules/m_spanningtree/treesocket.h
@@ -94,6 +94,7 @@ class TreeSocket : public BufferedSocket
 	time_t NextPing;			/* Time when we are due to ping this server */
 	bool LastPingWasGood;			/* Responded to last ping we sent? */
 	int proto_version;			/* Remote protocol version */
+	bool ConnectionFailureShown; /* Set to true if a connection failure message was shown */
  public:
 	time_t age;
 

--- a/src/modules/m_spanningtree/treesocket1.cpp
+++ b/src/modules/m_spanningtree/treesocket1.cpp
@@ -49,6 +49,7 @@ TreeSocket::TreeSocket(SpanningTreeUtilities* Util, Link* link, Autoconnect* mya
 	capab->capab_phase = 0;
 	MyRoot = NULL;
 	proto_version = 0;
+	ConnectionFailureShown = false;
 	LinkState = CONNECTING;
 	if (!link->Hook.empty())
 	{
@@ -78,6 +79,7 @@ TreeSocket::TreeSocket(SpanningTreeUtilities* Util, int newfd, ListenSocket* via
 	age = ServerInstance->Time();
 	LinkState = WAIT_AUTH_1;
 	proto_version = 0;
+	ConnectionFailureShown = false;
 	linkID = "inbound from " + client->addr();
 
 	FOREACH_MOD(I_OnHookIO, OnHookIO(this, via));

--- a/src/modules/m_spanningtree/treesocket2.cpp
+++ b/src/modules/m_spanningtree/treesocket2.cpp
@@ -483,14 +483,14 @@ void TreeSocket::Close()
 	// then propogate a netsplit to all peers.
 	if (MyRoot)
 		Squit(MyRoot,getError());
-
-	if (!linkID.empty())
+		
+	if(!ConnectionFailureShown)
 	{
+		ConnectionFailureShown = true;
 		ServerInstance->SNO->WriteGlobalSno('l', "Connection to '\2%s\2' failed.",linkID.c_str());
 
 		time_t server_uptime = ServerInstance->Time() - this->age;
 		if (server_uptime)
 			ServerInstance->SNO->WriteGlobalSno('l', "Connection to '\2%s\2' was established for %s", linkID.c_str(), Utils->Creator->TimeToStr(server_uptime).c_str());
-		linkID.clear();
 	}
 }


### PR DESCRIPTION
The linkID should not be cleared, as OnError can still be called after Close.
