### PR TITLE
Removed config option for +L

### DIFF
--- a/docs/conf/helpop-full.conf.example
+++ b/docs/conf/helpop-full.conf.example
@@ -802,6 +802,8 @@ When used, the victims won't see each other getting kicked or quitting.">
               hideoper module).
  I            Hides a user's entire channel list in WHOIS from
               non-IRCops (requires hidechans module).
+ L            Stops a user from being force-redirected by channel
+              mode +L.
  R            Blocks private messages from unregistered users
               (requires services account module).
  S            Strips mIRC color/bold/underline codes out of private

--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -102,6 +102,8 @@ LOCKSERV       UNLOCKSERV   JUMPSERVER">
               hideoper module).
  I            Hides a user's entire channel list in WHOIS from
               non-IRCops (requires hidechans module).
+ L            Stops a user from being force-redirected by channel
+              mode +L.
  R            Blocks private messages from unregistered users
               (requires services account module).
  S            Strips mIRC color/bold/underline codes out of private

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1377,17 +1377,10 @@
 #<randquote file="quotes.txt">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Redirect module: Adds channel redirection mode +L.                  #
-# Optional: <redirect:antiredirect> to add usermode +L to stop forced #
-# redirection and instead print an error.                             #
-#                                                                     #
-# Note: You can not update this with a simple rehash, it requires     #
-# reloading the module for it to take effect.                         #
-# This also breaks linking to servers that do not have the option.    #
-# This defaults to false for the 2.0 version, it will be enabled in   #
-# all the future versions.                                            #
+# Redirect module: Adds channel redirection mode and a usermode to    #
+# stop the forced redirection and print an error instead.             #
+# 
 #<module name="m_redirect.so">
-#<redirect antiredirect="true">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Regular expression provider for glob or wildcard (?/*) matching.

--- a/src/modules/m_redirect.cpp
+++ b/src/modules/m_redirect.cpp
@@ -79,8 +79,6 @@ class AntiRedirect : public SimpleUserModeHandler
 	public:
 		AntiRedirect(Module* Creator) : SimpleUserModeHandler(Creator, "antiredirect", 'L')
 		{
-			if (!ServerInstance->Config->ConfValue("redirect")->getBool("antiredirect"))
-				DisableAutoRegister();
 		}
 };
 
@@ -89,7 +87,6 @@ class ModuleRedirect : public Module
 	Redirect re;
 	AntiRedirect re_u;
 	ChanModeReference limitmode;
-	bool UseUsermode;
 
  public:
 	ModuleRedirect()
@@ -101,8 +98,6 @@ class ModuleRedirect : public Module
 
 	void init() CXX11_OVERRIDE
 	{
-		/* Setting this here so it isn't changable by rehasing the config later. */
-		UseUsermode = ServerInstance->Config->ConfValue("redirect")->getBool("antiredirect");
 	}
 
 	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
@@ -122,9 +117,8 @@ class ModuleRedirect : public Module
 						user->WriteNumeric(470, "%s * :You may not join this channel. A redirect is set, but you may not be redirected as it is a circular loop.", cname.c_str());
 						return MOD_RES_DENY;
 					}
-					/* We check the bool value here to make sure we have it enabled, if we don't then
-						usermode +L might be assigned to something else. */
-					if (UseUsermode && user->IsModeSet(re_u))
+
+					if (user->IsModeSet(re_u))
 					{
 						user->WriteNumeric(470, "%s %s :Force redirection stopped.", cname.c_str(), channel.c_str());
 						return MOD_RES_DENY;


### PR DESCRIPTION
Since the config option was only there to preserve backwards compatibility in 2.0, I've removed it for the new version.
