### PR TITLE
m_messageflood can now block instead of kick(ban)

### DIFF
--- a/docs/conf/helpop-full.conf.example
+++ b/docs/conf/helpop-full.conf.example
@@ -826,8 +826,9 @@ Closes all unregistered connections to the local server.">
  d [time]           Blocks messages to a channel from new users
                     until they have been in the channel for [time]
                     seconds (requires delaymsg module).
- f [*][lines]:[sec] Kicks on text flood equal to or above the
+ f [~*][lines]:[sec]Kicks on text flood equal to or above the
                     specified rate. With *, the user is banned
+                    With ~, the message is simply blocked, no kick or ban.
                     (requires messageflood module).
  i                  Makes the channel invite-only.
                     Users can only join if an operator

--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -138,6 +138,7 @@ LOCKSERV       UNLOCKSERV   JUMPSERVER">
                     (requires blockcolor module).
  f [*][lines]:[sec] Kicks on text flood equal to or above the
                     specified rate. With *, the user is banned
+                    With ~, the message is simply blocked, no kick or ban.
                     (requires messageflood module).
  g [mask]           Blocks messages matching the given blob mask
                     (requires chanfilter module).

--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -136,7 +136,7 @@ LOCKSERV       UNLOCKSERV   JUMPSERVER">
 
  c                  Blocks messages containing mIRC color codes
                     (requires blockcolor module).
- f [*][lines]:[sec] Kicks on text flood equal to or above the
+ f [~*][lines]:[sec]Kicks on text flood equal to or above the
                     specified rate. With *, the user is banned
                     With ~, the message is simply blocked, no kick or ban.
                     (requires messageflood module).

--- a/src/modules/m_messageflood.cpp
+++ b/src/modules/m_messageflood.cpp
@@ -121,12 +121,18 @@ class MsgFlood : public ModeHandler
 
 			ext.set(channel, new floodsettings(settings, nsecs, nlines));
 
-			if (settings == FLOOD_BAN)
-				parameter = std::string("*");
-			else if (settings == FLOOD_BLOCK)
-				parameter = std::string("~");
-			else
-				parameter = std::string("");
+
+			switch (settings)
+			{
+				case FLOOD_BAN:
+					parameter = std::string("*");
+					break;
+				case FLOOD_BLOCK:
+					parameter = std::string("~");
+					break;
+				default:
+					parameter = std::string("");
+			}
 
 			parameter += ConvToStr(nlines) + ":" + ConvToStr(nsecs);
 			channel->SetModeParam('f', parameter);

--- a/src/modules/m_messageflood.cpp
+++ b/src/modules/m_messageflood.cpp
@@ -26,11 +26,6 @@
 
 #include "inspircd.h"
 
-enum fsetting {
-	FLOOD_DEFAULT,
-	FLOOD_BAN,
-	FLOOD_BLOCK
-};
 
 /* $ModDesc: Provides channel mode +f (message flood protection) */
 
@@ -39,7 +34,12 @@ enum fsetting {
 class floodsettings
 {
  public:
-	fsetting settings;
+	enum fsetting {
+		FLOOD_DEFAULT,
+		FLOOD_BAN,
+		FLOOD_BLOCK
+	} settings;
+
 	unsigned int secs;
 	unsigned int lines;
 	time_t reset;
@@ -92,20 +92,20 @@ class MsgFlood : public ModeHandler
 			}
 
 			/* Set up the flood parameters for this channel */
-			fsetting settings;
+			floodsettings::fsetting settings;
 			switch (parameter[0])
 			{
 				case '*':
-					settings = FLOOD_BAN;
+					settings = floodsettings::FLOOD_BAN;
 					break;
 				case '~':
-					settings = FLOOD_BLOCK;
+					settings = floodsettings::FLOOD_BLOCK;
 					break;
 				default:
-					settings = FLOOD_DEFAULT;
+					settings = floodsettings::FLOOD_DEFAULT;
 					break;
 			}
-			unsigned int nlines = ConvToInt(parameter.substr(settings != FLOOD_DEFAULT ? 1 : 0, settings != FLOOD_DEFAULT ? colon-1 : colon));
+			unsigned int nlines = ConvToInt(parameter.substr(settings != floodsettings::FLOOD_DEFAULT ? 1 : 0, settings != floodsettings::FLOOD_DEFAULT ? colon-1 : colon));
 			unsigned int nsecs = ConvToInt(parameter.substr(colon+1));
 
 			if ((nlines<2) || (nsecs<1))
@@ -124,10 +124,10 @@ class MsgFlood : public ModeHandler
 
 			switch (settings)
 			{
-				case FLOOD_BAN:
+				case floodsettings::FLOOD_BAN:
 					parameter = std::string("*");
 					break;
-				case FLOOD_BLOCK:
+				case floodsettings::FLOOD_BLOCK:
 					parameter = std::string("~");
 					break;
 				default:
@@ -184,7 +184,7 @@ class ModuleMsgFlood : public Module
 			if (f->addmessage(user))
 			{
 				/* Youre outttta here! */
-				if (f->settings == FLOOD_BAN)
+				if (f->settings == floodsettings::FLOOD_BAN)
 				{
 					std::vector<std::string> parameters;
 					parameters.push_back(dest->name);
@@ -193,7 +193,7 @@ class ModuleMsgFlood : public Module
 					ServerInstance->SendGlobalMode(parameters, ServerInstance->FakeClient);
 				}
 
-				if (f->settings == FLOOD_BLOCK)
+				if (f->settings == floodsettings::FLOOD_BLOCK)
 				{
 					user->WriteNumeric(ERR_CANNOTSENDTOCHAN, "%s %s :Channel flood limit exceeded! (limit is %u lines in %u seconds)", user->nick.c_str(), dest->name.c_str(), f->lines, f->secs);
 				}


### PR DESCRIPTION
This adds the `~` parameter to block instead of kick.

Usage: `+f ~5:10`

This was requested in issue #469
