### PR TITLE
listensocket: Fix the two aliasing warnings

### DIFF
--- a/src/listensocket.cpp
+++ b/src/listensocket.cpp
@@ -142,16 +142,14 @@ void ListenSocket::AcceptInternal()
 		{
 			// recreate as a sockaddr_in using the IPv4 IP
 			uint16_t sport = client.in6.sin6_port;
-			uint32_t addr = *reinterpret_cast<uint32_t*>(client.in6.sin6_addr.s6_addr + 12);
 			client.in4.sin_family = AF_INET;
 			client.in4.sin_port = sport;
-			client.in4.sin_addr.s_addr = addr;
+			memcpy(&client.in4.sin_addr.s_addr, client.in6.sin6_addr.s6_addr + 12, sizeof(uint32_t));
 
 			sport = server.in6.sin6_port;
-			addr = *reinterpret_cast<uint32_t*>(server.in6.sin6_addr.s6_addr + 12);
 			server.in4.sin_family = AF_INET;
 			server.in4.sin_port = sport;
-			server.in4.sin_addr.s_addr = addr;
+			memcpy(&server.in4.sin_addr.s_addr, server.in6.sin6_addr.s6_addr + 12, sizeof(uint32_t));
 		}
 	}
 

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -180,6 +180,8 @@ class ModuleSSLGnuTLS : public Module
 	ModuleSSLGnuTLS()
 		: starttls(this), capHandler(this, "tls"), iohook(this, "ssl/gnutls", SERVICE_IOHOOK)
 	{
+	    gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
+
 		sessions = new issl_session[ServerInstance->SE->GetMaxFds()];
 
 		gnutls_global_init(); // This must be called once in the program
@@ -319,11 +321,11 @@ class ModuleSSLGnuTLS : public Module
 
 		reader.LoadFile(certfile);
 		std::string cert_string = reader.Contents();
-		gnutls_datum_t cert_datum = { (unsigned char*)cert_string.data(), cert_string.length() };
+		gnutls_datum_t cert_datum = { (unsigned char*)cert_string.data(), static_cast<unsigned int>(cert_string.length()) };
 
 		reader.LoadFile(keyfile);
 		std::string key_string = reader.Contents();
-		gnutls_datum_t key_datum = { (unsigned char*)key_string.data(), key_string.length() };
+		gnutls_datum_t key_datum = { (unsigned char*)key_string.data(), static_cast<unsigned int>(key_string.length()) };
 
 		// If this fails, no SSL port will work. At all. So, do the smart thing - throw a ModuleException
 		unsigned int certcount = Conf->getInt("certcount", 3);
@@ -350,7 +352,7 @@ class ModuleSSLGnuTLS : public Module
 		if ((ret = gnutls_priority_init(&priority, priocstr, &prioerror)) < 0)
 		{
 			// gnutls did not understand the user supplied string, log and fall back to the default priorities
-			ServerInstance->Logs->Log("m_ssl_gnutls",DEFAULT, "m_ssl_gnutls.so: Failed to set priorities to \"%s\": %s Syntax error at position %d, falling back to default (NORMAL)", priorities.c_str(), gnutls_strerror(ret), (prioerror - priocstr));
+			ServerInstance->Logs->Log("m_ssl_gnutls",DEFAULT, "m_ssl_gnutls.so: Failed to set priorities to \"%s\": %s Syntax error at position %ld, falling back to default (NORMAL)", priorities.c_str(), gnutls_strerror(ret), (prioerror - priocstr));
 			gnutls_priority_init(&priority, "NORMAL", NULL);
 		}
 


### PR DESCRIPTION
m_ssl_gnutls: Fix three warnings:
1. libgcrypt will emit a warning to stdout during runtime that it has not been properly initialized
2. Resolve a warning about invalid narrowing inside a { } block. This is not valid as of C++11.
3. Resolve a warning about a wrong format specifier being used
