### PR TITLE
Fix building with libc++.

### DIFF
--- a/include/bancache.h
+++ b/include/bancache.h
@@ -51,7 +51,7 @@ class CoreExport BanCacheHit
 /* A container of ban cache items.
  * must be defined after class BanCacheHit.
  */
-typedef std::tr1::unordered_map<std::string, BanCacheHit*, std::tr1::hash<std::string> > BanCacheHash;
+typedef TR1NS::unordered_map<std::string, BanCacheHit*, TR1NS::hash<std::string> > BanCacheHash;
 
 /** A manager for ban cache, which allocates and deallocates and checks cached bans.
  */

--- a/include/dns.h
+++ b/include/dns.h
@@ -101,7 +101,7 @@ class CoreExport CachedQuery
 
 /** DNS cache information. Holds IPs mapped to hostnames, and hostnames mapped to IPs.
  */
-typedef std::tr1::unordered_map<irc::string, CachedQuery, irc::hash> dnscache;
+typedef TR1NS::unordered_map<irc::string, CachedQuery, irc::hash> dnscache;
 
 /**
  * Error types that class Resolver can emit to its error method.

--- a/include/hashcomp.h
+++ b/include/hashcomp.h
@@ -109,6 +109,11 @@ namespace irc
 		bool operator()(const std::string& s1, const std::string& s2) const;
 	};
 
+	struct insensitive
+	{
+		size_t CoreExport operator()(const std::string &s) const;
+	};
+
 	/** The irc_char_traits class is used for RFC-style comparison of strings.
 	 * This class is used to implement irc::string, a case-insensitive, RFC-
 	 * comparing string class.
@@ -580,22 +585,4 @@ inline std::string& trim(std::string &str)
 		str = str.substr(start, end-start+1);
 
 	return str;
-}
-
-namespace std
-{
-	namespace tr1
-	{
-		
-		struct insensitive
-		{
-			size_t CoreExport operator()(const std::string &s) const;
-		};
-		
-        /** Convert a string to lower case respecting RFC1459
-        * @param n A string to lowercase
-        */
-        void strlower(char *n);
-		
-	}
 }

--- a/include/inspircd.h
+++ b/include/inspircd.h
@@ -66,9 +66,11 @@
 #include <unistd.h>
 #endif
 
-#ifdef _WIN32
+#if defined _LIBCPP_VERSION || defined _WIN32
+# define TR1NS std
 # include <unordered_map>
 #else
+# define TR1NS std::tr1
 # include <tr1/unordered_map>
 #endif
 #include <sstream>

--- a/include/typedefs.h
+++ b/include/typedefs.h
@@ -55,8 +55,8 @@ struct ResourceRecord;
 #include "hashcomp.h"
 #include "base.h"
 
-typedef std::tr1::unordered_map<std::string, User*, std::tr1::insensitive, irc::StrHashComp> user_hash;
-typedef std::tr1::unordered_map<std::string, Channel*, std::tr1::insensitive, irc::StrHashComp> chan_hash;
+typedef TR1NS::unordered_map<std::string, User*, irc::insensitive, irc::StrHashComp> user_hash;
+typedef TR1NS::unordered_map<std::string, Channel*, irc::insensitive, irc::StrHashComp> chan_hash;
 
 /** A list holding local users, this is the type of UserManager::local_users
  */
@@ -114,7 +114,7 @@ typedef std::map<std::string, file_cache> ConfigFileCache;
 
 /** A hash of commands used by the core
  */
-typedef std::tr1::unordered_map<std::string,Command*> Commandtable;
+typedef TR1NS::unordered_map<std::string, Command*> Commandtable;
 
 /** Membership list of a channel */
 typedef std::map<User*, Membership*> UserMembList;

--- a/src/hashcomp.cpp
+++ b/src/hashcomp.cpp
@@ -154,29 +154,6 @@ unsigned const char rfc_case_sensitive_map[256] = {
 	250, 251, 252, 253, 254, 255,                     // 250-255
 };
 
-void std::tr1::strlower(char *n)
-{
-	if (n)
-	{
-		for (char* t = n; *t; t++)
-			*t = national_case_insensitive_map[(unsigned char)*t];
-	}
-}
-
-size_t std::tr1::insensitive::operator()(const std::string &s) const
-{
-	/* XXX: NO DATA COPIES! :)
-	 * The hash function here is practically
-	 * a copy of the one in STL's hash_fun.h,
-	 * only with *x replaced with national_case_insensitive_map[*x].
-	 * This avoids a copy to use hash<const char*>
-	 */
-	register size_t t = 0;
-	for (std::string::const_iterator x = s.begin(); x != s.end(); ++x) /* ++x not x++, as its faster */
-		t = 5 * t + national_case_insensitive_map[(unsigned char)*x];
-	return t;
-}
-
 size_t CoreExport irc::hash::operator()(const irc::string &s) const
 {
 	register size_t t = 0;
@@ -193,6 +170,20 @@ bool irc::StrHashComp::operator()(const std::string& s1, const std::string& s2) 
 		if (national_case_insensitive_map[*n1] != national_case_insensitive_map[*n2])
 			return false;
 	return (national_case_insensitive_map[*n1] == national_case_insensitive_map[*n2]);
+}
+
+size_t irc::insensitive::operator()(const std::string &s) const
+{
+	/* XXX: NO DATA COPIES! :)
+	 * The hash function here is practically
+	 * a copy of the one in STL's hash_fun.h,
+	 * only with *x replaced with national_case_insensitive_map[*x].
+	 * This avoids a copy to use hash<const char*>
+	 */
+	register size_t t = 0;
+	for (std::string::const_iterator x = s.begin(); x != s.end(); ++x) /* ++x not x++, as its faster */
+		t = 5 * t + national_case_insensitive_map[(unsigned char)*x];
+	return t;
 }
 
 /******************************************************

--- a/src/modules/m_spanningtree/utils.h
+++ b/src/modules/m_spanningtree/utils.h
@@ -35,7 +35,7 @@ class SpanningTreeUtilities;
 /* This hash_map holds the hash equivalent of the server
  * tree, used for rapid linear lookups.
  */
-typedef std::tr1::unordered_map<std::string, TreeServer*, std::tr1::insensitive, irc::StrHashComp> server_hash;
+typedef TR1NS::unordered_map<std::string, TreeServer*, irc::insensitive, irc::StrHashComp> server_hash;
 
 typedef std::set<TreeServer*> TreeServerList;
 

--- a/src/modules/m_watch.cpp
+++ b/src/modules/m_watch.cpp
@@ -92,12 +92,7 @@
  * of users using WATCH.
  */
 
-/*
- * Before you start screaming, this definition is only used here, so moving it to a header is pointless.
- * Yes, it's horrid. Blame cl for being different. -- w00t
- */
-
-typedef std::tr1::unordered_map<irc::string, std::deque<User*>, irc::hash> watchentries;
+typedef TR1NS::unordered_map<irc::string, std::deque<User*>, irc::hash> watchentries;
 typedef std::map<irc::string, std::string> watchlist;
 
 /* Who's watching each nickname.


### PR DESCRIPTION
- Purged std::tr1::strlower (was never used, probably part of the old hash map implementation).
- Moved std::tr1::insensitive to irc::insensitive.
- Added TR1NS macro to point to the correct C++ TR1 namespace.
