### PR TITLE
[Retry] Modified m_timedbans to behave more like setting mode +b manually

### DIFF
--- a/src/modules/m_timedbans.cpp
+++ b/src/modules/m_timedbans.cpp
@@ -62,12 +62,8 @@ class CommandTban : public Command
 			user->WriteNumeric(482, "%s %s :You do not have permission to set bans on this channel",
 				user->nick.c_str(), channel->name.c_str());
 			return CMD_FAILURE;
-		}
-		if (!ServerInstance->IsValidMask(parameters[2]))
-		{
-			user->WriteServ("NOTICE "+user->nick+" :Invalid ban mask");
-			return CMD_FAILURE;
-		}
+		}		
+
 		TimedBan T;
 		std::string channelname = parameters[0];
 		long duration = ServerInstance->Duration(parameters[1]);
@@ -81,7 +77,15 @@ class CommandTban : public Command
 		std::vector<std::string> setban;
 		setban.push_back(parameters[0]);
 		setban.push_back("+b");
-		setban.push_back(parameters[2]);
+		bool isextban = ((mask.size() > 2) && (mask[1] == ':'));
+		if (!isextban && !ServerInstance->IsValidMask(mask))
+			mask.append("!*@*");
+		if ((mask.length() > 250) || (!ServerInstance->IsValidMask(mask) && !isextban))
+		{
+			user->WriteServ("NOTICE "+user->nick+" :Invalid ban mask");
+			return CMD_FAILURE;
+		}
+		setban.push_back(mask);
 		// use CallHandler to make it so that the user sets the mode
 		// themselves
 		ServerInstance->Parser->CallHandler("MODE",setban,user);


### PR DESCRIPTION
Same as #435 - But preventing insane banmasks.
## Org. text.

It now accepts extbans. If one enters something not an extban, or valid banmask, it'll add "!_@_", making it a nick-ban instead of borking.

Fixes #377
