### PR TITLE
Made blockcaps a per-channel setting.

### DIFF
--- a/docs/conf/helpop-full.conf.example
+++ b/docs/conf/helpop-full.conf.example
@@ -867,7 +867,9 @@ Closes all unregistered connections to the local server.">
  A                  Allows anyone to invite users to the channel
                     (normally only chanops can invite, requires
                     allowinvite module).
- B [percent]:[len]  Blocks messages with too many capital letters.
+ B [~*][percent]:[len] kicks users for messages with too many capital letters.
+                    If the ~ is used it will block instead of kick.
+                    If the * is used it will kickban instead of kick.
                     (requires blockcaps module).
  C                  Blocks any CTCPs to the channel (requires noctcp
                     module).

--- a/docs/conf/helpop-full.conf.example
+++ b/docs/conf/helpop-full.conf.example
@@ -867,8 +867,7 @@ Closes all unregistered connections to the local server.">
  A                  Allows anyone to invite users to the channel
                     (normally only chanops can invite, requires
                     allowinvite module).
- B                  Blocks messages with too many capital letters,
-                    as determined by the network configuration
+ B [percent]:[len]  Blocks messages with too many capital letters.
                     (requires blockcaps module).
  C                  Blocks any CTCPs to the channel (requires noctcp
                     module).
@@ -1039,8 +1038,6 @@ Acting extbans:
                nopartmsg module).
  A:<ban>       Blocks invites by matching users even when +A is set
                (requires allowinvite module).
