### PR TITLE
Windows: Replace the old DNS server find mechanism with the proper one, the appropriate API

### DIFF
--- a/win/inspircd_win32wrapper.h
+++ b/win/inspircd_win32wrapper.h
@@ -242,9 +242,6 @@ void ::operator delete(void * ptr);
 class ValueItem;
 class ServerConfig;
 
-/* Look up the nameserver in use from the registry on windows */
-CoreExport std::string FindNameServerWin();
-
 #define DISABLE_WRITEV
 
 /* Clear a windows console */


### PR DESCRIPTION
Parsing the registry for what an API can do isn't exactly a good idea - the API is way more forward compatible than parsing a registry key which might be subject to change.

This code uses GetNetworkParams() from IP Helper API because we require FindDNS() to return a string and using DnsQueryConfig would require a subsequent conversion.
