### PR TITLE
mode +l: do not accept a limit of 0

### DIFF
--- a/src/modes/cmode_l.cpp
+++ b/src/modes/cmode_l.cpp
@@ -39,7 +39,7 @@ bool ModeChannelLimit::ParamValidate(std::string &parameter)
 {
 	int limit = atoi(parameter.c_str());
 
-	if (limit < 0)
+	if (limit < 1)
 		return false;
 
 	parameter = ConvToStr(limit);


### PR DESCRIPTION
RFC1459 must be interpreted as assuming '+l 0' is equivilant to -l.  This
agrees with the interpretation in RFC2811 (section 4.2.9).

Furthermore, original IRCd derivatives do not accept '+l 0'.  Thusly,
I believe strongly that InspIRCd should not either as the behaviour of
'+l 0' is technically undefined.

(ref atheme/atheme#115)
