### PR TITLE
Fix OpenSSL detection on distributions which modify the version number.

### DIFF
--- a/configure
+++ b/configure
@@ -273,7 +273,7 @@ $exec = $config{CC} . " -dumpversion | cut -c 3";
 chomp($config{GCCMINOR}		= `$exec`);
 $config{MAXBUF}			= "512";				# Max buffer size
 
-if ($config{HAS_OPENSSL} =~ /^([-[:digit:].]+)([a-z])?(\-[a-z][0-9])?$/) {
+if ($config{HAS_OPENSSL} =~ /^([-[:digit:].]+)(?:[a-z])?(?:\-[a-z][0-9])?/) {
 	$config{HAS_OPENSSL} = $1;
 } else {
 	$config{HAS_OPENSSL} = "";


### PR DESCRIPTION
Fixes #406. Configure should now ignore everything after the version number. I have tested this on OS X and Ubuntu Server and it works fine on these systems.
