### PR TITLE
Windows: Replace the unused function hack with explicit instantiation

### DIFF
--- a/win/inspircd_win32wrapper.cpp
+++ b/win/inspircd_win32wrapper.cpp
@@ -733,44 +733,7 @@ int gettimeofday(timeval *tv, void *)
 /* World's largest hack to make reference<> work */
 #include "../src/modules/m_spanningtree/link.h"
 #include "../src/modules/ssl.h"
-static void unused_function()
-{
-	reference<Link> unused_Link;
-	reference<Autoconnect> unused_Autoconnect;
-	reference<ssl_cert> unused_Cert;
-	reference<OperInfo> unused_OperInfo;
-
-	if (unused_Link)
-		unused_Link->Port = -1;
-	if (unused_Autoconnect)
-		unused_Autoconnect->NextConnectTime = -1;
-	if (unused_Cert)
-		unused_Cert->dn = "";
-	if (unused_OperInfo)
-		unused_OperInfo->name = "";
-
-	Autoconnect *a = unused_Autoconnect;
-	Link *l = unused_Link;
-	ssl_cert *s = unused_Cert;
-	OperInfo *o = unused_OperInfo;
-
-	unused_Link = reference<Link>(unused_Link);
-	unused_Autoconnect = reference<Autoconnect>(unused_Autoconnect);
-	unused_Cert = reference<ssl_cert>(unused_Cert);
-	unused_OperInfo = reference<OperInfo>(unused_OperInfo);
-
-	unused_Link = reference<Link>(l);
-	unused_Autoconnect = reference<Autoconnect>(a);
-	unused_Cert = reference<ssl_cert>(s);
-	unused_OperInfo = reference<OperInfo>(o);
-
-	unused_Link = l;
-	unused_Autoconnect = a;
-	unused_Cert = s;
-	unused_OperInfo = o;
-
-	delete unused_Link;
-	delete unused_Autoconnect;
-	delete unused_Cert;
-	delete unused_OperInfo;
-}
+template class reference<Link>;
+template class reference<Autoconnect>;
+template class reference<ssl_cert>;
+template class reference<OperInfo>;


### PR DESCRIPTION
unused_function is a terrible idea for something there is a compiler internal mechanism for. This will build (tested), and won't need additional hacks in the future to prevent a breaking like the recent build failure (issue #303)
