### PR TITLE
New threadengine based on C++11

### DIFF
--- a/include/threadengines/threadengine_stdlib.h
+++ b/include/threadengines/threadengine_stdlib.h
@@ -1,0 +1,123 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2009 Daniel De Graaf <danieldg@inspircd.org>
+ *   Copyright (C) 2008 Craig Edwards <craigedwards@brainbox.cc>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef THREADENGINE_STDLIB_H
+#define THREADENGINE_STDLIB_H
+
+#include "inspircd_config.h"
+#include "base.h"
+
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+
+class Thread;
+
+/** The ThreadEngine class has the responsibility of initialising
+ * Thread derived classes. It does this by creating operating system
+ * level threads which are then associated with the class transparently.
+ * This allows Thread classes to be derived without needing to know how
+ * the OS implements threads. You should ensure that any sections of code
+ * that use threads are threadsafe and do not interact with any other
+ * parts of the code which are NOT known threadsafe! If you really MUST
+ * access non-threadsafe code from a Thread, use the Mutex class to wrap
+ * access to the code carefully.
+ */
+class CoreExport ThreadEngine
+{
+ public:
+	/** Create a new thread. This takes an already allocated
+	  * Thread* pointer and initializes it to use this threading
+	  * engine. On failure, this function may throw a CoreException.
+	  * @param thread_to_init Pointer to a newly allocated Thread
+	  * derived object.
+	  */
+	void Start(Thread* thread_to_init);
+
+	/** Returns the thread engine's name for display purposes
+	 * @return The thread engine name
+	 */
+	const std::string GetName()
+	{
+		return "stdlib-thread";
+	}
+};
+
+class CoreExport ThreadData
+{
+ public:
+	std::thread* thread;
+	void FreeThread(Thread* toFree);
+};
+
+/** The Mutex class represents a mutex, which can be used to keep threads
+ * properly synchronised. Use mutexes sparingly, as they are a good source
+ * of thread deadlocks etc, and should be avoided except where absolutely
+ * neccessary. Note that the internal behaviour of the mutex varies from OS
+ * to OS depending on the thread engine, for example in windows a Mutex
+ * in InspIRCd uses critical sections, as they are faster and simpler to
+ * manage.
+ */
+class CoreExport Mutex
+{
+ private:
+	std::mutex mymutex;
+ public:
+	void Lock()
+	{
+		mymutex.lock();
+	}
+	void Unlock()
+	{
+		mymutex.unlock();
+	}
+};
+
+class ThreadQueueData
+{
+	std::mutex mymutex;
+	std::condition_variable_any mycondvar;
+ public:
+	void Lock()
+	{
+		mymutex.lock();
+	}
+
+	void Unlock()
+	{
+		mymutex.unlock();
+	}
+
+	void Wakeup()
+	{
+		mycondvar.notify_all();
+	}
+
+	void Wait()
+	{
+		mycondvar.wait(mymutex);
+	}
+};
+
+class ThreadSignalData
+{};
+
+#endif
+

--- a/src/threadengines/threadengine_stdlib.cpp
+++ b/src/threadengines/threadengine_stdlib.cpp
@@ -1,0 +1,51 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2009 Daniel De Graaf <danieldg@inspircd.org>
+ *   Copyright (C) 2008 Craig Edwards <craigedwards@brainbox.cc>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+#include "threadengines/threadengine_stdlib.h"
+#include <stdexcept>
+
+static void entry_point(void* parameter)
+{
+	Thread* pt = static_cast<Thread*>(parameter);
+	pt->Run();
+}
+
+void ThreadEngine::Start(Thread* thread)
+{
+	ThreadData* data = new ThreadData;;
+	try
+	{
+		data->thread = new std::thread(entry_point, thread);
+	}
+	catch(std::exception e)
+	{
+		thread->state = NULL;
+		delete data;
+		throw CoreException("Unable to create new thread: " + std::string(e.what()));
+	}
+	thread->state = data;
+}
+
+void ThreadData::FreeThread(Thread* toFree)
+{
+	toFree->SetExitFlag();
+	thread->join();
+}


### PR DESCRIPTION
The idea behind this is to add a C++11 threading primitive based engine. I've tested it with VC11 and it does seem to work fine.

I'm not sure how useful this is after all; the actual reason I made this was because I was bored.

Please note that this class does not implement ThreadSignalSocket since I was unsure how to exactly do this and the class is little documented. As it's only used in m_mssql and m_mysql, this shouldn't be a problem unless you use these modules.