### PR TITLE
m_regex_stdlib: A regex provider based on the C++11 container std::regex

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1381,6 +1381,17 @@
 #<module name="m_regex_posix.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
+# Regular Expression Provider for C++11 std::regex Regular Expressions.
+# This module works on any fully compliant implementation of the C++11
+# std::regex container. Examples for such are Visual C++ 2010 and newer
+# but not libstdc++ (which GCC uses)
+#<module name="m_regex_stdlib.so">
+
+# Specify the Regular Expression engine to use here. Valid settings are
+# bre, ere, awk, grep, egrep, ecmascript (default if not specified)
+#<stdregex type="ecmascript">
+
+#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Regular Expression Provider for TRE Regular Expressions.
 # This is the same regular expression engine used by UnrealIRCd, so
 # if you are most familiar with the syntax of /spamfilter from there,

--- a/src/modules/extra/m_regex_stdlib.cpp
+++ b/src/modules/extra/m_regex_stdlib.cpp
@@ -1,0 +1,112 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2012 ChrisTX <chris@rev-crew.info>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#include "inspircd.h"
+#include "m_regex.h"
+#include <regex>
+
+/* $ModDesc: Regex Provider Module for std::regex Regular Expressions */
+/* $ModConfig: <stdregex type="ecmascript">
+ *  Specify the Regular Expression engine to use here. Valid settings are
+ *  bre, ere, awk, grep, egrep, ecmascript (default if not specified)*/
+/* $CompileFlags: -std=c++11 */
+/* $ModDep: m_regex.h */
+
+class StdRegexException : public ModuleException
+{
+public:
+	StdRegexException(const std::string& rx, const std::string& error)
+		: ModuleException(std::string("Error in regex ") + rx + ": " + error)
+	{
+	}
+};
+
+class StdRegex : public Regex
+{
+private:
+	std::regex regexcl;
+public:
+	StdRegex(const std::string& rx, std::regex::flag_type fltype) : Regex(rx)
+	{
+		try{
+			regexcl.assign(rx, fltype | std::regex::optimize);
+		}
+		catch(std::regex_error rxerr)
+		{
+			throw StdRegexException(rx, rxerr.what());
+		}
+	}
+	
+	virtual bool Matches(const std::string& text)
+	{
+		return std::regex_search(text, regexcl);
+	}
+};
+
+class StdRegexFactory : public RegexFactory
+{
+ public:
+	std::regex::flag_type regextype;
+	StdRegexFactory(Module* m) : RegexFactory(m, "regex/stdregex") {}
+	Regex* Create(const std::string& expr)
+	{
+		return new StdRegex(expr, regextype);
+	}
+};
+
+class ModuleRegexStd : public Module
+{
+public:
+	StdRegexFactory ref;
+	ModuleRegexStd() : ref(this) {
+		ServerInstance->Modules->AddService(ref);
+		Implementation eventlist[] = { I_OnRehash };
+		ServerInstance->Modules->Attach(eventlist, this, 1);
+		OnRehash(NULL);
+	}
+
+	Version GetVersion()
+	{
+		return Version("Regex Provider Module for std::regex", VF_VENDOR);
+	}
+	
+	void OnRehash(User* u)
+	{
+		ConfigTag* Conf = ServerInstance->Config->ConfValue("stdregex");
+		std::string regextype = Conf->getString("type", "ecmascript");
+		
+		if(regextype == "bre")
+			ref.regextype = std::regex::basic;
+		else if(regextype == "ere")
+			ref.regextype = std::regex::extended;
+		else if(regextype == "awk")
+			ref.regextype = std::regex::awk;
+		else if(regextype == "grep")
+			ref.regextype = std::regex::grep;
+		else if(regextype == "egrep")
+			ref.regextype = std::regex::egrep;
+		else
+		{
+			if(regextype != "ecmascript")
+				ServerInstance->SNO->WriteToSnoMask('a', "WARNING: Non-existent regex engine '%s' specified. Falling back to ECMAScript.", regextype.c_str());
+			ref.regextype = std::regex::ECMAScript;
+		}
+	}
+};
+
+MODULE_INIT(ModuleRegexStd)


### PR DESCRIPTION
This requires a compliant implementation, unfortunately GCC's libstdc++ hasn't
implemented this container yet. Although it will compile with GCC, you will be likely
not able to use any regexes (although bre or ere could work - I haven't tried every single one)
However, on Windows this will implement a regex provider that is independent of any 3rd party library,
since Visual C++ 2010 and higher have this implemented.