- B:<ban>       Blocks all capital or nearly all capital messages from
-               matching users (requires blockcaps module).
  C:<ban>       Blocks CTCPs from matching users (requires noctcp
                module).
  N:<ban>       Blocks nick changes from matching users (requires

--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -174,8 +174,7 @@ LOCKSERV       UNLOCKSERV   JUMPSERVER">
  A                  Allows anyone to invite users to the channel
                     (normally only chanops can invite, requires
                     allowinvite module).
- B                  Blocks messages with too many capital letters,
-                    as determined by the network configuration
+ B [percent]:[len]  Blocks messages with too many capital letters.
                     (requires blockcaps module).
  C                  Blocks any CTCPs to the channel (requires noctcp
                     module).
@@ -269,8 +268,6 @@ help channel if you have any questions.">
 
  A:n!u@h      Blocks invites by matching users even when +A is set
               (requires allowinvite module).
- B:n!u@h      Blocks all capital or nearly all capital messages from
-              matching users (requires blockcaps module).
  C:n!u@h      Blocks CTCPs from matching users (requires noctcp
               module).
  M:account    Blocks messages from users logged into a matching

--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -174,7 +174,9 @@ LOCKSERV       UNLOCKSERV   JUMPSERVER">
  A                  Allows anyone to invite users to the channel
                     (normally only chanops can invite, requires
                     allowinvite module).
- B [percent]:[len]  Blocks messages with too many capital letters.
+ B [~*][percent]:[len] Kicks users for messages with too many capital letters.
+                    If the ~ is used it will block instead of kick.
+                    If the * is used it will kickban instead of kick.
                     (requires blockcaps module).
  C                  Blocks any CTCPs to the channel (requires noctcp
                     module).

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -245,24 +245,31 @@
 #<blockamsg delay="3" action="killopers">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Block CAPS module: Blocking all-CAPS messages with cmode +B
-#<module name="m_blockcaps.so">
+# Block CAPS module: Blocking all-CAPS messages with cmode +B         #
+# For strictly 2.2 networks, use m_blockcaps.                         #
+# For networks with 2.0 servers still linked, you MUST use the other. #
+# Syntax for m_blockcaps is +B percentage:minlength                   #
+# Syntax for m_blockcaps_compat is +B, percent/minlength is defined   #
+# below for the legacy compatibility module.                          #
+#<module name="m_blockcaps.so">                                       #
+#<module name="m_blockcaps_compat.so">                                #
 #                                                                     #
 #-#-#-#-#-#-#-#-#-#-#-  BLOCKCAPS CONFIGURATION  -#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #
 # percent        - How many percent of text must be caps before text  #
-#                  will be blocked.                                   #
+#                  will be blocked. (blockcaps_compat ONLY)           #
 #                                                                     #
 # minlen         - The minimum length a line must be for the block    #
-#                  percent to have any effect.                        #
+#                  percent to have any effect. (blockcaps_compat ONLY)#
 #                                                                     #
 # capsmap        - A list of chars to be considered CAPS, this was    #
 #                  you can add CAPS for your language. Also you can   #
 #                  add things like ! and space to further lock down   #
-#                  on caps usage.                                     #
-#<blockcaps percent="50"
-#           minlen="5"
-#           capsmap="ABCDEFGHIJKLMNOPQRSTUVWXYZ! ">
+#                  on caps usage.(blockcaps and blockcaps_compat both)#
+#<blockcaps
+#	percent="50"
+#	minlen="5"
+#	capsmap="ABCDEFGHIJKLMNOPQRSTUVWXYZ! ">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Block color module: Blocking color-coded messages with cmode +c

--- a/src/modules/m_blockcaps_compat.cpp
+++ b/src/modules/m_blockcaps_compat.cpp
@@ -1,0 +1,140 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2006, 2008 Craig Edwards <craigedwards@brainbox.cc>
+ *   Copyright (C) 2006-2007 Dennis Friis <peavey@inspircd.org>
+ *   Copyright (C) 2007 Robin Burchell <robin+git@viroteck.net>
+ *   Copyright (C) 2006 Oliver Lupton <oliverlupton@gmail.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+
+/* $ModDesc: Provides support to block all-CAPS channel messages and notices */
+
+
+/** Handles the +B channel mode
+ */
+class BlockCaps : public SimpleChannelModeHandler
+{
+ public:
+	BlockCaps(Module* Creator) : SimpleChannelModeHandler(Creator, "blockcaps", 'B') { }
+};
+
+class ModuleBlockCAPS : public Module
+{
+	BlockCaps bc;
+	int percent;
+	unsigned int minlen;
+	char capsmap[256];
+
+public:
+	ModuleBlockCAPS() : bc(this)
+	{
+	}
+
+	void init()
+	{
+		OnRehash(NULL);
+		ServerInstance->Modules->AddService(bc);
+		Implementation eventlist[] = { I_OnUserPreMessage, I_OnUserPreNotice, I_OnRehash, I_On005Numeric };
+		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
+	}
+
+	virtual void On005Numeric(std::string &output)
+	{
+		ServerInstance->AddExtBanChar('B');
+	}
+
+	virtual void OnRehash(User* user)
+	{
+		ReadConf();
+	}
+
+	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	{
+		if (target_type == TYPE_CHANNEL)
+		{
+			if ((!IS_LOCAL(user)) || (text.length() < minlen))
+				return MOD_RES_PASSTHRU;
+
+			Channel* c = (Channel*)dest;
+			ModResult res = ServerInstance->OnCheckExemption(user,c,"blockcaps");
+
+			if (res == MOD_RES_ALLOW)
+				return MOD_RES_PASSTHRU;
+
+			if (!c->GetExtBanStatus(user, 'B').check(!c->IsModeSet('B')))
+			{
+				int caps = 0;
+				const char* actstr = "\1ACTION ";
+				int act = 0;
+
+				for (std::string::iterator i = text.begin(); i != text.end(); i++)
+				{
+					/* Smart fix for suggestion from Jobe, ignore CTCP ACTION (part of /ME) */
+					if (*actstr && *i == *actstr++ && act != -1)
+					{
+						act++;
+						continue;
+					}
+					else
+						act = -1;
+
+					caps += capsmap[(unsigned char)*i];
+				}
+				if ( ((caps*100)/(int)text.length()) >= percent )
+				{
+					user->WriteNumeric(ERR_CANNOTSENDTOCHAN, "%s %s :Your message cannot contain more than %d%% capital letters if it's longer than %d characters", user->nick.c_str(), c->name.c_str(), percent, minlen);
+					return MOD_RES_DENY;
+				}
+			}
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	{
+		return OnUserPreMessage(user,dest,target_type,text,status,exempt_list);
+	}
+
+	void ReadConf()
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("blockcaps");
+		percent = tag->getInt("percent", 100);
+		minlen = tag->getInt("minlen", 1);
+		std::string hmap = tag->getString("capsmap", "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+		memset(capsmap, 0, sizeof(capsmap));
+		for (std::string::iterator n = hmap.begin(); n != hmap.end(); n++)
+			capsmap[(unsigned char)*n] = 1;
+		if (percent < 1 || percent > 100)
+		{
+			ServerInstance->Logs->Log("CONFIG",DEFAULT, "<blockcaps:percent> out of range, setting to default of 100.");
+			percent = 100;
+		}
+		if (minlen < 1 || minlen > MAXBUF-1)
+		{
+			ServerInstance->Logs->Log("CONFIG",DEFAULT, "<blockcaps:minlen> out of range, setting to default of 1.");
+			minlen = 1;
+		}
+	}
+
+	virtual Version GetVersion()
+	{
+		return Version("Provides support to block all-CAPS channel messages and notices", VF_VENDOR);
+	}
+};
+
+MODULE_INIT(ModuleBlockCAPS)


### PR DESCRIPTION
This changes the `m_blockcaps` from a config-defined, network-wide setting to a per-channel setting defined with mode parameters.

The new syntax is `+B percent-to-match:minimum-length`
Example: `+B 50:10` will kick for anything over 10 characters that contains 50% or more caps.

You can also specify `~` or `*` for blocking or banning in the same manner as m_messageflood

Example: `+B *55:10` will ban for anything over 10 characters that contains 55% or more caps.
Example: `+B ~55:10` will block anything over 10 characters that contains 55% or more caps.

The current `m_blockcaps` module was moved to `m_blockcaps_compat` so networks that still have 2.0 servers linked may use that.

Requested in: #463
