### PR TITLE
unhook --uid from --system in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -165,7 +165,7 @@ if (defined $opt_system) {
 	$config{DATA_DIR}	 = '/var/inspircd';
 	$config{LOG_DIR}	 = '/var/log/inspircd';
 } else {
-	$config{UID} = $<;
+	$config{UID} = $opt_uid || $<;
 	$config{CONFIG_DIR}	 = resolve_directory($config{BASE_DIR}."/conf");	# Configuration Directory
 	$config{MODULE_DIR}	 = resolve_directory($config{BASE_DIR}."/modules");	# Modules Directory
 	$config{BINARY_DIR}	 = resolve_directory($config{BASE_DIR}."/bin");		# Binary Directory


### PR DESCRIPTION
Specifying --uid allows the ircd to run as a specific user, while
--system fixes the install directories to be spread all over the system.
Specifying --uid shouldn't imply --system. This fix allows a uid to be set
while not interfering with --prefix
