### PR TITLE
Allows to use user->ident string instead of user->nick for NickServ.

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1267,6 +1267,7 @@
 		# forwardmsg: Message to send to users using a connect password.
 		# $nick will be the users' nick, $nickrequired will be the nick
 		# of where the password is going (the nick above).
+		# You can also use $user for the user ident string.
 		forwardmsg="NOTICE $nick :*** Forwarding PASS to $nickrequired"
 
 		# cmd: Command for the nick to run when it recieves a connect

--- a/src/modules/m_passforward.cpp
+++ b/src/modules/m_passforward.cpp
@@ -47,7 +47,7 @@ class ModulePassForward : public Module
 		forwardcmd = Conf.ReadValue("passforward", "cmd", "PRIVMSG $nickrequired :IDENTIFY $pass", 0);
 	}
 
-	void FormatStr(std::string& result, const std::string& format, const std::string &nick, const std::string &pass)
+	void FormatStr(std::string& result, const std::string& format, const LocalUser* user)
 	{
 		for (unsigned int i = 0; i < format.length(); i++)
 		{
@@ -61,12 +61,17 @@ class ModulePassForward : public Module
 				}
 				else if (format.substr(i, 5) == "$nick")
 				{
-					result.append(nick);
+					result.append(user->nick);
+					i += 4;
+				}
+				else if (format.substr(i, 5) == "$user")
+				{
+					result.append(user->ident);
 					i += 4;
 				}
 				else if (format.substr(i,5) == "$pass")
 				{
-					result.append(pass);
+					result.append(user->password);
 					i += 4;
 				}
 				else
@@ -92,11 +97,11 @@ class ModulePassForward : public Module
 		}
 
 		std::string tmp;
-		FormatStr(tmp,forwardmsg, user->nick, user->password);
+		FormatStr(tmp,forwardmsg, user);
 		user->WriteServ(tmp);
 
 		tmp.clear();
-		FormatStr(tmp,forwardcmd, user->nick, user->password);
+		FormatStr(tmp,forwardcmd, user);
 		ServerInstance->Parser->ProcessBuffer(tmp,user);
 	}
 };


### PR DESCRIPTION
This adds a similar functionality to m_passforward.cpp as in the m_ldapauth.cpp module, where you can either use user->nick or user->ident for authentication.

If you use LDAP-compatible IRC services like Anope, you can use $user for both m_ldapauth and for m_passforward. This authenticates twice (to IRC server and to IRC services) but allows you to have a different nickname and not use the user:password trick.
