### PR TITLE
Remove halfvoice from the example configuration file.

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -634,7 +634,6 @@
 #<customprefix name="founder" letter="q" prefix="~" rank="50000" ranktoset="50000">
 #<customprefix name="admin" letter="a" prefix="&" rank="40000" ranktoset="50000">
 #<customprefix name="halfop" letter="h" prefix="%" rank="20000" ranktoset="30000">
-#<customprefix name="halfvoice" letter="V" prefix="-" rank="1" ranktoset="20000">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Custom title module: Adds the /TITLE command which allows for trusted


### PR DESCRIPTION
Rationale:
- I have never seen this deployed on a production network.
- This is a non-standard non-feature which is only supported by InspIRCd.
- As this is is a configuration change, it will not break existing installations.
- Half voice. Seriously?
