### PR TITLE
[2.0] Use the preprocessor to detect whether hash_map is available.

### DIFF
--- a/configure
+++ b/configure
@@ -904,15 +904,6 @@ print FILEHANDLE "#define MAXBUF " . ($config{MAXBUF}+2) . "\n";
 		if ($config{GCCVER} >= 3) {
 			print FILEHANDLE "#define GCC3\n";
 		}
-		if (
-			(($config{GCCVER} == 4) && ($config{GCCMINOR} >= 3))
-				||
-			($config{GCCVER} > 4)
-				|| # HACK: temporary fix for non-GCC (i.e. clang) builds
-			($config{CC} !~ /gcc/)
-		) {
-			print FILEHANDLE "#define HASHMAP_DEPRECATED\n";
-		}
 		if ($config{HAS_STRLCPY} eq "true") {
 			print FILEHANDLE "#define HAS_STRLCPY\n";
 		}

--- a/include/hash_map.h
+++ b/include/hash_map.h
@@ -22,17 +22,19 @@
 
 #ifndef INSPIRCD_HASHMAP_H
 #define INSPIRCD_HASHMAP_H
-
-#include "inspircd_config.h"
-
+ 
 	/** Where hash_map is varies from compiler to compiler
 	 * as it is not standard unless we have tr1.
+	 *
+	 * TODO: in 2.2 if we drop support for libstdc++ older than 3.4.7 and GCC older
+	 *       than 4.1 this can be cleaned up massively.
 	 */
 	#ifndef _WIN32
-		#ifdef HASHMAP_DEPRECATED
+		#if __GLIBCXX__ > 20060309
 			// GCC4+ has deprecated hash_map and uses tr1. But of course, uses a different include to MSVC. FOR FUCKS SAKE.
 			#include <tr1/unordered_map>
 			#define HAS_TR1_UNORDERED
+			#define HASHMAP_DEPRECATED
 		#else
 			#include <ext/hash_map>
 			/** Oddball linux namespace for hash_map */


### PR DESCRIPTION
This changes the legacy detection for hash maps to use the preprocessor macro containing the libstdc++ version instead of guessing using the configure script. This builds successfully on OS X under Clang and LLVM-GCC and Ubuntu Server with GCC.
