### PR TITLE
Fix m_ssl_gnutls under GCC on recent versions of GnuTLS.

### DIFF
--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -42,6 +42,7 @@
 /* $ModDesc: Provides SSL support for clients */
 /* $CompileFlags: pkgconfincludes("gnutls","/gnutls/gnutls.h","") exec("libgcrypt-config --cflags") */
 /* $LinkerFlags: rpath("pkg-config --libs gnutls") pkgconflibs("gnutls","/libgnutls.so","-lgnutls") exec("libgcrypt-config --libs") */
+/* $NoPedantic */
 
 // These don't exist in older GnuTLS versions
 #if(GNUTLS_VERSION_MAJOR < 2)


### PR DESCRIPTION
Commas at the end of enumerator lists are valid in C99 (which GnuTLS uses) but are not valid in C++ before C++11 (which InspIRCd uses). This causes a build error on GCC when using -pedantic.
