### PR TITLE
Fix typo in m_filter.

### DIFF
--- a/src/modules/m_filter.cpp
+++ b/src/modules/m_filter.cpp
@@ -114,7 +114,7 @@ class FilterResult
 			flags.push_back('P');
 		if (flag_quit_message)
 			flags.push_back('q');
-		if (flag_privmsg);
+		if (flag_privmsg)
 			flags.push_back('p');
 		if (flag_notice)
 			flags.push_back('n');


### PR DESCRIPTION
Fix an error detected by clang:

```
src/modules/m_filter.cpp:117:20: warning: if statement has empty body [-Wempty-body]
           if (flag_privmsg);
```
