### PR TITLE
Fix invalid argument warnings on clang.

### DIFF
--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -87,7 +87,10 @@ INSTMODE_LIB = 0644
 
 DBGOK=0
 @IFEQ $(D) 0
-  CXXFLAGS += -O2 -g1
+  CXXFLAGS += -O2
+  @IFEQ $(CC) gcc
+    CXXFLAGS += -g1
+  @ENDIF
   HEADER = std-header
   DBGOK=1
 @ENDIF


### PR DESCRIPTION
This fixes `clang: warning: argument unused during compilation: '-g1'`.

The references to -g1 in ./configure is junk which was never removed. I shall address this in a future pull request.
