### PR TITLE
Add <security:allowcoreunload>.

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -657,6 +657,9 @@
 #                                                                     #
 
 <security
+          # allowcoreunload: If this value is set to yes, Opers will be able to
+          # unload core modules (e.g. cmd_privmsg.so).
+          allowcoreunload="no"
 
           # announceinvites: This option controls which members of the channel
           # receive an announcement when someone is INVITEd. Available values:

--- a/src/commands/cmd_unloadmodule.cpp
+++ b/src/commands/cmd_unloadmodule.cpp
@@ -42,12 +42,19 @@ class CommandUnloadmodule : public Command
 
 CmdResult CommandUnloadmodule::Handle (const std::vector<std::string>& parameters, User *user)
 {
+	if (!ServerInstance->Config->ConfValue("security")->getBool("allowcoreunload") &&
+		InspIRCd::Match(parameters[0], "cmd_*.so", ascii_case_insensitive_map))
+	{
+		user->WriteNumeric(972, "%s %s :You cannot unload core commands!", user->nick.c_str(), parameters[0].c_str());
+		return CMD_FAILURE;
+	}
+
 	if (parameters[0] == "cmd_unloadmodule.so" || parameters[0] == "cmd_loadmodule.so")
 	{
 		user->WriteNumeric(972, "%s %s :You cannot unload module loading commands!", user->nick.c_str(), parameters[0].c_str());
 		return CMD_FAILURE;
 	}
-		
+
 	Module* m = ServerInstance->Modules->Find(parameters[0]);
 	if (m && ServerInstance->Modules->Unload(m))
 	{

--- a/src/modules/m_globalload.cpp
+++ b/src/modules/m_globalload.cpp
@@ -79,6 +79,13 @@ class CommandGunloadmodule : public Command
 
 	CmdResult Handle (const std::vector<std::string> &parameters, User *user)
 	{
+		if (!ServerInstance->Config->ConfValue("security")->getBool("allowcoreunload") &&
+			InspIRCd::Match(parameters[0], "cmd_*.so", ascii_case_insensitive_map))
+		{
+			user->WriteNumeric(972, "%s %s :You cannot unload core commands!", user->nick.c_str(), parameters[0].c_str());
+			return CMD_FAILURE;
+		}
+
 		std::string servername = parameters.size() > 1 ? parameters[1] : "*";
 
 		if (InspIRCd::Match(ServerInstance->Config->ServerName.c_str(), servername))


### PR DESCRIPTION
When enabled (the default) this setting prevents the unloading of core modules such as cmd_privmsg.
