### PR TITLE
[2.0] Fix some grammar errors

### DIFF
--- a/src/modules/m_servprotect.cpp
+++ b/src/modules/m_servprotect.cpp
@@ -70,11 +70,13 @@ class ModuleServProtectMode : public Module
 		return Version("Provides usermode +k to protect services from kicks, kills, and mode changes.", VF_VENDOR);
 	}
 
-	void OnWhois(User* src, User* dst)
+	void OnWhois(User* user, User* dest)
 	{
-		if (dst->IsModeSet('k'))
+		if (dest->IsModeSet('k'))
 		{
-			ServerInstance->SendWhoisLine(src, dst, 310, src->nick+" "+dst->nick+" :is an "+ServerInstance->Config->Network+" Service");
+			/* Changed this from what it was because it was making the Grammar Nazi
+			in me cry each and every time I saw it. */
+			ServerInstance->SendWhoisLine(user, dest, 310, "%s %s :is a Network Service on %s", user->nick.c_str(), dest->nick.c_str(), ServerInstance->Config->Network.c_str());
 		}
 	}
 

--- a/src/whois.cpp
+++ b/src/whois.cpp
@@ -59,10 +59,13 @@ void InspIRCd::DoWhois(User* user, User* dest,unsigned long signon, unsigned lon
 		this->SendWhoisLine(user, dest, 301, "%s %s :%s",user->nick.c_str(), dest->nick.c_str(), dest->awaymsg.c_str());
 	}
 
-	if (IS_OPER(dest))
+	/* Check to make sure the user isn't a 'Network Service' as that oper-line is printed by
+	m_servprotect. This isn't a great fix, but it's easier than modifying the oper-name given by
+	services to make it grammatically correct. -Shawn */
+	if (IS_OPER(dest) && !strcmp(dest->oper->NameStr(), "Services"))
 	{
 		if (this->Config->GenericOper)
-			this->SendWhoisLine(user, dest, 313, "%s %s :is an IRC operator",user->nick.c_str(), dest->nick.c_str());
+			this->SendWhoisLine(user, dest, 313, "%s %s :is an IRC Operator",user->nick.c_str(), dest->nick.c_str());
 		else
 			this->SendWhoisLine(user, dest, 313, "%s %s :is %s %s on %s",user->nick.c_str(), dest->nick.c_str(), (strchr("AEIOUaeiou",dest->oper->name[0]) ? "an" : "a"),dest->oper->NameStr(), this->Config->Network.c_str());
 	}


### PR DESCRIPTION
I've noticed that with network services, like NickServ/ChanServ/etc, there are some grammatical errors with the whois output from them, example: `ChanServ is an ChatSpike Service`

There's also repeated output if you have `m_servprotect` loaded, example:

```
ChanServ is an IRC operator
ChanServ is an ChatSpike Service
```

So, this update fixes that by checking to make sure the oper-name is not `Services` when outputting the `is an IRC operator` line, and then changes the services-line given by `m_servprotect` to the following: 

`ChanServ is a Network Service on ChatSpike`

This hasn't been tested as I don't have a test-net with services enabled, if anybody could test it that would be great. It DOES compile.
