### PR TITLE
Fix ModuleManager error caused by a lack of arguments.

### DIFF
--- a/modulemanager
+++ b/modulemanager
@@ -262,7 +262,7 @@ sub resolve_deps {
 	}
 }
 
-my $action = lc shift @ARGV;
+my $action = $#ARGV > 0 ? lc shift @ARGV : 'help';
 
 if ($action eq 'install') {
 	for my $mod (@ARGV) {


### PR DESCRIPTION
Fixes this:

```
SaberUK@Rikka3210:~/Projects/inspircd/personal$ ./modulemanager 
Use of uninitialized value within @ARGV in lc at ./modulemanager line 265.
```

This should probably also be backported to 2.0.
