### PR TITLE
Improve the config deprecation system.

### DIFF
--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -434,21 +434,28 @@ void ServerConfig::CrossCheckConnectBlocks(ServerConfig* current)
 
 /** Represents a deprecated configuration tag.
  */
-struct Deprecated
+struct DeprecatedConfig
 {
-	/** Tag name
-	 */
-	const char* tag;
-	/** Tag value
-	 */
-	const char* value;
-	/** Reason for deprecation
-	 */
-	const char* reason;
+	/** Tag name. */
+	std::string tag;
+	
+	/** Attribute key. */
+	std::string key;
+	
+	/** Attribute value. */
+	std::string value;
+	
+	/** Reason for deprecation. */
+	std::string reason;
 };
 
-static const Deprecated ChangedConfig[] = {
-	{ "die", "value", "you need to reread your config" },
+static const DeprecatedConfig ChangedConfig[] = {
+	{ "bind",   "transport",   "",                 "has been moved to <bind:ssl> as of 2.0" },
+	{ "die",    "value",       "",                 "you need to reread your config" },
+	{ "link",   "autoconnect", "",                 "2.0+ does not use this attribute - define <autoconnect> tags instead" },
+	{ "link",   "transport",   "",                 "has been moved to <link:ssl> as of 2.0" },
+	{ "module", "name",        "m_chanprotect.so", "has been replaced with m_customprefix as of 2.2" },
+	{ "module", "name",        "m_halfop.so",      "has been replaced with m_customprefix as of 2.2" },
 };
 
 void ServerConfig::Fill()
@@ -659,16 +666,26 @@ void ServerConfig::Apply(ServerConfig* old, const std::string &useruid)
 	/* The stuff in here may throw CoreException, be sure we're in a position to catch it. */
 	try
 	{
-		for (int Index = 0; Index * sizeof(Deprecated) < sizeof(ChangedConfig); Index++)
+		for (int index = 0; index * sizeof(DeprecatedConfig) < sizeof(ChangedConfig); index++)
 		{
-			std::string dummy;
-			ConfigTagList tags = ConfTags(ChangedConfig[Index].tag);
+			std::string value;
+			ConfigTagList tags = ConfTags(ChangedConfig[index].tag);
 			for(ConfigIter i = tags.first; i != tags.second; ++i)
 			{
-				if (i->second->readString(ChangedConfig[Index].value, dummy, true))
-					errstr << "Your configuration contains a deprecated value: <"
-						<< ChangedConfig[Index].tag << ":" << ChangedConfig[Index].value << "> - " << ChangedConfig[Index].reason
-						<< " (at " << i->second->getTagLocation() << ")\n";
+				if (i->second->readString(ChangedConfig[index].key, value, true)
+					&& (ChangedConfig[index].value.empty() || value == ChangedConfig[index].value))
+				{
+					errstr << "Your configuration contains a deprecated value: <"  << ChangedConfig[index].tag;
+					if (ChangedConfig[index].value.empty())
+					{
+						errstr << ':' << ChangedConfig[index].key;
+					}
+					else
+					{
+						errstr << ' ' << ChangedConfig[index].key << "=\"" << ChangedConfig[index].value << "\"";
+					}
+					errstr << "> - " << ChangedConfig[index].reason << " (at " << i->second->getTagLocation() << ")\n";
+				}
 			}
 		}
 


### PR DESCRIPTION
Attribute values can now be deprecated (e.g. `<module name="m_halfop.so">`).
