### PR TITLE
Tidy up keywords on module methods.

### DIFF
--- a/src/modules/extra/m_geoip.cpp
+++ b/src/modules/extra/m_geoip.cpp
@@ -50,7 +50,7 @@ class ModuleGeoIP : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		gi = GeoIP_new(GEOIP_STANDARD);
 		if (gi == NULL)
@@ -76,12 +76,12 @@ class ModuleGeoIP : public Module
 			GeoIP_delete(gi);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides a way to assign users to connect classes by country using GeoIP lookup", VF_VENDOR);
 	}
 
-	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass)
+	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass) CXX11_OVERRIDE
 	{
 		std::string* cc = ext.get(user);
 		if (!cc)
@@ -98,7 +98,7 @@ class ModuleGeoIP : public Module
 		return MOD_RES_DENY;
 	}
 
-	ModResult OnStats(char symbol, User* user, string_list &out)
+	ModResult OnStats(char symbol, User* user, string_list &out) CXX11_OVERRIDE
 	{
 		if (symbol != 'G')
 			return MOD_RES_PASSTHRU;

--- a/src/modules/extra/m_ldapauth.cpp
+++ b/src/modules/extra/m_ldapauth.cpp
@@ -119,7 +119,7 @@ public:
 		conn = NULL;
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(ldapAuthed);
 		ServerInstance->Modules->AddService(ldapVhost);
@@ -134,7 +134,7 @@ public:
 			ldap_unbind_ext(conn, NULL, NULL);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("ldapauth");
 		whitelistedcidrs.clear();
@@ -234,7 +234,7 @@ public:
 	   return result;
 	}
 
-	virtual void OnUserConnect(LocalUser *user)
+	void OnUserConnect(LocalUser *user) CXX11_OVERRIDE
 	{
 		std::string* cc = ldapVhost.get(user);
 		if (cc)
@@ -244,7 +244,7 @@ public:
 		}
 	}
 
-	ModResult OnUserRegister(LocalUser* user)
+	ModResult OnUserRegister(LocalUser* user) CXX11_OVERRIDE
 	{
 		if ((!allowpattern.empty()) && (InspIRCd::Match(user->nick,allowpattern)))
 		{
@@ -421,12 +421,12 @@ public:
 		return true;
 	}
 
-	ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user) CXX11_OVERRIDE
 	{
 		return ldapAuthed.get(user) ? MOD_RES_PASSTHRU : MOD_RES_DENY;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allow/Deny connections based upon answer from LDAP server", VF_VENDOR);
 	}

--- a/src/modules/extra/m_ldapoper.cpp
+++ b/src/modules/extra/m_ldapoper.cpp
@@ -98,20 +98,20 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnRehash, I_OnPreCommand };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 		OnRehash(NULL);
 	}
 
-	virtual ~ModuleLDAPAuth()
+	~ModuleLDAPAuth()
 	{
 		if (conn)
 			ldap_unbind_ext(conn, NULL, NULL);
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("ldapoper");
 
@@ -153,7 +153,7 @@ public:
 		return true;
 	}
 
-	ModResult OnPreCommand(std::string& command, std::vector<std::string>& parameters, LocalUser* user, bool validated, const std::string& original_line)
+	ModResult OnPreCommand(std::string& command, std::vector<std::string>& parameters, LocalUser* user, bool validated, const std::string& original_line) CXX11_OVERRIDE
 	{
 		if (validated && command == "OPER" && parameters.size() >= 2)
 		{
@@ -230,7 +230,7 @@ public:
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Adds the ability to authenticate opers via LDAP", VF_VENDOR);
 	}

--- a/src/modules/extra/m_mssql.cpp
+++ b/src/modules/extra/m_mssql.cpp
@@ -64,8 +64,8 @@ class QueryThread : public SocketThread
   public:
 	QueryThread(ModuleMsSQL* mod) : Parent(mod) { }
 	~QueryThread() { }
-	virtual void Run();
-	virtual void OnNotify();
+	void Run();
+	void OnNotify();
 };
 
 class MsSQLResult : public SQLresult
@@ -107,17 +107,17 @@ class MsSQLResult : public SQLresult
 		rows++;
 	}
 
-	virtual int Rows()
+	int Rows()
 	{
 		return rows;
 	}
 
-	virtual int Cols()
+	int Cols()
 	{
 		return cols;
 	}
 
-	virtual std::string ColName(int column)
+	std::string ColName(int column)
 	{
 		if (column < (int)colnames.size())
 		{
@@ -130,7 +130,7 @@ class MsSQLResult : public SQLresult
 		return "";
 	}
 
-	virtual int ColNum(const std::string &column)
+	int ColNum(const std::string &column)
 	{
 		for (unsigned int i = 0; i < colnames.size(); i++)
 		{
@@ -141,7 +141,7 @@ class MsSQLResult : public SQLresult
 		return 0;
 	}
 
-	virtual SQLfield GetValue(int row, int column)
+	SQLfield GetValue(int row, int column)
 	{
 		if ((row >= 0) && (row < rows) && (column >= 0) && (column < Cols()))
 		{
@@ -154,7 +154,7 @@ class MsSQLResult : public SQLresult
 		return SQLfield("",true);
 	}
 
-	virtual SQLfieldList& GetRow()
+	SQLfieldList& GetRow()
 	{
 		if (currentrow < rows)
 			return fieldlists[currentrow];
@@ -162,7 +162,7 @@ class MsSQLResult : public SQLresult
 			return emptyfieldlist;
 	}
 
-	virtual SQLfieldMap& GetRowMap()
+	SQLfieldMap& GetRowMap()
 	{
 		/* In an effort to reduce overhead we don't actually allocate the map
 		 * until the first time it's needed...so...
@@ -188,7 +188,7 @@ class MsSQLResult : public SQLresult
 		return *fieldmap;
 	}
 
-	virtual SQLfieldList* GetRowPtr()
+	SQLfieldList* GetRowPtr()
 	{
 		fieldlist = new SQLfieldList();
 
@@ -203,7 +203,7 @@ class MsSQLResult : public SQLresult
 		return fieldlist;
 	}
 
-	virtual SQLfieldMap* GetRowMapPtr()
+	SQLfieldMap* GetRowMapPtr()
 	{
 		fieldmap = new SQLfieldMap();
 
@@ -219,12 +219,12 @@ class MsSQLResult : public SQLresult
 		return fieldmap;
 	}
 
-	virtual void Free(SQLfieldMap* fm)
+	void Free(SQLfieldMap* fm)
 	{
 		delete fm;
 	}
 
-	virtual void Free(SQLfieldList* fl)
+	void Free(SQLfieldList* fl)
 	{
 		delete fl;
 	}
@@ -653,7 +653,7 @@ class ModuleMsSQL : public Module
 		queryDispatcher = new QueryThread(this);
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ReadConf();
 
@@ -664,7 +664,7 @@ class ModuleMsSQL : public Module
 		ServerInstance->Modules->AddService(sqlserv);
 	}
 
-	virtual ~ModuleMsSQL()
+	~ModuleMsSQL()
 	{
 		queryDispatcher->join();
 		delete queryDispatcher;
@@ -783,14 +783,14 @@ class ModuleMsSQL : public Module
 		connections.clear();
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		queryDispatcher->LockQueue();
 		ReadConf();
 		queryDispatcher->UnlockQueueWakeup();
 	}
 
-	void OnRequest(Request& request)
+	void OnRequest(Request& request) CXX11_OVERRIDE
 	{
 		if(strcmp(SQLREQID, request.id) == 0)
 		{
@@ -821,7 +821,7 @@ class ModuleMsSQL : public Module
 		return ++currid;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("MsSQL provider", VF_VENDOR);
 	}

--- a/src/modules/extra/m_mysql.cpp
+++ b/src/modules/extra/m_mysql.cpp
@@ -107,11 +107,11 @@ class ModuleSQL : public Module
 	ConnMap connections; // main thread only
 
 	ModuleSQL();
-	void init();
+	void init() CXX11_OVERRIDE;
 	~ModuleSQL();
-	void OnRehash(User* user);
-	void OnUnloadModule(Module* mod);
-	Version GetVersion();
+	void OnRehash(User* user) CXX11_OVERRIDE;
+	void OnUnloadModule(Module* mod) CXX11_OVERRIDE;
+	Version GetVersion() CXX11_OVERRIDE;
 };
 
 class DispatcherThread : public SocketThread
@@ -121,8 +121,8 @@ class DispatcherThread : public SocketThread
  public:
 	DispatcherThread(ModuleSQL* CreatorModule) : Parent(CreatorModule) { }
 	~DispatcherThread() { }
-	virtual void Run();
-	virtual void OnNotify();
+	void Run();
+	void OnNotify();
 };
 
 #if !defined(MYSQL_VERSION_ID) || MYSQL_VERSION_ID<32224
@@ -189,17 +189,17 @@ class MySQLresult : public SQLResult
 
 	}
 
-	virtual int Rows()
+	int Rows()
 	{
 		return rows;
 	}
 
-	virtual void GetCols(std::vector<std::string>& result)
+	void GetCols(std::vector<std::string>& result)
 	{
 		result.assign(colnames.begin(), colnames.end());
 	}
 
-	virtual SQLEntry GetValue(int row, int column)
+	SQLEntry GetValue(int row, int column)
 	{
 		if ((row >= 0) && (row < rows) && (column >= 0) && (column < (int)fieldlists[row].size()))
 		{
@@ -208,7 +208,7 @@ class MySQLresult : public SQLResult
 		return SQLEntry();
 	}
 
-	virtual bool GetRow(SQLEntries& result)
+	bool GetRow(SQLEntries& result)
 	{
 		if (currentrow < rows)
 		{

--- a/src/modules/extra/m_pgsql.cpp
+++ b/src/modules/extra/m_pgsql.cpp
@@ -62,7 +62,7 @@ class ReconnectTimer : public Timer
 	ReconnectTimer(ModulePgSQL* m) : Timer(5, ServerInstance->Time(), false), mod(m)
 	{
 	}
-	virtual bool Tick(time_t TIME);
+	bool Tick(time_t TIME);
 };
 
 struct QueueItem
@@ -97,12 +97,12 @@ class PgSQLresult : public SQLResult
 		PQclear(res);
 	}
 
-	virtual int Rows()
+	int Rows()
 	{
 		return rows;
 	}
 
-	virtual void GetCols(std::vector<std::string>& result)
+	void GetCols(std::vector<std::string>& result)
 	{
 		result.resize(PQnfields(res));
 		for(unsigned int i=0; i < result.size(); i++)
@@ -111,7 +111,7 @@ class PgSQLresult : public SQLResult
 		}
 	}
 
-	virtual SQLEntry GetValue(int row, int column)
+	SQLEntry GetValue(int row, int column)
 	{
 		char* v = PQgetvalue(res, row, column);
 		if (!v || PQgetisnull(res, row, column))
@@ -120,7 +120,7 @@ class PgSQLresult : public SQLResult
 		return SQLEntry(std::string(v, PQgetlength(res, row, column)));
 	}
 
-	virtual bool GetRow(SQLEntries& result)
+	bool GetRow(SQLEntries& result)
 	{
 		if (currentrow >= PQntuples(res))
 			return false;
@@ -180,7 +180,7 @@ class SQLConn : public SQLProvider, public EventHandler
 		}
 	}
 
-	virtual void HandleEvent(EventType et, int errornum)
+	void HandleEvent(EventType et, int errornum)
 	{
 		switch (et)
 		{
@@ -509,7 +509,7 @@ class ModulePgSQL : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ReadConf();
 
@@ -517,13 +517,13 @@ class ModulePgSQL : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual ~ModulePgSQL()
+	~ModulePgSQL()
 	{
 		delete retimer;
 		ClearAllConnections();
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ReadConf();
 	}
@@ -564,7 +564,7 @@ class ModulePgSQL : public Module
 		connections.clear();
 	}
 
-	void OnUnloadModule(Module* mod)
+	void OnUnloadModule(Module* mod) CXX11_OVERRIDE
 	{
 		SQLerror err(SQL_BAD_DBID);
 		for(ConnMap::iterator i = connections.begin(); i != connections.end(); i++)
@@ -592,7 +592,7 @@ class ModulePgSQL : public Module
 		}
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("PostgreSQL Service Provider module for all other m_sql* modules, uses v2 of the SQL API", VF_VENDOR);
 	}

--- a/src/modules/extra/m_regex_pcre.cpp
+++ b/src/modules/extra/m_regex_pcre.cpp
@@ -57,12 +57,12 @@ class PCRERegex : public Regex
 		}
 	}
 
-	virtual ~PCRERegex()
+	~PCRERegex()
 	{
 		pcre_free(regex);
 	}
 
-	virtual bool Matches(const std::string& text)
+	bool Matches(const std::string& text)
 	{
 		if (pcre_exec(regex, NULL, text.c_str(), text.length(), 0, 0, NULL, 0) > -1)
 		{
@@ -92,7 +92,7 @@ class ModuleRegexPCRE : public Module
 		ServerInstance->Modules->AddService(ref);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Regex Provider Module for PCRE", VF_VENDOR);
 	}

--- a/src/modules/extra/m_regex_posix.cpp
+++ b/src/modules/extra/m_regex_posix.cpp
@@ -61,12 +61,12 @@ class POSIXRegex : public Regex
 		}
 	}
 
-	virtual ~POSIXRegex()
+	~POSIXRegex()
 	{
 		regfree(&regbuf);
 	}
 
-	virtual bool Matches(const std::string& text)
+	bool Matches(const std::string& text)
 	{
 		if (regexec(&regbuf, text.c_str(), 0, NULL, 0) == 0)
 		{
@@ -101,12 +101,12 @@ class ModuleRegexPOSIX : public Module
 		OnRehash(NULL);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Regex Provider Module for POSIX Regular Expressions", VF_VENDOR);
 	}
 
-	void OnRehash(User* u)
+	void OnRehash(User* u) CXX11_OVERRIDE
 	{
 		ref.extended = ServerInstance->Config->ConfValue("posix")->getBool("extended");
 	}

--- a/src/modules/extra/m_regex_stdlib.cpp
+++ b/src/modules/extra/m_regex_stdlib.cpp
@@ -52,7 +52,7 @@ class StdRegex : public Regex
 		}
 	}
 
-	virtual bool Matches(const std::string& text)
+	bool Matches(const std::string& text)
 	{
 		return std::regex_search(text, regexcl);
 	}
@@ -81,12 +81,12 @@ public:
 		OnRehash(NULL);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Regex Provider Module for std::regex", VF_VENDOR);
 	}
 
-	void OnRehash(User* u)
+	void OnRehash(User* u) CXX11_OVERRIDE
 	{
 		ConfigTag* Conf = ServerInstance->Config->ConfValue("stdregex");
 		std::string regextype = Conf->getString("type", "ecmascript");

--- a/src/modules/extra/m_regex_tre.cpp
+++ b/src/modules/extra/m_regex_tre.cpp
@@ -63,12 +63,12 @@ public:
 		}
 	}
 
-	virtual ~TRERegex()
+	~TRERegex()
 	{
 		regfree(&regbuf);
 	}
 
-	virtual bool Matches(const std::string& text)
+	bool Matches(const std::string& text)
 	{
 		if (regexec(&regbuf, text.c_str(), 0, NULL, 0) == 0)
 		{
@@ -99,7 +99,7 @@ class ModuleRegexTRE : public Module
 		ServerInstance->Modules->AddService(trf);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Regex Provider Module for TRE Regular Expressions", VF_VENDOR);
 	}

--- a/src/modules/extra/m_sqlite3.cpp
+++ b/src/modules/extra/m_sqlite3.cpp
@@ -48,12 +48,12 @@ class SQLite3Result : public SQLResult
 	{
 	}
 
-	virtual int Rows()
+	int Rows()
 	{
 		return rows;
 	}
 
-	virtual bool GetRow(SQLEntries& result)
+	bool GetRow(SQLEntries& result)
 	{
 		if (currentrow < rows)
 		{
@@ -68,7 +68,7 @@ class SQLite3Result : public SQLResult
 		}
 	}
 
-	virtual void GetCols(std::vector<std::string>& result)
+	void GetCols(std::vector<std::string>& result)
 	{
 		result.assign(columns.begin(), columns.end());
 	}
@@ -144,13 +144,13 @@ class SQLConn : public SQLProvider
 		sqlite3_finalize(stmt);
 	}
 
-	virtual void submit(SQLQuery* query, const std::string& q)
+	void submit(SQLQuery* query, const std::string& q)
 	{
 		Query(query, q);
 		delete query;
 	}
 
-	virtual void submit(SQLQuery* query, const std::string& q, const ParamL& p)
+	void submit(SQLQuery* query, const std::string& q, const ParamL& p)
 	{
 		std::string res;
 		unsigned int param = 0;
@@ -171,7 +171,7 @@ class SQLConn : public SQLProvider
 		submit(query, res);
 	}
 
-	virtual void submit(SQLQuery* query, const std::string& q, const ParamM& p)
+	void submit(SQLQuery* query, const std::string& q, const ParamM& p)
 	{
 		std::string res;
 		for(std::string::size_type i = 0; i < q.length(); i++)
@@ -204,7 +204,7 @@ class ModuleSQLite3 : public Module
 	ConnMap conns;
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ReadConf();
 
@@ -212,7 +212,7 @@ class ModuleSQLite3 : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual ~ModuleSQLite3()
+	~ModuleSQLite3()
 	{
 		ClearConns();
 	}
@@ -242,12 +242,12 @@ class ModuleSQLite3 : public Module
 		}
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ReadConf();
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("sqlite3 provider", VF_VENDOR);
 	}

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -233,7 +233,7 @@ class ModuleSSLGnuTLS : public Module
 		dh_alloc = false;
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		// Needs the flag as it ignores a plain /rehash
 		OnModuleRehash(NULL,"ssl");
@@ -250,7 +250,7 @@ class ModuleSSLGnuTLS : public Module
 		ServerInstance->Modules->AddService(starttls);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		sslports.clear();
 
@@ -290,7 +290,7 @@ class ModuleSSLGnuTLS : public Module
 		}
 	}
 
-	void OnModuleRehash(User* user, const std::string &param)
+	void OnModuleRehash(User* user, const std::string &param) CXX11_OVERRIDE
 	{
 		if(param != "ssl")
 			return;
@@ -484,7 +484,7 @@ class ModuleSSLGnuTLS : public Module
 		ServerInstance->GenRandom = &ServerInstance->HandleGenRandom;
 	}
 
-	void OnCleanup(int target_type, void* item)
+	void OnCleanup(int target_type, void* item) CXX11_OVERRIDE
 	{
 		if(target_type == TYPE_USER)
 		{
@@ -499,12 +499,12 @@ class ModuleSSLGnuTLS : public Module
 		}
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides SSL support for clients", VF_VENDOR);
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		if (!sslports.empty())
 			tokens["SSL"] = sslports;
@@ -512,7 +512,7 @@ class ModuleSSLGnuTLS : public Module
 			tokens["STARTTLS"];
 	}
 
-	void OnHookIO(StreamSocket* user, ListenSocket* lsb)
+	void OnHookIO(StreamSocket* user, ListenSocket* lsb) CXX11_OVERRIDE
 	{
 		if (!user->GetIOHook() && lsb->bind_tag->getString("ssl") == "gnutls")
 		{
@@ -521,7 +521,7 @@ class ModuleSSLGnuTLS : public Module
 		}
 	}
 
-	void OnRequest(Request& request)
+	void OnRequest(Request& request) CXX11_OVERRIDE
 	{
 		if (strcmp("GET_SSL_CERT", request.id) == 0)
 		{
@@ -554,7 +554,7 @@ class ModuleSSLGnuTLS : public Module
 		Handshake(session, user);
 	}
 
-	void OnStreamSocketAccept(StreamSocket* user, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server)
+	void OnStreamSocketAccept(StreamSocket* user, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server) CXX11_OVERRIDE
 	{
 		issl_session* session = &sessions[user->GetFd()];
 
@@ -565,17 +565,17 @@ class ModuleSSLGnuTLS : public Module
 		InitSession(user, true);
 	}
 
-	void OnStreamSocketConnect(StreamSocket* user)
+	void OnStreamSocketConnect(StreamSocket* user) CXX11_OVERRIDE
 	{
 		InitSession(user, false);
 	}
 
-	void OnStreamSocketClose(StreamSocket* user)
+	void OnStreamSocketClose(StreamSocket* user) CXX11_OVERRIDE
 	{
 		CloseSession(&sessions[user->GetFd()]);
 	}
 
-	int OnStreamSocketRead(StreamSocket* user, std::string& recvq)
+	int OnStreamSocketRead(StreamSocket* user, std::string& recvq) CXX11_OVERRIDE
 	{
 		issl_session* session = &sessions[user->GetFd()];
 
@@ -633,7 +633,7 @@ class ModuleSSLGnuTLS : public Module
 		return 0;
 	}
 
-	int OnStreamSocketWrite(StreamSocket* user, std::string& sendq)
+	int OnStreamSocketWrite(StreamSocket* user, std::string& sendq) CXX11_OVERRIDE
 	{
 		issl_session* session = &sessions[user->GetFd()];
 
@@ -732,7 +732,7 @@ class ModuleSSLGnuTLS : public Module
 		}
 	}
 
-	void OnUserConnect(LocalUser* user)
+	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
 	{
 		if (user->eh.GetIOHook() == this)
 		{
@@ -860,7 +860,7 @@ info_done_dealloc:
 		gnutls_x509_crt_deinit(cert);
 	}
 
-	void OnEvent(Event& ev)
+	void OnEvent(Event& ev) CXX11_OVERRIDE
 	{
 		if (starttls.enabled)
 			capHandler.HandleEvent(ev);

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -134,7 +134,7 @@ class ModuleSSLOpenSSL : public Module
 		SSL_CTX_set_verify(clictx, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, OnVerify);
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		// Needs the flag as it ignores a plain /rehash
 		OnModuleRehash(NULL,"ssl");
@@ -143,7 +143,7 @@ class ModuleSSLOpenSSL : public Module
 		ServerInstance->Modules->AddService(iohook);
 	}
 
-	void OnHookIO(StreamSocket* user, ListenSocket* lsb)
+	void OnHookIO(StreamSocket* user, ListenSocket* lsb) CXX11_OVERRIDE
 	{
 		if (!user->GetIOHook() && lsb->bind_tag->getString("ssl") == "openssl")
 		{
@@ -152,7 +152,7 @@ class ModuleSSLOpenSSL : public Module
 		}
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		sslports.clear();
 
@@ -191,7 +191,7 @@ class ModuleSSLOpenSSL : public Module
 		}
 	}
 
-	void OnModuleRehash(User* user, const std::string &param)
+	void OnModuleRehash(User* user, const std::string &param) CXX11_OVERRIDE
 	{
 		if (param != "ssl")
 			return;
@@ -267,7 +267,7 @@ class ModuleSSLOpenSSL : public Module
 		fclose(dhpfile);
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		if (!sslports.empty())
 			tokens["SSL"] = sslports;
@@ -280,7 +280,7 @@ class ModuleSSLOpenSSL : public Module
 		delete[] sessions;
 	}
 
-	void OnUserConnect(LocalUser* user)
+	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
 	{
 		if (user->eh.GetIOHook() == this)
 		{
@@ -295,7 +295,7 @@ class ModuleSSLOpenSSL : public Module
 		}
 	}
 
-	void OnCleanup(int target_type, void* item)
+	void OnCleanup(int target_type, void* item) CXX11_OVERRIDE
 	{
 		if (target_type == TYPE_USER)
 		{
@@ -310,12 +310,12 @@ class ModuleSSLOpenSSL : public Module
 		}
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides SSL support for clients", VF_VENDOR);
 	}
 
-	void OnRequest(Request& request)
+	void OnRequest(Request& request) CXX11_OVERRIDE
 	{
 		if (strcmp("GET_SSL_CERT", request.id) == 0)
 		{
@@ -327,7 +327,7 @@ class ModuleSSLOpenSSL : public Module
 		}
 	}
 
-	void OnStreamSocketAccept(StreamSocket* user, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server)
+	void OnStreamSocketAccept(StreamSocket* user, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server) CXX11_OVERRIDE
 	{
 		int fd = user->GetFd();
 
@@ -350,7 +350,7 @@ class ModuleSSLOpenSSL : public Module
  		Handshake(user, session);
 	}
 
-	void OnStreamSocketConnect(StreamSocket* user)
+	void OnStreamSocketConnect(StreamSocket* user) CXX11_OVERRIDE
 	{
 		int fd = user->GetFd();
 		/* Are there any possibilities of an out of range fd? Hope not, but lets be paranoid */
@@ -375,7 +375,7 @@ class ModuleSSLOpenSSL : public Module
 		Handshake(user, session);
 	}
 
-	void OnStreamSocketClose(StreamSocket* user)
+	void OnStreamSocketClose(StreamSocket* user) CXX11_OVERRIDE
 	{
 		int fd = user->GetFd();
 		/* Are there any possibilities of an out of range fd? Hope not, but lets be paranoid */
@@ -385,7 +385,7 @@ class ModuleSSLOpenSSL : public Module
 		CloseSession(&sessions[fd]);
 	}
 
-	int OnStreamSocketRead(StreamSocket* user, std::string& recvq)
+	int OnStreamSocketRead(StreamSocket* user, std::string& recvq) CXX11_OVERRIDE
 	{
 		int fd = user->GetFd();
 		/* Are there any possibilities of an out of range fd? Hope not, but lets be paranoid */
@@ -459,7 +459,7 @@ class ModuleSSLOpenSSL : public Module
 		return 0;
 	}
 
-	int OnStreamSocketWrite(StreamSocket* user, std::string& buffer)
+	int OnStreamSocketWrite(StreamSocket* user, std::string& buffer) CXX11_OVERRIDE
 	{
 		int fd = user->GetFd();
 

--- a/src/modules/m_abbreviation.cpp
+++ b/src/modules/m_abbreviation.cpp
@@ -24,7 +24,7 @@
 class ModuleAbbreviation : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->Attach(I_OnPreCommand, this);
 	}
@@ -34,12 +34,12 @@ class ModuleAbbreviation : public Module
 		ServerInstance->Modules->SetPriority(this, I_OnPreCommand, PRIORITY_FIRST);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the ability to abbreviate commands a-la BBC BASIC keywords.",VF_VENDOR);
 	}
 
-	virtual ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		/* Command is already validated, has a length of 0, or last character is not a . */
 		if (validated || command.empty() || *command.rbegin() != '.')

--- a/src/modules/m_alias.cpp
+++ b/src/modules/m_alias.cpp
@@ -70,7 +70,7 @@ class ModuleAlias : public Module
 	/* whether or not +B users are allowed to use fantasy commands */
 	bool AllowBots;
 
-	virtual void ReadAliases()
+	void ReadAliases()
 	{
 		ConfigTag* fantasy = ServerInstance->Config->ConfValue("fantasy");
 		AllowBots = fantasy->getBool("allowbots", false);
@@ -98,14 +98,14 @@ class ModuleAlias : public Module
 	}
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ReadAliases();
 		Implementation eventlist[] = { I_OnPreCommand, I_OnRehash, I_OnUserMessage };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides aliases of commands.", VF_VENDOR);
 	}
@@ -135,7 +135,7 @@ class ModuleAlias : public Module
 		return word;
 	}
 
-	virtual ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		std::multimap<irc::string, Alias>::iterator i, upperbound;
 
@@ -175,7 +175,7 @@ class ModuleAlias : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void OnUserMessage(User *user, void *dest, int target_type, const std::string &text, char status, const CUList &exempt_list)
+	void OnUserMessage(User *user, void *dest, int target_type, const std::string &text, char status, const CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (target_type != TYPE_CHANNEL)
 		{
@@ -367,12 +367,12 @@ class ModuleAlias : public Module
 		ServerInstance->Parser->CallHandler(command, pars, user);
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ReadAliases();
  	}
 
-	virtual void Prioritize()
+	void Prioritize()
 	{
 		// Prioritise after spanningtree so that channel aliases show the alias before the effects.
 		Module* linkmod = ServerInstance->Modules->Find("m_spanningtree.so");

--- a/src/modules/m_allowinvite.cpp
+++ b/src/modules/m_allowinvite.cpp
@@ -36,19 +36,19 @@ class ModuleAllowInvite : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(ni);
 		Implementation eventlist[] = { I_OnUserPreInvite, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('A');
 	}
 
-	virtual ModResult OnUserPreInvite(User* user,User* dest,Channel* channel, time_t timeout)
+	ModResult OnUserPreInvite(User* user,User* dest,Channel* channel, time_t timeout) CXX11_OVERRIDE
 	{
 		if (IS_LOCAL(user))
 		{
@@ -69,7 +69,7 @@ class ModuleAllowInvite : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for channel mode +A, allowing /invite freely on a channel and extban A to deny specific users it",VF_VENDOR);
 	}

--- a/src/modules/m_alltime.cpp
+++ b/src/modules/m_alltime.cpp
@@ -61,12 +61,12 @@ class Modulealltime : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(mycommand);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Display timestamps from all servers connected to the network", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_auditorium.cpp
+++ b/src/modules/m_auditorium.cpp
@@ -53,7 +53,7 @@ class ModuleAuditorium : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(aum);
 
@@ -66,7 +66,7 @@ class ModuleAuditorium : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("auditorium");
 		OpsVisible = tag->getBool("opvisible");
@@ -74,7 +74,7 @@ class ModuleAuditorium : public Module
 		OperCanSee = tag->getBool("opercansee", true);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows for auditorium channels (+u) where nobody can see others joining and parting or the nick list", VF_VENDOR);
 	}
@@ -108,7 +108,7 @@ class ModuleAuditorium : public Module
 		return false;
 	}
 
-	void OnNamesListItem(User* issuer, Membership* memb, std::string &prefixes, std::string &nick)
+	void OnNamesListItem(User* issuer, Membership* memb, std::string &prefixes, std::string &nick) CXX11_OVERRIDE
 	{
 		// Some module already hid this from being displayed, don't bother
 		if (nick.empty())
@@ -137,22 +137,22 @@ class ModuleAuditorium : public Module
 		}
 	}
 
-	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& excepts)
+	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& excepts) CXX11_OVERRIDE
 	{
 		BuildExcept(memb, excepts);
 	}
 
-	void OnUserPart(Membership* memb, std::string &partmessage, CUList& excepts)
+	void OnUserPart(Membership* memb, std::string &partmessage, CUList& excepts) CXX11_OVERRIDE
 	{
 		BuildExcept(memb, excepts);
 	}
 
-	void OnUserKick(User* source, Membership* memb, const std::string &reason, CUList& excepts)
+	void OnUserKick(User* source, Membership* memb, const std::string &reason, CUList& excepts) CXX11_OVERRIDE
 	{
 		BuildExcept(memb, excepts);
 	}
 
-	void OnBuildNeighborList(User* source, UserChanList &include, std::map<User*,bool> &exception)
+	void OnBuildNeighborList(User* source, UserChanList &include, std::map<User*,bool> &exception) CXX11_OVERRIDE
 	{
 		UCListIter i = include.begin();
 		while (i != include.end())
@@ -173,7 +173,7 @@ class ModuleAuditorium : public Module
 		}
 	}
 
-	void OnSendWhoLine(User* source, const std::vector<std::string>& params, User* user, std::string& line)
+	void OnSendWhoLine(User* source, const std::vector<std::string>& params, User* user, std::string& line) CXX11_OVERRIDE
 	{
 		Channel* channel = ServerInstance->FindChan(params[0]);
 		if (!channel)

--- a/src/modules/m_autoop.cpp
+++ b/src/modules/m_autoop.cpp
@@ -87,7 +87,7 @@ class ModuleAutoOp : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(mh);
 		mh.DoImplements(this);
@@ -96,7 +96,7 @@ class ModuleAutoOp : public Module
 		ServerInstance->Modules->Attach(list, this, sizeof(list)/sizeof(Implementation));
 	}
 
-	void OnPostJoin(Membership *memb)
+	void OnPostJoin(Membership *memb) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(memb->user))
 			return;
@@ -127,17 +127,17 @@ class ModuleAutoOp : public Module
 		}
 	}
 
-	void OnSyncChannel(Channel* chan, Module* proto, void* opaque)
+	void OnSyncChannel(Channel* chan, Module* proto, void* opaque) CXX11_OVERRIDE
 	{
 		mh.DoSyncChannel(chan, proto, opaque);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		mh.DoRehash();
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the +w channel mode", VF_VENDOR);
 	}

--- a/src/modules/m_banexception.cpp
+++ b/src/modules/m_banexception.cpp
@@ -53,7 +53,7 @@ class ModuleBanException : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(be);
 
@@ -62,12 +62,12 @@ class ModuleBanException : public Module
 		ServerInstance->Modules->Attach(list, this, sizeof(list)/sizeof(Implementation));
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXCEPTS"] = "e";
 	}
 
-	ModResult OnExtBanCheck(User *user, Channel *chan, char type)
+	ModResult OnExtBanCheck(User *user, Channel *chan, char type) CXX11_OVERRIDE
 	{
 		if (chan != NULL)
 		{
@@ -92,7 +92,7 @@ class ModuleBanException : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnCheckChannelBan(User* user, Channel* chan)
+	ModResult OnCheckChannelBan(User* user, Channel* chan) CXX11_OVERRIDE
 	{
 		if (chan)
 		{
@@ -116,17 +116,17 @@ class ModuleBanException : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnSyncChannel(Channel* chan, Module* proto, void* opaque)
+	void OnSyncChannel(Channel* chan, Module* proto, void* opaque) CXX11_OVERRIDE
 	{
 		be.DoSyncChannel(chan, proto, opaque);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		be.DoRehash();
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the +e channel mode", VF_VENDOR);
 	}

--- a/src/modules/m_banredirect.cpp
+++ b/src/modules/m_banredirect.cpp
@@ -226,7 +226,7 @@ class ModuleBanRedirect : public Module
 	}
 
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		if(!ServerInstance->Modes->AddModeWatcher(&re))
 			throw ModuleException("Could not add mode watcher");
@@ -236,7 +236,7 @@ class ModuleBanRedirect : public Module
 		ServerInstance->Modules->Attach(list, this, sizeof(list)/sizeof(Implementation));
 	}
 
-	virtual void OnCleanup(int target_type, void* item)
+	void OnCleanup(int target_type, void* item) CXX11_OVERRIDE
 	{
 		if(target_type == TYPE_CHANNEL)
 		{
@@ -271,7 +271,7 @@ class ModuleBanRedirect : public Module
 		}
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		if (chan)
 		{
@@ -338,14 +338,14 @@ class ModuleBanRedirect : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ~ModuleBanRedirect()
+	~ModuleBanRedirect()
 	{
 		/* XXX is this the best place to do this? */
 		if (!ServerInstance->Modes->DelModeWatcher(&re))
 			ServerInstance->Logs->Log("m_banredirect.so", LOG_DEBUG, "Failed to delete modewatcher!");
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows an extended ban (+b) syntax redirecting banned users to another channel", VF_COMMON|VF_VENDOR);
 	}

--- a/src/modules/m_blockamsg.cpp
+++ b/src/modules/m_blockamsg.cpp
@@ -59,7 +59,7 @@ class ModuleBlockAmsg : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		this->OnRehash(NULL);
 		ServerInstance->Modules->AddService(blockamsg);
@@ -67,12 +67,12 @@ class ModuleBlockAmsg : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Attempt to block /amsg, at least some of the irritating mIRC scripts.",VF_VENDOR);
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("blockamsg");
 		ForgetDelay = tag->getInt("delay", -1);
@@ -90,7 +90,7 @@ class ModuleBlockAmsg : public Module
 			action = IBLOCK_KILLOPERS;
 	}
 
-	virtual ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		// Don't do anything with unregistered users
 		if (user->registered != REG_ALL)

--- a/src/modules/m_blockcaps.cpp
+++ b/src/modules/m_blockcaps.cpp
@@ -45,7 +45,7 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		ServerInstance->Modules->AddService(bc);
@@ -53,17 +53,17 @@ public:
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('B');
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ReadConf();
 	}
 
-	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (target_type == TYPE_CHANNEL)
 		{
@@ -105,7 +105,7 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return OnUserPreMessage(user,dest,target_type,text,status,exempt_list);
 	}
@@ -131,7 +131,7 @@ public:
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support to block all-CAPS channel messages and notices", VF_VENDOR);
 	}

--- a/src/modules/m_blockcolor.cpp
+++ b/src/modules/m_blockcolor.cpp
@@ -42,19 +42,19 @@ class ModuleBlockColor : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(bc);
 		Implementation eventlist[] = { I_OnUserPreMessage, I_OnUserPreNotice, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('c');
 	}
 
-	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if ((target_type == TYPE_CHANNEL) && (IS_LOCAL(user)))
 		{
@@ -86,12 +86,12 @@ class ModuleBlockColor : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return OnUserPreMessage(user,dest,target_type,text,status,exempt_list);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel mode +c to block color",VF_VENDOR);
 	}

--- a/src/modules/m_botmode.cpp
+++ b/src/modules/m_botmode.cpp
@@ -40,19 +40,19 @@ class ModuleBotMode : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(bm);
 		Implementation eventlist[] = { I_OnWhois };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides user mode +B to mark the user as a bot",VF_VENDOR);
 	}
 
-	virtual void OnWhois(User* src, User* dst)
+	void OnWhois(User* src, User* dst) CXX11_OVERRIDE
 	{
 		if (dst->IsModeSet('B'))
 		{

--- a/src/modules/m_callerid.cpp
+++ b/src/modules/m_callerid.cpp
@@ -150,7 +150,7 @@ public:
 		TRANSLATE2(TR_CUSTOM, TR_END);
 	}
 
-	virtual void EncodeParameter(std::string& parameter, int index)
+	void EncodeParameter(std::string& parameter, int index)
 	{
 		if (index != 0)
 			return;
@@ -344,7 +344,7 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 
@@ -356,12 +356,12 @@ public:
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implementation of callerid, usermode +g, /accept", VF_COMMON | VF_VENDOR);
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["CALLERID"] = "g";
 	}
@@ -394,7 +394,7 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreMessage(User* user, void* dest, int target_type, std::string& text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user, void* dest, int target_type, std::string& text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (IS_LOCAL(user) && target_type == TYPE_USER)
 			return PreText(user, (User*)dest, text);
@@ -402,7 +402,7 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreNotice(User* user, void* dest, int target_type, std::string& text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user, void* dest, int target_type, std::string& text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (IS_LOCAL(user) && target_type == TYPE_USER)
 			return PreText(user, (User*)dest, text);
@@ -410,18 +410,18 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnUserPostNick(User* user, const std::string& oldnick)
+	void OnUserPostNick(User* user, const std::string& oldnick) CXX11_OVERRIDE
 	{
 		if (!tracknick)
 			RemoveFromAllAccepts(user);
 	}
 
-	void OnUserQuit(User* user, const std::string& message, const std::string& oper_message)
+	void OnUserQuit(User* user, const std::string& message, const std::string& oper_message) CXX11_OVERRIDE
 	{
 		RemoveFromAllAccepts(user);
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("callerid");
 		cmd.maxaccepts = tag->getInt("maxaccepts", 16);

--- a/src/modules/m_cap.cpp
+++ b/src/modules/m_cap.cpp
@@ -132,7 +132,7 @@ class ModuleCAP : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		ServerInstance->Modules->AddService(cmd.reghold);
@@ -141,7 +141,7 @@ class ModuleCAP : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user) CXX11_OVERRIDE
 	{
 		/* Users in CAP state get held until CAP END */
 		if (cmd.reghold.get(user))
@@ -150,7 +150,7 @@ class ModuleCAP : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Client CAP extension support", VF_VENDOR);
 	}

--- a/src/modules/m_cban.cpp
+++ b/src/modules/m_cban.cpp
@@ -154,7 +154,7 @@ class ModuleCBan : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->XLines->RegisterFactory(&f);
 
@@ -163,13 +163,13 @@ class ModuleCBan : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual ~ModuleCBan()
+	~ModuleCBan()
 	{
 		ServerInstance->XLines->DelAll("CBAN");
 		ServerInstance->XLines->UnregisterFactory(&f);
 	}
 
-	virtual ModResult OnStats(char symbol, User* user, string_list &out)
+	ModResult OnStats(char symbol, User* user, string_list &out) CXX11_OVERRIDE
 	{
 		if (symbol != 'C')
 			return MOD_RES_PASSTHRU;
@@ -178,7 +178,7 @@ class ModuleCBan : public Module
 		return MOD_RES_DENY;
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		XLine *rl = ServerInstance->XLines->MatchesLine("CBAN", cname);
 
@@ -194,7 +194,7 @@ class ModuleCBan : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Gives /cban, aka C:lines. Think Q:lines, for channels.", VF_COMMON | VF_VENDOR);
 	}

--- a/src/modules/m_censor.cpp
+++ b/src/modules/m_censor.cpp
@@ -55,7 +55,7 @@ class ModuleCensor : public Module
  public:
 	ModuleCensor() : cu(this), cc(this) { }
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		/* Read the configuration file on startup.
 		 */
@@ -67,7 +67,7 @@ class ModuleCensor : public Module
 	}
 
 	// format of a config entry is <badword text="shit" replace="poo">
-	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user))
 			return MOD_RES_PASSTHRU;
@@ -107,12 +107,12 @@ class ModuleCensor : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return OnUserPreMessage(user,dest,target_type,text,status,exempt_list);
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		/*
 		 * reload our config file on rehash - we must destroy and re-allocate the classes
@@ -131,7 +131,7 @@ class ModuleCensor : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides user and channel +G mode",VF_VENDOR);
 	}

--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -131,7 +131,7 @@ class CGIResolver : public DNS::Request
 	{
 	}
 
-	void OnLookupComplete(const DNS::Query *r)
+	void OnLookupComplete(const DNS::Query *r) CXX11_OVERRIDE
 	{
 		/* Check the user still exists */
 		User* them = ServerInstance->FindUUID(theiruid);
@@ -154,7 +154,7 @@ class CGIResolver : public DNS::Request
 		}
 	}
 
-	void OnError(const DNS::Query *r)
+	void OnError(const DNS::Query *r) CXX11_OVERRIDE
 	{
 		if (!notify)
 			return;
@@ -166,7 +166,7 @@ class CGIResolver : public DNS::Request
 		}
 	}
 
-	virtual ~CGIResolver()
+	~CGIResolver()
 	{
 		User* them = ServerInstance->FindUUID(theiruid);
 		if (!them)
@@ -236,7 +236,7 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		ServiceProvider* providerlist[] = { &cmd, &cmd.realhost, &cmd.realip, &cmd.webirc_hostname, &cmd.webirc_ip, &waiting };
@@ -246,7 +246,7 @@ public:
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		cmd.Hosts.clear();
 
@@ -295,7 +295,7 @@ public:
 		}
 	}
 
-	ModResult OnCheckReady(LocalUser *user)
+	ModResult OnCheckReady(LocalUser *user) CXX11_OVERRIDE
 	{
 		if (waiting.get(user))
 			return MOD_RES_DENY;
@@ -323,7 +323,7 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnUserRegister(LocalUser* user)
+	ModResult OnUserRegister(LocalUser* user) CXX11_OVERRIDE
 	{
 		for(CGIHostlist::iterator iter = cmd.Hosts.begin(); iter != cmd.Hosts.end(); iter++)
 		{
@@ -420,7 +420,7 @@ public:
 		return true;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Change user's hosts connecting from known CGI:IRC hosts",VF_VENDOR);
 	}

--- a/src/modules/m_chancreate.cpp
+++ b/src/modules/m_chancreate.cpp
@@ -26,19 +26,19 @@
 class ModuleChanCreate : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->SNO->EnableSnomask('j', "CHANCREATE");
 		Implementation eventlist[] = { I_OnUserJoin };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides snomasks 'j' and 'J', to which notices about newly created channels are sent",VF_VENDOR);
 	}
 
-	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& except)
+	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& except) CXX11_OVERRIDE
 	{
 		if ((created) && (IS_LOCAL(memb->user)))
 		{

--- a/src/modules/m_chanfilter.cpp
+++ b/src/modules/m_chanfilter.cpp
@@ -38,7 +38,7 @@ class ChanFilter : public ListModeBase
  public:
 	ChanFilter(Module* Creator) : ListModeBase(Creator, "filter", 'g', "End of channel spamfilter list", 941, 940, false, "chanfilter") { }
 
-	virtual bool ValidateParam(User* user, Channel* chan, std::string &word)
+	bool ValidateParam(User* user, Channel* chan, std::string &word)
 	{
 		if ((word.length() > 35) || (word.empty()))
 		{
@@ -49,17 +49,17 @@ class ChanFilter : public ListModeBase
 		return true;
 	}
 
-	virtual void TellListTooLong(User* user, Channel* chan, std::string &word)
+	void TellListTooLong(User* user, Channel* chan, std::string &word)
 	{
 		user->WriteNumeric(939, "%s %s %s :Channel spamfilter list is full", user->nick.c_str(), chan->name.c_str(), word.c_str());
 	}
 
-	virtual void TellAlreadyOnList(User* user, Channel* chan, std::string &word)
+	void TellAlreadyOnList(User* user, Channel* chan, std::string &word)
 	{
 		user->WriteNumeric(937, "%s %s :The word %s is already on the spamfilter list",user->nick.c_str(), chan->name.c_str(), word.c_str());
 	}
 
-	virtual void TellNotSet(User* user, Channel* chan, std::string &word)
+	void TellNotSet(User* user, Channel* chan, std::string &word)
 	{
 		user->WriteNumeric(938, "%s %s :No such spamfilter word is set",user->nick.c_str(), chan->name.c_str());
 	}
@@ -77,7 +77,7 @@ class ModuleChanFilter : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cf);
 
@@ -88,13 +88,13 @@ class ModuleChanFilter : public Module
 		OnRehash(NULL);
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		hidemask = ServerInstance->Config->ConfValue("chanfilter")->getBool("hidemask");
 		cf.DoRehash();
 	}
 
-	virtual ModResult ProcessMessages(User* user,Channel* chan,std::string &text)
+	ModResult ProcessMessages(User* user,Channel* chan,std::string &text)
 	{
 		ModResult res = ServerInstance->OnCheckExemption(user,chan,"filter");
 
@@ -121,7 +121,7 @@ class ModuleChanFilter : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (target_type == TYPE_CHANNEL)
 		{
@@ -130,17 +130,17 @@ class ModuleChanFilter : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return OnUserPreMessage(user,dest,target_type,text,status,exempt_list);
 	}
 
-	virtual void OnSyncChannel(Channel* chan, Module* proto, void* opaque)
+	void OnSyncChannel(Channel* chan, Module* proto, void* opaque) CXX11_OVERRIDE
 	{
 		cf.DoSyncChannel(chan, proto, opaque);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel-specific censor lists (like mode +G but varies from channel to channel)", VF_VENDOR);
 	}

--- a/src/modules/m_chanhistory.cpp
+++ b/src/modules/m_chanhistory.cpp
@@ -116,7 +116,7 @@ class ModuleChanHistory : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(m);
 		ServerInstance->Modules->AddService(m.ext);
@@ -126,14 +126,14 @@ class ModuleChanHistory : public Module
 		OnRehash(NULL);
 	}
 
-	void OnRehash(User*)
+	void OnRehash(User*) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("chanhistory");
 		m.maxlines = tag->getInt("maxlines", 50);
 		sendnotice = tag->getBool("notice", true);
 	}
 
-	void OnUserMessage(User* user, void* dest, int target_type, const std::string &text, char status, const CUList&)
+	void OnUserMessage(User* user, void* dest, int target_type, const std::string &text, char status, const CUList&) CXX11_OVERRIDE
 	{
 		if (target_type == TYPE_CHANNEL && status == 0)
 		{
@@ -149,7 +149,7 @@ class ModuleChanHistory : public Module
 		}
 	}
 
-	void OnPostJoin(Membership* memb)
+	void OnPostJoin(Membership* memb) CXX11_OVERRIDE
 	{
 		if (IS_REMOTE(memb->user))
 			return;
@@ -173,7 +173,7 @@ class ModuleChanHistory : public Module
 		}
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel history replayed on join", VF_VENDOR);
 	}

--- a/src/modules/m_chanlog.cpp
+++ b/src/modules/m_chanlog.cpp
@@ -31,7 +31,7 @@ class ModuleChanLog : public Module
 	ChanLogTargets logstreams;
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnRehash, I_OnSendSnotice };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
@@ -39,7 +39,7 @@ class ModuleChanLog : public Module
 		OnRehash(NULL);
 	}
 
-	virtual void OnRehash(User *user)
+	void OnRehash(User *user) CXX11_OVERRIDE
 	{
 		std::string snomasks;
 		std::string channel;
@@ -67,7 +67,7 @@ class ModuleChanLog : public Module
 
 	}
 
-	virtual ModResult OnSendSnotice(char &sno, std::string &desc, const std::string &msg)
+	ModResult OnSendSnotice(char &sno, std::string &desc, const std::string &msg) CXX11_OVERRIDE
 	{
 		std::pair<ChanLogTargets::const_iterator, ChanLogTargets::const_iterator> itpair = logstreams.equal_range(sno);
 		if (itpair.first == itpair.second)
@@ -88,7 +88,7 @@ class ModuleChanLog : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Logs snomask output to channel(s).", VF_VENDOR);
 	}
@@ -125,7 +125,7 @@ class ChannelLogStream : public LogStream
 	{
 	}
 
-	virtual void OnLog(int loglevel, const std::string &type, const std::string &msg)
+	void OnLog(int loglevel, const std::string &type, const std::string &msg)
 	{
 		Channel *c = ServerInstance->FindChan(channel);
 		static bool Logging = false;

--- a/src/modules/m_channames.cpp
+++ b/src/modules/m_channames.cpp
@@ -27,8 +27,8 @@ class NewIsChannelHandler : public HandlerBase2<bool, const std::string&, size_t
 {
  public:
 	NewIsChannelHandler() { }
-	virtual ~NewIsChannelHandler() { }
-	virtual bool Call(const std::string&, size_t);
+	~NewIsChannelHandler() { }
+	bool Call(const std::string&, size_t);
 };
 
 bool NewIsChannelHandler::Call(const std::string& channame, size_t max)
@@ -57,7 +57,7 @@ class ModuleChannelNames : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->IsChannel = &myhandler;
 		Implementation eventlist[] = { I_OnRehash, I_OnUserKick };
@@ -94,7 +94,7 @@ class ModuleChannelNames : public Module
 		badchan = false;
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("channames");
 		std::string denyToken = tag->getString("denyrange");
@@ -118,7 +118,7 @@ class ModuleChannelNames : public Module
 		ValidateChans();
 	}
 
-	virtual void OnUserKick(User* source, Membership* memb, const std::string &reason, CUList& except_list)
+	void OnUserKick(User* source, Membership* memb, const std::string &reason, CUList& except_list) CXX11_OVERRIDE
 	{
 		if (badchan)
 		{
@@ -129,13 +129,13 @@ class ModuleChannelNames : public Module
 		}
 	}
 
-	virtual ~ModuleChannelNames()
+	~ModuleChannelNames()
 	{
 		ServerInstance->IsChannel = rememberer;
 		ValidateChans();
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements config tags which allow changing characters allowed in channel names", VF_VENDOR);
 	}

--- a/src/modules/m_channelban.cpp
+++ b/src/modules/m_channelban.cpp
@@ -25,18 +25,18 @@
 class ModuleBadChannelExtban : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnCheckBan, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Extban 'j' - channel status/join ban", VF_OPTCOMMON|VF_VENDOR);
 	}
 
-	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask)
+	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask) CXX11_OVERRIDE
 	{
 		if ((mask.length() > 2) && (mask[0] == 'j') && (mask[1] == ':'))
 		{
@@ -66,7 +66,7 @@ class ModuleBadChannelExtban : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('j');
 	}

--- a/src/modules/m_check.cpp
+++ b/src/modules/m_check.cpp
@@ -255,7 +255,7 @@ class ModuleCheck : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(mycommand);
 	}
@@ -276,7 +276,7 @@ class ModuleCheck : public Module
 		user->SendText(checkstr);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("CHECK command, view user, channel, IP address or hostname information", VF_VENDOR|VF_OPTCOMMON);
 	}

--- a/src/modules/m_chghost.cpp
+++ b/src/modules/m_chghost.cpp
@@ -96,7 +96,7 @@ class ModuleChgHost : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		ServerInstance->Modules->AddService(cmd);
@@ -104,7 +104,7 @@ class ModuleChgHost : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		std::string hmap = ServerInstance->Config->ConfValue("hostname")->getString("charmap", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.-_/0123456789");
 
@@ -113,7 +113,7 @@ class ModuleChgHost : public Module
 			hostmap[(unsigned char)*n] = 1;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the CHGHOST command", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_chgident.cpp
+++ b/src/modules/m_chgident.cpp
@@ -88,12 +88,12 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the CHGIDENT command", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_chgname.cpp
+++ b/src/modules/m_chgname.cpp
@@ -84,12 +84,12 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the CHGNAME command", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_cloaking.cpp
+++ b/src/modules/m_cloaking.cpp
@@ -148,7 +148,7 @@ class ModuleCloaking : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 
@@ -284,7 +284,7 @@ class ModuleCloaking : public Module
 		return rv;
 	}
 
-	ModResult OnCheckBan(User* user, Channel* chan, const std::string& mask)
+	ModResult OnCheckBan(User* user, Channel* chan, const std::string& mask) CXX11_OVERRIDE
 	{
 		LocalUser* lu = IS_LOCAL(user);
 		if (!lu)
@@ -310,7 +310,7 @@ class ModuleCloaking : public Module
 
 	// this unsets umode +x on every host change. If we are actually doing a +x
 	// mode change, we will call SetMode back to true AFTER the host change is done.
-	void OnChangeHost(User* u, const std::string& host)
+	void OnChangeHost(User* u, const std::string& host) CXX11_OVERRIDE
 	{
 		if(u->IsModeSet('x'))
 		{
@@ -319,7 +319,7 @@ class ModuleCloaking : public Module
 		}
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		std::string testcloak = "broken";
 		if (Hash)
@@ -336,7 +336,7 @@ class ModuleCloaking : public Module
 		return Version("Provides masking of user hostnames", VF_COMMON|VF_VENDOR, testcloak);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("cloak");
 		prefix = tag->getString("prefix");
@@ -376,7 +376,7 @@ class ModuleCloaking : public Module
 		return chost;
 	}
 
-	void OnUserConnect(LocalUser* dest)
+	void OnUserConnect(LocalUser* dest) CXX11_OVERRIDE
 	{
 		std::string* cloak = cu.ext.get(dest);
 		if (cloak)

--- a/src/modules/m_clones.cpp
+++ b/src/modules/m_clones.cpp
@@ -71,12 +71,12 @@ class ModuleClones : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the /CLONES command to retrieve information on clones.", VF_VENDOR);
 	}

--- a/src/modules/m_close.cpp
+++ b/src/modules/m_close.cpp
@@ -72,12 +72,12 @@ class ModuleClose : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides /CLOSE functionality", VF_VENDOR);
 	}

--- a/src/modules/m_commonchans.cpp
+++ b/src/modules/m_commonchans.cpp
@@ -37,19 +37,19 @@ class ModulePrivacyMode : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(pm);
 		Implementation eventlist[] = { I_OnUserPreMessage, I_OnUserPreNotice };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Adds user mode +c, which if set, users must be on a common channel with you to private message you", VF_VENDOR);
 	}
 
-	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (target_type == TYPE_USER)
 		{
@@ -63,7 +63,7 @@ class ModulePrivacyMode : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return OnUserPreMessage(user, dest, target_type, text, status, exempt_list);
 	}

--- a/src/modules/m_conn_join.cpp
+++ b/src/modules/m_conn_join.cpp
@@ -27,7 +27,7 @@
 class ModuleConnJoin : public Module
 {
 	public:
-		void init()
+		void init() CXX11_OVERRIDE
 		{
 			Implementation eventlist[] = { I_OnPostConnect };
 			ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
@@ -38,12 +38,12 @@ class ModuleConnJoin : public Module
 			ServerInstance->Modules->SetPriority(this, I_OnPostConnect, PRIORITY_LAST);
 		}
 
-		Version GetVersion()
+		Version GetVersion() CXX11_OVERRIDE
 		{
 			return Version("Forces users to join the specified channel(s) on connect", VF_VENDOR);
 		}
 
-		void OnPostConnect(User* user)
+		void OnPostConnect(User* user) CXX11_OVERRIDE
 		{
 			LocalUser* localuser = IS_LOCAL(user);
 			if (!localuser)

--- a/src/modules/m_conn_umodes.cpp
+++ b/src/modules/m_conn_umodes.cpp
@@ -27,7 +27,7 @@
 class ModuleModesOnConnect : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->Attach(I_OnUserConnect, this);
 	}
@@ -38,12 +38,12 @@ class ModuleModesOnConnect : public Module
 		ServerInstance->Modules->SetPriority(this, I_OnUserConnect, PRIORITY_FIRST);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Sets (and unsets) modes on users when they connect", VF_VENDOR);
 	}
 
-	virtual void OnUserConnect(LocalUser* user)
+	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
 	{
 		// Backup and zero out the disabled usermodes, so that we can override them here.
 		char save[64];

--- a/src/modules/m_conn_waitpong.cpp
+++ b/src/modules/m_conn_waitpong.cpp
@@ -38,7 +38,7 @@ class ModuleWaitPong : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(ext);
 		OnRehash(NULL);
@@ -46,14 +46,14 @@ class ModuleWaitPong : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("waitpong");
 		sendsnotice = tag->getBool("sendsnotice", true);
 		killonbadreply = tag->getBool("killonbadreply", true);
 	}
 
-	ModResult OnUserRegister(LocalUser* user)
+	ModResult OnUserRegister(LocalUser* user) CXX11_OVERRIDE
 	{
 		std::string pingrpl = ServerInstance->GenRandomStr(10);
 
@@ -66,7 +66,7 @@ class ModuleWaitPong : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser* user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser* user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		if (command == "PONG")
 		{
@@ -90,12 +90,12 @@ class ModuleWaitPong : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user) CXX11_OVERRIDE
 	{
 		return ext.get(user) ? MOD_RES_DENY : MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Require pong prior to registration", VF_VENDOR);
 	}

--- a/src/modules/m_connectban.cpp
+++ b/src/modules/m_connectban.cpp
@@ -31,19 +31,19 @@ class ModuleConnectBan : public Module
 	unsigned int ipv6_cidr;
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnSetUserIP, I_OnGarbageCollect, I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 		OnRehash(NULL);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Throttles the connections of IP ranges who try to connect flood.", VF_VENDOR);
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("connectban");
 
@@ -64,7 +64,7 @@ class ModuleConnectBan : public Module
 			banduration = 10*60;
 	}
 
-	virtual void OnSetUserIP(LocalUser* u)
+	void OnSetUserIP(LocalUser* u) CXX11_OVERRIDE
 	{
 		if (u->exempt)
 			return;
@@ -112,7 +112,7 @@ class ModuleConnectBan : public Module
 		}
 	}
 
-	virtual void OnGarbageCollect()
+	void OnGarbageCollect()
 	{
 		ServerInstance->Logs->Log("m_connectban",LOG_DEBUG, "Clearing map.");
 		connects.clear();

--- a/src/modules/m_connflood.cpp
+++ b/src/modules/m_connflood.cpp
@@ -38,14 +38,14 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		InitConf();
 		Implementation eventlist[] = { I_OnRehash, I_OnUserRegister };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Connection throttle", VF_VENDOR);
 	}
@@ -66,7 +66,7 @@ public:
 		first = ServerInstance->Time();
 	}
 
-	virtual ModResult OnUserRegister(LocalUser* user)
+	ModResult OnUserRegister(LocalUser* user) CXX11_OVERRIDE
 	{
 		if (user->exempt)
 			return MOD_RES_PASSTHRU;
@@ -114,7 +114,7 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		InitConf();
 	}

--- a/src/modules/m_customprefix.cpp
+++ b/src/modules/m_customprefix.cpp
@@ -97,7 +97,7 @@ class ModuleCustomPrefix : public Module
 {
 	std::vector<CustomPrefixMode*> modes;
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ConfigTagList tags = ServerInstance->Config->ConfTags("customprefix");
 		while (tags.first != tags.second)
@@ -127,7 +127,7 @@ class ModuleCustomPrefix : public Module
 			delete *i;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides custom prefix channel modes", VF_VENDOR);
 	}

--- a/src/modules/m_customtitle.cpp
+++ b/src/modules/m_customtitle.cpp
@@ -81,7 +81,7 @@ class ModuleCustomTitle : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		ServerInstance->Modules->AddService(cmd.ctitle);
@@ -89,7 +89,7 @@ class ModuleCustomTitle : public Module
 	}
 
 	// :kenny.chatspike.net 320 Brain Azhrarn :is getting paid to play games.
-	ModResult OnWhoisLine(User* user, User* dest, int &numeric, std::string &text)
+	ModResult OnWhoisLine(User* user, User* dest, int &numeric, std::string &text) CXX11_OVERRIDE
 	{
 		/* We use this and not OnWhois because this triggers for remote, too */
 		if (numeric == 312)
@@ -105,7 +105,7 @@ class ModuleCustomTitle : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Custom Title for users", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_cycle.cpp
+++ b/src/modules/m_cycle.cpp
@@ -91,12 +91,12 @@ class ModuleCycle : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides command CYCLE, acts as a server-side HOP command to part and rejoin a channel.", VF_VENDOR);
 	}

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -255,7 +255,7 @@ class ModuleDCCAllow : public Module
 		ext = NULL;
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ext = new SimpleExtItem<dccallowlist>("dccallow", this);
 		ServerInstance->Modules->AddService(*ext);
@@ -265,12 +265,12 @@ class ModuleDCCAllow : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ReadFileConf();
 	}
 
-	virtual void OnUserQuit(User* user, const std::string &reason, const std::string &oper_message)
+	void OnUserQuit(User* user, const std::string &reason, const std::string &oper_message) CXX11_OVERRIDE
 	{
 		dccallowlist* udl = ext->get(user);
 
@@ -287,17 +287,17 @@ class ModuleDCCAllow : public Module
 		RemoveNick(user);
 	}
 
-	virtual void OnUserPostNick(User* user, const std::string &oldnick)
+	void OnUserPostNick(User* user, const std::string &oldnick) CXX11_OVERRIDE
 	{
 		RemoveNick(user);
 	}
 
-	virtual ModResult OnUserPreMessage(User* user, void* dest, int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user, void* dest, int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
-		return OnUserPreNotice(user, dest, target_type, text, status, exempt_list);
+		return OnUserPreMessage(user, dest, target_type, text, status, exempt_list);
 	}
 
-	virtual ModResult OnUserPreNotice(User* user, void* dest, int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user, void* dest, int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user))
 			return MOD_RES_PASSTHRU;
@@ -475,12 +475,12 @@ class ModuleDCCAllow : public Module
 		}
 	}
 
-	virtual ~ModuleDCCAllow()
+	~ModuleDCCAllow()
 	{
 		delete ext;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the /DCCALLOW command", VF_COMMON | VF_VENDOR);
 	}

--- a/src/modules/m_deaf.cpp
+++ b/src/modules/m_deaf.cpp
@@ -65,7 +65,7 @@ class ModuleDeaf : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(m1);
 
@@ -74,14 +74,14 @@ class ModuleDeaf : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("deaf");
 		deaf_bypasschars = tag->getString("bypasschars");
 		deaf_bypasschars_uline = tag->getString("bypasscharsuline");
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (target_type == TYPE_CHANNEL)
 		{
@@ -93,7 +93,7 @@ class ModuleDeaf : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (target_type == TYPE_CHANNEL)
 		{
@@ -105,7 +105,7 @@ class ModuleDeaf : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void BuildDeafList(MessageType message_type, Channel* chan, User* sender, char status, const std::string &text, CUList &exempt_list)
+	void BuildDeafList(MessageType message_type, Channel* chan, User* sender, char status, const std::string &text, CUList &exempt_list)
 	{
 		const UserMembList *ulist = chan->GetUsers();
 		bool is_a_uline;
@@ -158,7 +158,7 @@ class ModuleDeaf : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides usermode +d to block channel messages and channel notices", VF_VENDOR);
 	}

--- a/src/modules/m_delayjoin.cpp
+++ b/src/modules/m_delayjoin.cpp
@@ -46,22 +46,22 @@ class ModuleDelayJoin : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(djm);
 		ServerInstance->Modules->AddService(unjoined);
 		Implementation eventlist[] = { I_OnUserJoin, I_OnUserPart, I_OnUserKick, I_OnBuildNeighborList, I_OnNamesListItem, I_OnText, I_OnRawMode };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
-	Version GetVersion();
-	void OnNamesListItem(User* issuer, Membership*, std::string &prefixes, std::string &nick);
-	void OnUserJoin(Membership*, bool, bool, CUList&);
+	Version GetVersion() CXX11_OVERRIDE;
+	void OnNamesListItem(User* issuer, Membership*, std::string &prefixes, std::string &nick) CXX11_OVERRIDE;
+	void OnUserJoin(Membership*, bool, bool, CUList&) CXX11_OVERRIDE;
 	void CleanUser(User* user);
-	void OnUserPart(Membership*, std::string &partmessage, CUList&);
-	void OnUserKick(User* source, Membership*, const std::string &reason, CUList&);
-	void OnBuildNeighborList(User* source, UserChanList &include, std::map<User*,bool> &exception);
-	void OnText(User* user, void* dest, int target_type, const std::string &text, char status, CUList &exempt_list);
-	ModResult OnRawMode(User* user, Channel* channel, const char mode, const std::string &param, bool adding, int pcnt);
+	void OnUserPart(Membership*, std::string &partmessage, CUList&) CXX11_OVERRIDE;
+	void OnUserKick(User* source, Membership*, const std::string &reason, CUList&) CXX11_OVERRIDE;
+	void OnBuildNeighborList(User* source, UserChanList &include, std::map<User*,bool> &exception) CXX11_OVERRIDE;
+	void OnText(User* user, void* dest, int target_type, const std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE;
+	ModResult OnRawMode(User* user, Channel* channel, const char mode, const std::string &param, bool adding, int pcnt) CXX11_OVERRIDE;
 };
 
 ModeAction DelayJoinMode::OnModeChange(User* source, User* dest, Channel* channel, std::string &parameter, bool adding)

--- a/src/modules/m_delaymsg.cpp
+++ b/src/modules/m_delaymsg.cpp
@@ -47,16 +47,16 @@ class ModuleDelayMsg : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(djm);
 		ServerInstance->Modules->AddService(djm.jointime);
 		Implementation eventlist[] = { I_OnUserJoin, I_OnUserPreMessage};
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
-	Version GetVersion();
-	void OnUserJoin(Membership* memb, bool sync, bool created, CUList&);
-	ModResult OnUserPreMessage(User* user, void* dest, int target_type, std::string &text, char status, CUList &exempt_list);
+	Version GetVersion() CXX11_OVERRIDE;
+	void OnUserJoin(Membership* memb, bool sync, bool created, CUList&) CXX11_OVERRIDE;
+	ModResult OnUserPreMessage(User* user, void* dest, int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE;
 };
 
 ModeAction DelayMsgMode::OnModeChange(User* source, User* dest, Channel* channel, std::string &parameter, bool adding)

--- a/src/modules/m_denychans.cpp
+++ b/src/modules/m_denychans.cpp
@@ -27,13 +27,13 @@
 class ModuleDenyChannels : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnUserPreJoin, I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		/* check for redirect validity and loops/chains */
 		ConfigTagList tags = ServerInstance->Config->ConfTags("badchan");
@@ -77,13 +77,13 @@ class ModuleDenyChannels : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements config tags which allow blocking of joins to channels", VF_VENDOR);
 	}
 
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		ConfigTagList tags = ServerInstance->Config->ConfTags("badchan");
 		for (ConfigIter j = tags.first; j != tags.second; ++j)

--- a/src/modules/m_devoice.cpp
+++ b/src/modules/m_devoice.cpp
@@ -65,12 +65,12 @@ class ModuleDeVoice : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides voiced users with the ability to devoice themselves.", VF_VENDOR);
 	}

--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -61,7 +61,7 @@ class DNSBLResolver : public DNS::Request
 	}
 
 	/* Note: This may be called multiple times for multiple A record results */
-	void OnLookupComplete(const DNS::Query *r)
+	void OnLookupComplete(const DNS::Query *r) CXX11_OVERRIDE
 	{
 		/* Check the user still exists */
 		LocalUser* them = (LocalUser*)ServerInstance->FindUUID(theiruid);
@@ -188,7 +188,7 @@ class DNSBLResolver : public DNS::Request
 			ConfEntry->stats_misses++;
 	}
 
-	void OnError(const DNS::Query *q)
+	void OnError(const DNS::Query *q) CXX11_OVERRIDE
 	{
 		LocalUser* them = (LocalUser*)ServerInstance->FindUUID(theiruid);
 		if (!them)
@@ -231,7 +231,7 @@ class ModuleDNSBL : public Module
  public:
 	ModuleDNSBL() : DNS(this, "DNS"), nameExt("dnsbl_match", this), countExt("dnsbl_pending", this) { }
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ReadConf();
 		ServerInstance->Modules->AddService(nameExt);
@@ -240,12 +240,12 @@ class ModuleDNSBL : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual ~ModuleDNSBL()
+	~ModuleDNSBL()
 	{
 		ClearEntries();
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides handling of DNS blacklists", VF_VENDOR);
 	}
@@ -342,12 +342,12 @@ class ModuleDNSBL : public Module
 		}
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ReadConf();
 	}
 
-	void OnSetUserIP(LocalUser* user)
+	void OnSetUserIP(LocalUser* user) CXX11_OVERRIDE
 	{
 		if ((user->exempt) || (user->client_sa.sa.sa_family != AF_INET) || !DNS)
 			return;
@@ -393,7 +393,7 @@ class ModuleDNSBL : public Module
 		}
 	}
 
-	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass)
+	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass) CXX11_OVERRIDE
 	{
 		std::string dnsbl;
 		if (!myclass->config->readString("dnsbl", dnsbl))
@@ -405,14 +405,14 @@ class ModuleDNSBL : public Module
 		return MOD_RES_DENY;
 	}
 
-	ModResult OnCheckReady(LocalUser *user)
+	ModResult OnCheckReady(LocalUser *user) CXX11_OVERRIDE
 	{
 		if (countExt.get(user))
 			return MOD_RES_DENY;
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnStats(char symbol, User* user, string_list &results)
+	ModResult OnStats(char symbol, User* user, string_list &results) CXX11_OVERRIDE
 	{
 		if (symbol != 'd')
 			return MOD_RES_PASSTHRU;

--- a/src/modules/m_exemptchanops.cpp
+++ b/src/modules/m_exemptchanops.cpp
@@ -115,7 +115,7 @@ class ModuleExemptChanOps : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(eh.ec);
 		Implementation eventlist[] = { I_OnRehash, I_OnSyncChannel };
@@ -130,17 +130,17 @@ class ModuleExemptChanOps : public Module
 		ServerInstance->OnCheckExemption = &ServerInstance->HandleOnCheckExemption;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the ability to allow channel operators to be exempt from certain modes.",VF_VENDOR);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		eh.ec.DoRehash();
 	}
 
-	void OnSyncChannel(Channel* chan, Module* proto, void* opaque)
+	void OnSyncChannel(Channel* chan, Module* proto, void* opaque) CXX11_OVERRIDE
 	{
 		eh.ec.DoSyncChannel(chan, proto, opaque);
 	}

--- a/src/modules/m_filter.cpp
+++ b/src/modules/m_filter.cpp
@@ -179,22 +179,22 @@ class ModuleFilter : public Module
 	std::set<std::string> exemptfromfilter; // List of channel names excluded from filtering.
 
 	ModuleFilter();
-	void init();
+	void init() CXX11_OVERRIDE;
 	CullResult cull();
-	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list);
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE;
 	FilterResult* FilterMatch(User* user, const std::string &text, int flags);
 	bool DeleteFilter(const std::string &freeform);
 	std::pair<bool, std::string> AddFilter(const std::string &freeform, FilterAction type, const std::string &reason, long duration, const std::string &flags);
-	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list);
-	void OnRehash(User* user);
-	Version GetVersion();
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE;
+	void OnRehash(User* user) CXX11_OVERRIDE;
+	Version GetVersion() CXX11_OVERRIDE;
 	std::string EncodeFilter(FilterResult* filter);
 	FilterResult DecodeFilter(const std::string &data);
-	void OnSyncNetwork(Module* proto, void* opaque);
-	void OnDecodeMetaData(Extensible* target, const std::string &extname, const std::string &extdata);
-	ModResult OnStats(char symbol, User* user, string_list &results);
-	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line);
-	void OnUnloadModule(Module* mod);
+	void OnSyncNetwork(Module* proto, void* opaque) CXX11_OVERRIDE;
+	void OnDecodeMetaData(Extensible* target, const std::string &extname, const std::string &extdata) CXX11_OVERRIDE;
+	ModResult OnStats(char symbol, User* user, string_list &results) CXX11_OVERRIDE;
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE;
+	void OnUnloadModule(Module* mod) CXX11_OVERRIDE;
 	bool AppliesToMe(User* user, FilterResult* filter, int flags);
 	void ReadFilters();
 	static bool StringToFilterAction(const std::string& str, FilterAction& fa);

--- a/src/modules/m_gecosban.cpp
+++ b/src/modules/m_gecosban.cpp
@@ -24,18 +24,18 @@
 class ModuleGecosBan : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnCheckBan, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Extban 'r' - realname (gecos) ban", VF_OPTCOMMON|VF_VENDOR);
 	}
 
-	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask)
+	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask) CXX11_OVERRIDE
 	{
 		if ((mask.length() > 2) && (mask[0] == 'r') && (mask[1] == ':'))
 		{
@@ -45,7 +45,7 @@ class ModuleGecosBan : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('r');
 	}

--- a/src/modules/m_globalload.cpp
+++ b/src/modules/m_globalload.cpp
@@ -187,14 +187,14 @@ class ModuleGlobalLoad : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd1);
 		ServerInstance->Modules->AddService(cmd2);
 		ServerInstance->Modules->AddService(cmd3);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows global loading of a module.", VF_COMMON | VF_VENDOR);
 	}

--- a/src/modules/m_globops.cpp
+++ b/src/modules/m_globops.cpp
@@ -49,13 +49,13 @@ class ModuleGlobops : public Module
  public:
 	ModuleGlobops() : cmd(this) {}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		ServerInstance->SNO->EnableSnomask('g',"GLOBOPS");
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for GLOBOPS and snomask +g", VF_VENDOR);
 	}

--- a/src/modules/m_helpop.cpp
+++ b/src/modules/m_helpop.cpp
@@ -108,7 +108,7 @@ class ModuleHelpop : public Module
 		{
 		}
 
-		void init()
+		void init() CXX11_OVERRIDE
 		{
 			ReadConfig();
 			ServerInstance->Modules->AddService(ho);
@@ -150,12 +150,12 @@ class ModuleHelpop : public Module
 
 		}
 
-		void OnRehash(User* user)
+		void OnRehash(User* user) CXX11_OVERRIDE
 		{
 			ReadConfig();
 		}
 
-		void OnWhois(User* src, User* dst)
+		void OnWhois(User* src, User* dst) CXX11_OVERRIDE
 		{
 			if (dst->IsModeSet('h'))
 			{
@@ -163,7 +163,7 @@ class ModuleHelpop : public Module
 			}
 		}
 
-		Version GetVersion()
+		Version GetVersion() CXX11_OVERRIDE
 		{
 			return Version("Provides the /HELPOP command for useful information", VF_VENDOR);
 		}

--- a/src/modules/m_hidechans.cpp
+++ b/src/modules/m_hidechans.cpp
@@ -39,7 +39,7 @@ class ModuleHideChans : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(hm);
 		Implementation eventlist[] = { I_OnWhoisLine, I_OnRehash };
@@ -47,17 +47,17 @@ class ModuleHideChans : public Module
 		OnRehash(NULL);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for hiding channels with user mode +I", VF_VENDOR);
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		AffectsOpers = ServerInstance->Config->ConfValue("hidechans")->getBool("affectsopers");
 	}
 
-	ModResult OnWhoisLine(User* user, User* dest, int &numeric, std::string &text)
+	ModResult OnWhoisLine(User* user, User* dest, int &numeric, std::string &text) CXX11_OVERRIDE
 	{
 		/* always show to self */
 		if (user == dest)

--- a/src/modules/m_hideoper.cpp
+++ b/src/modules/m_hideoper.cpp
@@ -43,19 +43,19 @@ class ModuleHideOper : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(hm);
 		Implementation eventlist[] = { I_OnWhoisLine, I_OnSendWhoLine };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for hiding oper status with user mode +H", VF_VENDOR);
 	}
 
-	ModResult OnWhoisLine(User* user, User* dest, int &numeric, std::string &text)
+	ModResult OnWhoisLine(User* user, User* dest, int &numeric, std::string &text) CXX11_OVERRIDE
 	{
 		/* Dont display numeric 313 (RPL_WHOISOPER) if they have +H set and the
 		 * person doing the WHOIS is not an oper
@@ -72,7 +72,7 @@ class ModuleHideOper : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnSendWhoLine(User* source, const std::vector<std::string>& params, User* user, std::string& line)
+	void OnSendWhoLine(User* source, const std::vector<std::string>& params, User* user, std::string& line) CXX11_OVERRIDE
 	{
 		if (user->IsModeSet('H') && !source->HasPrivPermission("users/auspex"))
 		{

--- a/src/modules/m_hostchange.cpp
+++ b/src/modules/m_hostchange.cpp
@@ -53,14 +53,14 @@ class ModuleHostChange : public Module
 	std::string MySeparator;
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		Implementation eventlist[] = { I_OnRehash, I_OnUserConnect };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* host = ServerInstance->Config->ConfValue("host");
 		MySuffix = host->getString("suffix");
@@ -96,14 +96,14 @@ class ModuleHostChange : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		// returns the version number of the module to be
 		// listed in /MODULES
 		return Version("Provides masking of user hostnames in a different way to m_cloaking", VF_VENDOR);
 	}
 
-	virtual void OnUserConnect(LocalUser* user)
+	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
 	{
 		for (hostchanges_t::iterator i = hostchanges.begin(); i != hostchanges.end(); i++)
 		{

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -68,7 +68,7 @@ class HttpServerSocket : public BufferedSocket
 			GetIOHook()->OnStreamSocketAccept(this, client, server);
 	}
 
-	virtual void OnError(BufferedSocketError)
+	void OnError(BufferedSocketError) CXX11_OVERRIDE
 	{
 		ServerInstance->GlobalCulls.AddItem(this);
 	}
@@ -335,13 +335,13 @@ class ModuleHttpServer : public Module
 	std::vector<HttpServerSocket *> httpsocks;
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		HttpModule = this;
 		ServerInstance->Modules->Attach(I_OnAcceptConnection, this);
 	}
 
-	void OnRequest(Request& request)
+	void OnRequest(Request& request) CXX11_OVERRIDE
 	{
 		if (strcmp(request.id, "HTTP-DOC") != 0)
 			return;
@@ -350,7 +350,7 @@ class ModuleHttpServer : public Module
 		resp.src.sock->Page(resp.document, resp.responsecode, &resp.headers);
 	}
 
-	ModResult OnAcceptConnection(int nfd, ListenSocket* from, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server)
+	ModResult OnAcceptConnection(int nfd, ListenSocket* from, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server) CXX11_OVERRIDE
 	{
 		if (from->bind_tag->getString("type") != "httpd")
 			return MOD_RES_PASSTHRU;
@@ -361,7 +361,7 @@ class ModuleHttpServer : public Module
 		return MOD_RES_ALLOW;
 	}
 
-	virtual ~ModuleHttpServer()
+	~ModuleHttpServer()
 	{
 		for (size_t i = 0; i < httpsocks.size(); i++)
 		{
@@ -370,7 +370,7 @@ class ModuleHttpServer : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides HTTP serving facilities to modules", VF_VENDOR);
 	}

--- a/src/modules/m_httpd_acl.cpp
+++ b/src/modules/m_httpd_acl.cpp
@@ -89,7 +89,7 @@ class ModuleHTTPAccessList : public Module
 		}
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ReadConfig();
 		Implementation eventlist[] = { I_OnEvent };
@@ -108,7 +108,7 @@ class ModuleHTTPAccessList : public Module
 		response.Send();
 	}
 
-	void OnEvent(Event& event)
+	void OnEvent(Event& event) CXX11_OVERRIDE
 	{
 		if (event.id == "httpd_acl")
 		{
@@ -218,7 +218,7 @@ class ModuleHTTPAccessList : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides access control lists (passwording of resources, ip restrictions etc) to m_httpd.so dependent modules", VF_VENDOR);
 	}

--- a/src/modules/m_httpd_config.cpp
+++ b/src/modules/m_httpd_config.cpp
@@ -27,7 +27,7 @@
 class ModuleHttpConfig : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnEvent };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
@@ -67,7 +67,7 @@ class ModuleHttpConfig : public Module
 		return ret;
 	}
 
-	void OnEvent(Event& event)
+	void OnEvent(Event& event) CXX11_OVERRIDE
 	{
 		std::stringstream data("");
 
@@ -102,7 +102,7 @@ class ModuleHttpConfig : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows for the server configuration to be viewed over HTTP via m_httpd.so", VF_VENDOR);
 	}

--- a/src/modules/m_httpd_stats.cpp
+++ b/src/modules/m_httpd_stats.cpp
@@ -34,7 +34,7 @@ class ModuleHttpStats : public Module
 
  public:
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnEvent };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
@@ -91,7 +91,7 @@ class ModuleHttpStats : public Module
 		data << "</metadata>";
 	}
 
-	void OnEvent(Event& event)
+	void OnEvent(Event& event) CXX11_OVERRIDE
 	{
 		std::stringstream data("");
 
@@ -238,7 +238,7 @@ class ModuleHttpStats : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides statistics over HTTP via m_httpd.so", VF_VENDOR);
 	}

--- a/src/modules/m_ident.cpp
+++ b/src/modules/m_ident.cpp
@@ -142,7 +142,7 @@ class IdentRequestSocket : public EventHandler
 		}
 	}
 
-	virtual void OnConnected()
+	void OnConnected()
 	{
 		ServerInstance->Logs->Log("m_ident",LOG_DEBUG,"OnConnected()");
 		ServerInstance->SE->ChangeEventMask(this, FD_WANT_POLL_READ | FD_WANT_NO_WRITE);
@@ -165,7 +165,7 @@ class IdentRequestSocket : public EventHandler
 			done = true;
 	}
 
-	virtual void HandleEvent(EventType et, int errornum = 0)
+	void HandleEvent(EventType et, int errornum = 0)
 	{
 		switch (et)
 		{
@@ -278,7 +278,7 @@ class ModuleIdent : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(ext);
 		OnRehash(NULL);
@@ -289,19 +289,19 @@ class ModuleIdent : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for RFC1413 ident lookups", VF_VENDOR);
 	}
 
-	virtual void OnRehash(User *user)
+	void OnRehash(User *user) CXX11_OVERRIDE
 	{
 		RequestTimeout = ServerInstance->Config->ConfValue("ident")->getInt("timeout", 5);
 		if (!RequestTimeout)
 			RequestTimeout = 5;
 	}
 
-	void OnUserInit(LocalUser *user)
+	void OnUserInit(LocalUser *user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = user->MyClass->config;
 		if (!tag->getBool("useident", true))
@@ -324,7 +324,7 @@ class ModuleIdent : public Module
 	 * creating a Timer object and especially better than creating a
 	 * Timer per ident lookup!
 	 */
-	virtual ModResult OnCheckReady(LocalUser *user)
+	ModResult OnCheckReady(LocalUser *user) CXX11_OVERRIDE
 	{
 		/* Does user have an ident socket attached at all? */
 		IdentRequestSocket *isock = ext.get(user);
@@ -373,14 +373,14 @@ class ModuleIdent : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass)
+	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass) CXX11_OVERRIDE
 	{
 		if (myclass->config->getBool("requireident") && user->ident[0] == '~')
 			return MOD_RES_DENY;
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void OnCleanup(int target_type, void *item)
+	void OnCleanup(int target_type, void *item) CXX11_OVERRIDE
 	{
 		/* Module unloading, tidy up users */
 		if (target_type == TYPE_USER)
@@ -391,7 +391,7 @@ class ModuleIdent : public Module
 		}
 	}
 
-	virtual void OnUserDisconnect(LocalUser *user)
+	void OnUserDisconnect(LocalUser *user) CXX11_OVERRIDE
 	{
 		/* User disconnect (generic socket detatch event) */
 		IdentRequestSocket *isock = ext.get(user);

--- a/src/modules/m_inviteexception.cpp
+++ b/src/modules/m_inviteexception.cpp
@@ -53,7 +53,7 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(ie);
 
@@ -63,12 +63,12 @@ public:
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["INVEX"] = "I";
 	}
 
-	ModResult OnCheckInvite(User* user, Channel* chan)
+	ModResult OnCheckInvite(User* user, Channel* chan) CXX11_OVERRIDE
 	{
 		ListModeBase::ModeList* list = ie.GetList(chan);
 		if (list)
@@ -85,25 +85,25 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnCheckKey(User* user, Channel* chan, const std::string& key)
+	ModResult OnCheckKey(User* user, Channel* chan, const std::string& key) CXX11_OVERRIDE
 	{
 		if (invite_bypass_key)
 			return OnCheckInvite(user, chan);
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnSyncChannel(Channel* chan, Module* proto, void* opaque)
+	void OnSyncChannel(Channel* chan, Module* proto, void* opaque) CXX11_OVERRIDE
 	{
 		ie.DoSyncChannel(chan, proto, opaque);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		invite_bypass_key = ServerInstance->Config->ConfValue("inviteexception")->getBool("bypasskey", true);
 		ie.DoRehash();
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the +I channel mode", VF_VENDOR);
 	}

--- a/src/modules/m_ircv3.cpp
+++ b/src/modules/m_ircv3.cpp
@@ -78,14 +78,14 @@ class ModuleIRCv3 : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		Implementation eventlist[] = { I_OnUserJoin, I_OnPostJoin, I_OnSetAway, I_OnEvent, I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* conf = ServerInstance->Config->ConfValue("ircv3");
 		accountnotify = conf->getBool("accoutnotify", true);
@@ -93,7 +93,7 @@ class ModuleIRCv3 : public Module
 		extendedjoin = conf->getBool("extendedjoin", true);
 	}
 
-	void OnEvent(Event& ev)
+	void OnEvent(Event& ev) CXX11_OVERRIDE
 	{
 		if (awaynotify)
 			cap_awaynotify.HandleEvent(ev);
@@ -122,7 +122,7 @@ class ModuleIRCv3 : public Module
 		}
 	}
 
-	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& excepts)
+	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& excepts) CXX11_OVERRIDE
 	{
 		// Remember who is not going to see the JOIN because of other modules
 		if ((awaynotify) && (memb->user->IsAway()))
@@ -195,7 +195,7 @@ class ModuleIRCv3 : public Module
 		}
 	}
 
-	ModResult OnSetAway(User* user, const std::string &awaymsg)
+	ModResult OnSetAway(User* user, const std::string &awaymsg) CXX11_OVERRIDE
 	{
 		if (awaynotify)
 		{
@@ -210,7 +210,7 @@ class ModuleIRCv3 : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnPostJoin(Membership *memb)
+	void OnPostJoin(Membership *memb) CXX11_OVERRIDE
 	{
 		if ((!awaynotify) || (!memb->user->IsAway()))
 			return;
@@ -236,7 +236,7 @@ class ModuleIRCv3 : public Module
 		ServerInstance->Modules->SetPriority(this, I_OnUserJoin, PRIORITY_LAST);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for extended-join, away-notify and account-notify CAP capabilities", VF_VENDOR);
 	}

--- a/src/modules/m_joinflood.cpp
+++ b/src/modules/m_joinflood.cpp
@@ -197,7 +197,7 @@ class ModuleJoinFlood : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(jf);
 		ServerInstance->Modules->AddService(jf.ext);
@@ -205,7 +205,7 @@ class ModuleJoinFlood : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		if (chan)
 		{
@@ -219,7 +219,7 @@ class ModuleJoinFlood : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& excepts)
+	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& excepts) CXX11_OVERRIDE
 	{
 		/* We arent interested in JOIN events caused by a network burst */
 		if (sync)
@@ -240,7 +240,7 @@ class ModuleJoinFlood : public Module
 		}
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel mode +j (join flood protection)", VF_VENDOR);
 	}

--- a/src/modules/m_jumpserver.cpp
+++ b/src/modules/m_jumpserver.cpp
@@ -138,14 +138,14 @@ class ModuleJumpServer : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(js);
 		Implementation eventlist[] = { I_OnUserRegister, I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual ModResult OnUserRegister(LocalUser* user)
+	ModResult OnUserRegister(LocalUser* user) CXX11_OVERRIDE
 	{
 		if (js.port && js.redirect_new_users)
 		{
@@ -157,13 +157,13 @@ class ModuleJumpServer : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		// Emergency way to unlock
 		if (!user) js.redirect_new_users = false;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the RPL_REDIR numeric and the /JUMPSERVER command.", VF_VENDOR);
 	}

--- a/src/modules/m_kicknorejoin.cpp
+++ b/src/modules/m_kicknorejoin.cpp
@@ -42,7 +42,7 @@ class KickRejoin : public ModeHandler
 	{
 	}
 
-	ModeAction OnModeChange(User* source, User* dest, Channel* channel, std::string& parameter, bool adding)
+	ModeAction OnModeChange(User* source, User* dest, Channel* channel, std::string& parameter, bool adding) CXX11_OVERRIDE
 	{
 		if (adding)
 		{
@@ -80,7 +80,7 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(kr);
 		ServerInstance->Modules->AddService(kr.ext);
@@ -88,7 +88,7 @@ public:
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		if (chan)
 		{
@@ -122,7 +122,7 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnUserKick(User* source, Membership* memb, const std::string &reason, CUList& excepts)
+	void OnUserKick(User* source, Membership* memb, const std::string &reason, CUList& excepts) CXX11_OVERRIDE
 	{
 		if (memb->chan->IsModeSet(&kr) && (IS_LOCAL(memb->user)) && (source != memb->user))
 		{
@@ -136,7 +136,7 @@ public:
 		}
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Channel mode to delay rejoin after kick", VF_VENDOR);
 	}

--- a/src/modules/m_knock.cpp
+++ b/src/modules/m_knock.cpp
@@ -97,7 +97,7 @@ class ModuleKnock : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(kn);
 		ServerInstance->Modules->AddService(cmd);
@@ -106,7 +106,7 @@ class ModuleKnock : public Module
 		OnRehash(NULL);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		std::string knocknotify = ServerInstance->Config->ConfValue("knock")->getString("notify");
 		irc::string notify(knocknotify.c_str());
@@ -128,7 +128,7 @@ class ModuleKnock : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for /KNOCK and channel mode +K", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_lockserv.cpp
+++ b/src/modules/m_lockserv.cpp
@@ -88,7 +88,7 @@ class ModuleLockserv : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		locked = false;
 		ServerInstance->Modules->AddService(lockcommand);
@@ -97,13 +97,13 @@ class ModuleLockserv : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		// Emergency way to unlock
 		if (!user) locked = false;
 	}
 
-	virtual ModResult OnUserRegister(LocalUser* user)
+	ModResult OnUserRegister(LocalUser* user) CXX11_OVERRIDE
 	{
 		if (locked)
 		{
@@ -113,12 +113,12 @@ class ModuleLockserv : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user) CXX11_OVERRIDE
 	{
 		return locked ? MOD_RES_DENY : MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows locking of the server to stop all incoming connections until unlocked again", VF_VENDOR);
 	}

--- a/src/modules/m_maphide.cpp
+++ b/src/modules/m_maphide.cpp
@@ -25,19 +25,19 @@ class ModuleMapHide : public Module
 {
 	std::string url;
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnPreCommand, I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 		OnRehash(NULL);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		url = ServerInstance->Config->ConfValue("security")->getString("maphide");
 	}
 
-	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		if (validated && !user->IsOper() && !url.empty() && (command == "MAP" || command == "LINKS"))
 		{
@@ -48,7 +48,7 @@ class ModuleMapHide : public Module
 			return MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Hide /MAP and /LINKS in the same form as ircu (mostly useless)", VF_VENDOR);
 	}

--- a/src/modules/m_md5.cpp
+++ b/src/modules/m_md5.cpp
@@ -287,7 +287,7 @@ class ModuleMD5 : public Module
 		ServerInstance->Modules->AddService(md5);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements MD5 hashing",VF_VENDOR);
 	}

--- a/src/modules/m_messageflood.cpp
+++ b/src/modules/m_messageflood.cpp
@@ -128,7 +128,7 @@ class ModuleMsgFlood : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(mf);
 		ServerInstance->Modules->AddService(mf.ext);
@@ -172,7 +172,7 @@ class ModuleMsgFlood : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnUserPreMessage(User *user, void *dest, int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User *user, void *dest, int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (target_type == TYPE_CHANNEL)
 			return ProcessMessages(user,(Channel*)dest,text);
@@ -180,7 +180,7 @@ class ModuleMsgFlood : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnUserPreNotice(User *user, void *dest, int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User *user, void *dest, int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (target_type == TYPE_CHANNEL)
 			return ProcessMessages(user,(Channel*)dest,text);
@@ -195,7 +195,7 @@ class ModuleMsgFlood : public Module
 		ServerInstance->Modules->SetPriority(this, I_OnUserPreNotice, PRIORITY_LAST);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel mode +f (message flood protection)", VF_VENDOR);
 	}

--- a/src/modules/m_mlock.cpp
+++ b/src/modules/m_mlock.cpp
@@ -28,13 +28,13 @@ class ModuleMLock : public Module
 public:
 	ModuleMLock() : mlock("mlock", this) {};
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->Attach(I_OnPreMode, this);
 		ServerInstance->Modules->AddService(this->mlock);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements the ability to have server-side MLOCK enforcement.", VF_VENDOR);
 	}
@@ -44,7 +44,7 @@ public:
 		ServerInstance->Modules->SetPriority(this, I_OnPreMode, PRIORITY_FIRST);
 	}
 
-	ModResult OnPreMode(User* source, User* dest, Channel* channel, const std::vector<std::string>& parameters)
+	ModResult OnPreMode(User* source, User* dest, Channel* channel, const std::vector<std::string>& parameters) CXX11_OVERRIDE
 	{
 		if (!channel)
 			return MOD_RES_PASSTHRU;

--- a/src/modules/m_muteban.cpp
+++ b/src/modules/m_muteban.cpp
@@ -25,18 +25,18 @@
 class ModuleQuietBan : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnUserPreMessage, I_OnUserPreNotice, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements extban +b m: - mute bans",VF_OPTCOMMON|VF_VENDOR);
 	}
 
-	virtual ModResult OnUserPreMessage(User *user, void *dest, int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User *user, void *dest, int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user) || target_type != TYPE_CHANNEL)
 			return MOD_RES_PASSTHRU;
@@ -51,12 +51,12 @@ class ModuleQuietBan : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreNotice(User *user, void *dest, int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User *user, void *dest, int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return OnUserPreMessage(user, dest, target_type, text, status, exempt_list);
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('m');
 	}

--- a/src/modules/m_namedmodes.cpp
+++ b/src/modules/m_namedmodes.cpp
@@ -105,7 +105,7 @@ class ModuleNamedModes : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		ServerInstance->Modules->AddService(dummyZ);
@@ -114,7 +114,7 @@ class ModuleNamedModes : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the ability to manipulate modes via long names.",VF_VENDOR);
 	}
@@ -124,7 +124,7 @@ class ModuleNamedModes : public Module
 		ServerInstance->Modules->SetPriority(this, I_OnPreMode, PRIORITY_FIRST);
 	}
 
-	ModResult OnPreMode(User* source, User* dest, Channel* channel, const std::vector<std::string>& parameters)
+	ModResult OnPreMode(User* source, User* dest, Channel* channel, const std::vector<std::string>& parameters) CXX11_OVERRIDE
 	{
 		if (!channel)
 			return MOD_RES_PASSTHRU;

--- a/src/modules/m_namesx.cpp
+++ b/src/modules/m_namesx.cpp
@@ -33,23 +33,23 @@ class ModuleNamesX : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnPreCommand, I_OnNamesListItem, I_On005Numeric, I_OnEvent, I_OnSendWhoLine };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the NAMESX (CAP multi-prefix) capability.",VF_VENDOR);
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["NAMESX"];
 	}
 
-	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		/* We don't actually create a proper command handler class for PROTOCTL,
 		 * because other modules might want to have PROTOCTL hooks too.
@@ -67,7 +67,7 @@ class ModuleNamesX : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnNamesListItem(User* issuer, Membership* memb, std::string &prefixes, std::string &nick)
+	void OnNamesListItem(User* issuer, Membership* memb, std::string &prefixes, std::string &nick) CXX11_OVERRIDE
 	{
 		if (!cap.ext.get(issuer))
 			return;
@@ -79,7 +79,7 @@ class ModuleNamesX : public Module
 		prefixes = memb->chan->GetAllPrefixChars(memb->user);
 	}
 
-	void OnSendWhoLine(User* source, const std::vector<std::string>& params, User* user, std::string& line)
+	void OnSendWhoLine(User* source, const std::vector<std::string>& params, User* user, std::string& line) CXX11_OVERRIDE
 	{
 		if (!cap.ext.get(source))
 			return;
@@ -117,7 +117,7 @@ class ModuleNamesX : public Module
 		line.insert(pos, prefixes);
 	}
 
-	void OnEvent(Event& ev)
+	void OnEvent(Event& ev) CXX11_OVERRIDE
 	{
 		cap.HandleEvent(ev);
 	}

--- a/src/modules/m_nationalchars.cpp
+++ b/src/modules/m_nationalchars.cpp
@@ -35,8 +35,8 @@ class lwbNickHandler : public HandlerBase2<bool, const std::string&, size_t>
 {
  public:
 	lwbNickHandler() { }
-	virtual ~lwbNickHandler() { }
-	virtual bool Call(const std::string&, size_t);
+	~lwbNickHandler() { }
+	bool Call(const std::string&, size_t);
 };
 
 								 /*,m_reverse_additionalUp[256];*/
@@ -235,7 +235,7 @@ class ModuleNationalChars : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		memcpy(m_lower, rfc_case_insensitive_map, 256);
 		national_case_insensitive_map = m_lower;
@@ -247,12 +247,12 @@ class ModuleNationalChars : public Module
 		OnRehash(NULL);
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["CASEMAPPING"] = casemapping;
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("nationalchars");
 		charset = tag->getString("file");
@@ -279,14 +279,14 @@ class ModuleNationalChars : public Module
 		}
 	}
 
-	virtual ~ModuleNationalChars()
+	~ModuleNationalChars()
 	{
 		ServerInstance->IsNick = rememberer;
 		national_case_insensitive_map = lowermap_rememberer;
 		CheckForceQuit("National characters module unloaded");
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides an ability to have non-RFC1459 nicks & support for national CASEMAPPING", VF_VENDOR | VF_COMMON, charset);
 	}

--- a/src/modules/m_nickflood.cpp
+++ b/src/modules/m_nickflood.cpp
@@ -140,7 +140,7 @@ class ModuleNickFlood : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(nf);
 		ServerInstance->Modules->AddService(nf.ext);
@@ -148,7 +148,7 @@ class ModuleNickFlood : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	ModResult OnUserPreNick(User* user, const std::string &newnick)
+	ModResult OnUserPreNick(User* user, const std::string &newnick) CXX11_OVERRIDE
 	{
 		if (ServerInstance->NICKForced.get(user)) /* Allow forced nick changes */
 			return MOD_RES_PASSTHRU;
@@ -187,7 +187,7 @@ class ModuleNickFlood : public Module
 	/*
 	 * XXX: HACK: We do the increment on the *POST* event here (instead of all together) because we have no way of knowing whether other modules would block a nickchange.
 	 */
-	void OnUserPostNick(User* user, const std::string &oldnick)
+	void OnUserPostNick(User* user, const std::string &oldnick) CXX11_OVERRIDE
 	{
 		if (isdigit(user->nick[0])) /* allow switches to UID */
 			return;
@@ -213,7 +213,7 @@ class ModuleNickFlood : public Module
 		}
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Channel mode F - nick flood protection", VF_VENDOR);
 	}

--- a/src/modules/m_nicklock.cpp
+++ b/src/modules/m_nicklock.cpp
@@ -150,7 +150,7 @@ class ModuleNickLock : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd1);
 		ServerInstance->Modules->AddService(cmd2);
@@ -158,12 +158,12 @@ class ModuleNickLock : public Module
 		ServerInstance->Modules->Attach(I_OnUserPreNick, this);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the NICKLOCK command, allows an oper to change a users nick and lock them to it until they quit", VF_OPTCOMMON | VF_VENDOR);
 	}
 
-	ModResult OnUserPreNick(User* user, const std::string &newnick)
+	ModResult OnUserPreNick(User* user, const std::string &newnick) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user))
 			return MOD_RES_PASSTHRU;

--- a/src/modules/m_noctcp.cpp
+++ b/src/modules/m_noctcp.cpp
@@ -39,24 +39,24 @@ class ModuleNoCTCP : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(nc);
 		Implementation eventlist[] = { I_OnUserPreMessage, I_OnUserPreNotice, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel mode +C to block CTCPs", VF_VENDOR);
 	}
 
-	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return OnUserPreNotice(user,dest,target_type,text,status,exempt_list);
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if ((target_type == TYPE_CHANNEL) && (IS_LOCAL(user)))
 		{
@@ -77,7 +77,7 @@ class ModuleNoCTCP : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('C');
 	}

--- a/src/modules/m_nokicks.cpp
+++ b/src/modules/m_nokicks.cpp
@@ -40,19 +40,19 @@ class ModuleNoKicks : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(nk);
 		Implementation eventlist[] = { I_OnUserPreKick, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('Q');
 	}
 
-	ModResult OnUserPreKick(User* source, Membership* memb, const std::string &reason)
+	ModResult OnUserPreKick(User* source, Membership* memb, const std::string &reason) CXX11_OVERRIDE
 	{
 		if (!memb->chan->GetExtBanStatus(source, 'Q').check(!memb->chan->IsModeSet('Q')))
 		{
@@ -63,7 +63,7 @@ class ModuleNoKicks : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel mode +Q to prevent kicks on the channel.", VF_VENDOR);
 	}

--- a/src/modules/m_nonicks.cpp
+++ b/src/modules/m_nonicks.cpp
@@ -38,7 +38,7 @@ class ModuleNoNickChange : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		ServerInstance->Modules->AddService(nn);
@@ -46,17 +46,17 @@ class ModuleNoNickChange : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for channel mode +N & extban +b N: which prevents nick changes on channel", VF_VENDOR);
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('N');
 	}
 
-	virtual ModResult OnUserPreNick(User* user, const std::string &newnick)
+	ModResult OnUserPreNick(User* user, const std::string &newnick) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user))
 			return MOD_RES_PASSTHRU;
@@ -88,7 +88,7 @@ class ModuleNoNickChange : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		override = ServerInstance->Config->ConfValue("nonicks")->getBool("operoverride", false);
 	}

--- a/src/modules/m_nonotice.cpp
+++ b/src/modules/m_nonotice.cpp
@@ -39,19 +39,19 @@ class ModuleNoNotice : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(nt);
 		Implementation eventlist[] = { I_OnUserPreNotice, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('T');
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		ModResult res;
 		if ((target_type == TYPE_CHANNEL) && (IS_LOCAL(user)))
@@ -72,7 +72,7 @@ class ModuleNoNotice : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel mode +T to block notices to the channel", VF_VENDOR);
 	}

--- a/src/modules/m_nopartmsg.cpp
+++ b/src/modules/m_nopartmsg.cpp
@@ -24,18 +24,18 @@
 class ModulePartMsgBan : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnUserPart, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements extban +b p: - part message bans", VF_OPTCOMMON|VF_VENDOR);
 	}
 
-	virtual void OnUserPart(Membership* memb, std::string &partmessage, CUList& excepts)
+	void OnUserPart(Membership* memb, std::string &partmessage, CUList& excepts) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(memb->user))
 			return;
@@ -44,7 +44,7 @@ class ModulePartMsgBan : public Module
 			partmessage.clear();
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('p');
 	}

--- a/src/modules/m_ojoin.cpp
+++ b/src/modules/m_ojoin.cpp
@@ -180,7 +180,7 @@ class ModuleOjoin : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		/* Load config stuff */
 		OnRehash(NULL);
@@ -195,7 +195,7 @@ class ModuleOjoin : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		if (mycommand.active)
 		{
@@ -208,7 +208,7 @@ class ModuleOjoin : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* Conf = ServerInstance->Config->ConfValue("ojoin");
 
@@ -226,7 +226,7 @@ class ModuleOjoin : public Module
 		op = Conf->getBool("op", true);
 	}
 
-	ModResult OnUserPreKick(User* source, Membership* memb, const std::string &reason)
+	ModResult OnUserPreKick(User* source, Membership* memb, const std::string &reason) CXX11_OVERRIDE
 	{
 		// Don't do anything if they're not +Y
 		if (!memb->hasMode('Y'))
@@ -250,7 +250,7 @@ class ModuleOjoin : public Module
 		ServerInstance->Modules->SetPriority(this, I_OnUserPreJoin, PRIORITY_FIRST);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Network Business Join", VF_VENDOR);
 	}

--- a/src/modules/m_operchans.cpp
+++ b/src/modules/m_operchans.cpp
@@ -42,14 +42,14 @@ class ModuleOperChans : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(oc);
 		Implementation eventlist[] = { I_OnCheckBan, I_On005Numeric, I_OnUserPreJoin };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		if (chan && chan->IsModeSet('O') && !user->IsOper())
 		{
@@ -60,7 +60,7 @@ class ModuleOperChans : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask)
+	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask) CXX11_OVERRIDE
 	{
 		if ((mask.length() > 2) && (mask[0] == 'O') && (mask[1] == ':'))
 		{
@@ -70,12 +70,12 @@ class ModuleOperChans : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('O');
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for oper-only chans via the +O channel mode and 'O' extban", VF_VENDOR);
 	}

--- a/src/modules/m_operjoin.cpp
+++ b/src/modules/m_operjoin.cpp
@@ -52,7 +52,7 @@ class ModuleOperjoin : public Module
 		}
 
 	public:
-		void init()
+		void init() CXX11_OVERRIDE
 		{
 			OnRehash(NULL);
 			Implementation eventlist[] = { I_OnPostOper, I_OnRehash };
@@ -60,7 +60,7 @@ class ModuleOperjoin : public Module
 		}
 
 
-		virtual void OnRehash(User* user)
+		void OnRehash(User* user) CXX11_OVERRIDE
 		{
 			ConfigTag* tag = ServerInstance->Config->ConfValue("operjoin");
 
@@ -71,12 +71,12 @@ class ModuleOperjoin : public Module
 				tokenize(operChan,operChans);
 		}
 
-		virtual Version GetVersion()
+		Version GetVersion() CXX11_OVERRIDE
 		{
 			return Version("Forces opers to join the specified channel(s) on oper-up", VF_VENDOR);
 		}
 
-		virtual void OnPostOper(User* user, const std::string &opertype, const std::string &opername)
+		void OnPostOper(User* user, const std::string &opertype, const std::string &opername) CXX11_OVERRIDE
 		{
 			LocalUser* localuser = IS_LOCAL(user);
 			if (!localuser)

--- a/src/modules/m_operlevels.cpp
+++ b/src/modules/m_operlevels.cpp
@@ -27,17 +27,17 @@
 class ModuleOperLevels : public Module
 {
 	public:
-		void init()
+		void init() CXX11_OVERRIDE
 		{
 			ServerInstance->Modules->Attach(I_OnKill, this);
 		}
 
-		virtual Version GetVersion()
+		Version GetVersion() CXX11_OVERRIDE
 		{
 			return Version("Gives each oper type a 'level', cannot kill opers 'above' your level.", VF_VENDOR);
 		}
 
-		virtual ModResult OnKill(User* source, User* dest, const std::string &reason)
+		ModResult OnKill(User* source, User* dest, const std::string &reason) CXX11_OVERRIDE
 		{
 			// oper killing an oper?
 			if (dest->IsOper() && source->IsOper())

--- a/src/modules/m_operlog.cpp
+++ b/src/modules/m_operlog.cpp
@@ -28,7 +28,7 @@ class ModuleOperLog : public Module
 	bool tosnomask;
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnPreCommand, I_On005Numeric, I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
@@ -36,17 +36,17 @@ class ModuleOperLog : public Module
 		OnRehash(NULL);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("A module which logs all oper commands to the ircd log at default loglevel.", VF_VENDOR);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		tosnomask = ServerInstance->Config->ConfValue("operlog")->getBool("tosnomask", false);
 	}
 
-	virtual ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		/* If the command doesnt appear to be valid, we dont want to mess with it. */
 		if (!validated)
@@ -70,7 +70,7 @@ class ModuleOperLog : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["OPERLOG"];
 	}

--- a/src/modules/m_opermodes.cpp
+++ b/src/modules/m_opermodes.cpp
@@ -27,17 +27,17 @@
 class ModuleModesOnOper : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->Attach(I_OnPostOper, this);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Sets (and unsets) modes on opers when they oper up", VF_VENDOR);
 	}
 
-	virtual void OnPostOper(User* user, const std::string &opertype, const std::string &opername)
+	void OnPostOper(User* user, const std::string &opertype, const std::string &opername) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user))
 			return;

--- a/src/modules/m_opermotd.cpp
+++ b/src/modules/m_opermotd.cpp
@@ -82,7 +82,7 @@ class ModuleOpermotd : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		OnRehash(NULL);
@@ -90,18 +90,18 @@ class ModuleOpermotd : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Shows a message to opers after oper-up, adds /opermotd", VF_VENDOR | VF_OPTCOMMON);
 	}
 
-	virtual void OnOper(User* user, const std::string &opertype)
+	void OnOper(User* user, const std::string &opertype) CXX11_OVERRIDE
 	{
 		if (onoper && IS_LOCAL(user))
 			cmd.ShowOperMOTD(user);
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		cmd.opermotd.clear();
 		ConfigTag* conf = ServerInstance->Config->ConfValue("opermotd");

--- a/src/modules/m_operprefix.cpp
+++ b/src/modules/m_operprefix.cpp
@@ -80,7 +80,7 @@ class ModuleOperPrefixMode : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(opm);
 
@@ -96,7 +96,7 @@ class ModuleOperPrefixMode : public Module
 			mw_added = ServerInstance->Modes->AddModeWatcher(&hideoperwatcher);
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		/* The user may have the +H umode on himself, but +H does not necessarily correspond
 		 * to the +H of m_hideoper.
@@ -122,19 +122,19 @@ class ModuleOperPrefixMode : public Module
 		}
 	}
 
-	void OnPostOper(User* user, const std::string& opername, const std::string& opertype)
+	void OnPostOper(User* user, const std::string& opername, const std::string& opertype) CXX11_OVERRIDE
 	{
 		if (IS_LOCAL(user) && (!mw_added || !user->IsModeSet('H')))
 			SetOperPrefix(user, true);
 	}
 
-	void OnLoadModule(Module* mod)
+	void OnLoadModule(Module* mod) CXX11_OVERRIDE
 	{
 		if ((!mw_added) && (mod->ModuleSourceFile == "m_hideoper.so"))
 			mw_added = ServerInstance->Modes->AddModeWatcher(&hideoperwatcher);
 	}
 
-	void OnUnloadModule(Module* mod)
+	void OnUnloadModule(Module* mod) CXX11_OVERRIDE
 	{
 		if ((mw_added) && (mod->ModuleSourceFile == "m_hideoper.so") && (ServerInstance->Modes->DelModeWatcher(&hideoperwatcher)))
 			mw_added = false;
@@ -146,7 +146,7 @@ class ModuleOperPrefixMode : public Module
 			ServerInstance->Modes->DelModeWatcher(&hideoperwatcher);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Gives opers cmode +y which provides a staff prefix.", VF_VENDOR);
 	}

--- a/src/modules/m_override.cpp
+++ b/src/modules/m_override.cpp
@@ -35,7 +35,7 @@ class ModuleOverride : public Module
 
  public:
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		// read our config options (main config file)
 		OnRehash(NULL);
@@ -44,7 +44,7 @@ class ModuleOverride : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		// re-read our config options on a rehash
 		ConfigTag* tag = ServerInstance->Config->ConfValue("override");
@@ -52,7 +52,7 @@ class ModuleOverride : public Module
 		RequireKey = tag->getBool("requirekey");
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["OVERRIDE"];
 	}
@@ -66,7 +66,7 @@ class ModuleOverride : public Module
 	}
 
 
-	ModResult OnPreTopicChange(User *source, Channel *channel, const std::string &topic)
+	ModResult OnPreTopicChange(User *source, Channel *channel, const std::string &topic) CXX11_OVERRIDE
 	{
 		if (IS_LOCAL(source) && source->IsOper() && CanOverride(source, "TOPIC"))
 		{
@@ -82,7 +82,7 @@ class ModuleOverride : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnUserPreKick(User* source, Membership* memb, const std::string &reason)
+	ModResult OnUserPreKick(User* source, Membership* memb, const std::string &reason) CXX11_OVERRIDE
 	{
 		if (source->IsOper() && CanOverride(source,"KICK"))
 		{
@@ -96,7 +96,7 @@ class ModuleOverride : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnPreMode(User* source,User* dest,Channel* channel, const std::vector<std::string>& parameters)
+	ModResult OnPreMode(User* source,User* dest,Channel* channel, const std::vector<std::string>& parameters) CXX11_OVERRIDE
 	{
 		if (!source || !channel)
 			return MOD_RES_PASSTHRU;
@@ -116,7 +116,7 @@ class ModuleOverride : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		if (user->IsOper())
 		{
@@ -189,7 +189,7 @@ class ModuleOverride : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for allowing opers to override certain things",VF_VENDOR);
 	}

--- a/src/modules/m_passforward.cpp
+++ b/src/modules/m_passforward.cpp
@@ -26,19 +26,19 @@ class ModulePassForward : public Module
 	std::string nickrequired, forwardmsg, forwardcmd;
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		Implementation eventlist[] = { I_OnPostConnect, I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Sends server password to NickServ", VF_VENDOR);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("passforward");
 		nickrequired = tag->getString("nick", "NickServ");
@@ -81,7 +81,7 @@ class ModulePassForward : public Module
 		}
 	}
 
-	virtual void OnPostConnect(User* ruser)
+	void OnPostConnect(User* ruser) CXX11_OVERRIDE
 	{
 		LocalUser* user = IS_LOCAL(ruser);
 		if (!user || user->password.empty())

--- a/src/modules/m_password_hash.cpp
+++ b/src/modules/m_password_hash.cpp
@@ -82,7 +82,7 @@ class ModuleOperHash : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		/* Read the config file first */
 		OnRehash(NULL);
@@ -92,7 +92,7 @@ class ModuleOperHash : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual ModResult OnPassCompare(Extensible* ex, const std::string &data, const std::string &input, const std::string &hashtype)
+	ModResult OnPassCompare(Extensible* ex, const std::string &data, const std::string &input, const std::string &hashtype) CXX11_OVERRIDE
 	{
 		if (hashtype.substr(0,5) == "hmac-")
 		{
@@ -130,7 +130,7 @@ class ModuleOperHash : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows for hashed oper passwords",VF_VENDOR);
 	}

--- a/src/modules/m_permchannels.cpp
+++ b/src/modules/m_permchannels.cpp
@@ -165,7 +165,7 @@ public:
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(p);
 		Implementation eventlist[] = { I_OnChannelPreDelete, I_OnPostTopicChange, I_OnRawMode, I_OnRehash, I_OnBackgroundTimer };
@@ -200,7 +200,7 @@ public:
 		return Module::cull();
 	}
 
-	virtual void OnRehash(User *user)
+	void OnRehash(User *user) CXX11_OVERRIDE
 	{
 		permchannelsconf = ServerInstance->Config->ConfValue("permchanneldb")->getString("filename");
 	}
@@ -271,7 +271,7 @@ public:
 		}
 	}
 
-	virtual ModResult OnRawMode(User* user, Channel* chan, const char mode, const std::string &param, bool adding, int pcnt)
+	ModResult OnRawMode(User* user, Channel* chan, const char mode, const std::string &param, bool adding, int pcnt) CXX11_OVERRIDE
 	{
 		if (chan && (chan->IsModeSet('P') || mode == 'P'))
 			dirty = true;
@@ -279,13 +279,13 @@ public:
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void OnPostTopicChange(User*, Channel *c, const std::string&)
+	void OnPostTopicChange(User*, Channel *c, const std::string&) CXX11_OVERRIDE
 	{
 		if (c->IsModeSet('P'))
 			dirty = true;
 	}
 
-	void OnBackgroundTimer(time_t)
+	void OnBackgroundTimer(time_t) CXX11_OVERRIDE
 	{
 		if (dirty)
 			WriteDatabase();
@@ -324,12 +324,12 @@ public:
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for channel mode +P to provide permanent channels",VF_VENDOR);
 	}
 
-	virtual ModResult OnChannelPreDelete(Channel *c)
+	ModResult OnChannelPreDelete(Channel *c) CXX11_OVERRIDE
 	{
 		if (c->IsModeSet('P'))
 			return MOD_RES_DENY;

--- a/src/modules/m_randquote.cpp
+++ b/src/modules/m_randquote.cpp
@@ -61,7 +61,7 @@ class ModuleRandQuote : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ConfigTag* conf = ServerInstance->Config->ConfValue("randquote");
 
@@ -79,17 +79,17 @@ class ModuleRandQuote : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual ~ModuleRandQuote()
+	~ModuleRandQuote()
 	{
 		delete quotes;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides random quotes on connect.",VF_VENDOR);
 	}
 
-	virtual void OnUserConnect(LocalUser* user)
+	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
 	{
 		cmd.Handle(std::vector<std::string>(), user);
 	}

--- a/src/modules/m_redirect.cpp
+++ b/src/modules/m_redirect.cpp
@@ -109,7 +109,7 @@ class ModuleRedirect : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		/* Setting this here so it isn't changable by rehasing the config later. */
 		UseUsermode = ServerInstance->Config->ConfValue("redirect")->getBool("antiredirect");
@@ -131,7 +131,7 @@ class ModuleRedirect : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		if (chan)
 		{
@@ -167,7 +167,7 @@ class ModuleRedirect : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel mode +L (limit redirection) and user mode +L (no forced redirection)", VF_VENDOR);
 	}

--- a/src/modules/m_regex_glob.cpp
+++ b/src/modules/m_regex_glob.cpp
@@ -30,7 +30,7 @@ public:
 	{
 	}
 
-	virtual bool Matches(const std::string& text)
+	bool Matches(const std::string& text)
 	{
 		return InspIRCd::Match(text, this->regex_string);
 	}
@@ -55,7 +55,7 @@ public:
 		ServerInstance->Modules->AddService(gf);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Regex module using plain wildcard matching.", VF_VENDOR);
 	}

--- a/src/modules/m_regonlycreate.cpp
+++ b/src/modules/m_regonlycreate.cpp
@@ -28,13 +28,13 @@
 class ModuleRegOnlyCreate : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnUserPreJoin };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		if (chan)
 			return MOD_RES_PASSTHRU;
@@ -54,7 +54,7 @@ class ModuleRegOnlyCreate : public Module
 		return MOD_RES_DENY;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Prevents users whose nicks are not registered from creating new channels", VF_VENDOR);
 	}

--- a/src/modules/m_remove.cpp
+++ b/src/modules/m_remove.cpp
@@ -136,7 +136,7 @@ class RemoveBase : public Command
 
 		return CMD_SUCCESS;
 	}
-	virtual RouteDescriptor GetRouting(User* user, const std::vector<std::string>& parameters) = 0;
+	RouteDescriptor GetRouting(User* user, const std::vector<std::string>& parameters) = 0;
 };
 
 /** Handle /REMOVE
@@ -202,7 +202,7 @@ class ModuleRemove : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd1);
 		ServerInstance->Modules->AddService(cmd2);
@@ -211,17 +211,17 @@ class ModuleRemove : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["REMOVE"];
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		supportnokicks = ServerInstance->Config->ConfValue("remove")->getBool("supportnokicks");
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides a /remove command, this is mostly an alternative to /kick, except makes users appear to have parted the channel", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_restrictchans.cpp
+++ b/src/modules/m_restrictchans.cpp
@@ -41,19 +41,19 @@ class ModuleRestrictChans : public Module
 	}
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ReadConfig();
 		Implementation eventlist[] = { I_OnUserPreJoin, I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ReadConfig();
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		irc::string x(cname.c_str());
 
@@ -70,7 +70,7 @@ class ModuleRestrictChans : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Only opers may create new channels if this module is loaded",VF_VENDOR);
 	}

--- a/src/modules/m_restrictmsg.cpp
+++ b/src/modules/m_restrictmsg.cpp
@@ -29,14 +29,14 @@ class ModuleRestrictMsg : public Module
 
  public:
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnUserPreMessage, I_OnUserPreNotice };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
 
-	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if ((target_type == TYPE_USER) && (IS_LOCAL(user)))
 		{
@@ -58,12 +58,12 @@ class ModuleRestrictMsg : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return this->OnUserPreMessage(user,dest,target_type,text,status,exempt_list);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Forbids users from messaging each other. Users may still message opers and opers may message other opers.",VF_VENDOR);
 	}

--- a/src/modules/m_ripemd160.cpp
+++ b/src/modules/m_ripemd160.cpp
@@ -463,7 +463,7 @@ class ModuleRIPEMD160 : public Module
 		ServerInstance->Modules->AddService(mr);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides RIPEMD-160 hashing", VF_VENDOR);
 	}

--- a/src/modules/m_rline.cpp
+++ b/src/modules/m_rline.cpp
@@ -224,7 +224,7 @@ class ModuleRLine : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 
@@ -235,18 +235,18 @@ class ModuleRLine : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual ~ModuleRLine()
+	~ModuleRLine()
 	{
 		ServerInstance->XLines->DelAll("R");
 		ServerInstance->XLines->UnregisterFactory(&f);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("RLINE: Regexp user banning.", VF_COMMON | VF_VENDOR, rxfactory ? rxfactory->name : "");
 	}
 
-	ModResult OnUserRegister(LocalUser* user)
+	ModResult OnUserRegister(LocalUser* user) CXX11_OVERRIDE
 	{
 		// Apply lines on user connect
 		XLine *rl = ServerInstance->XLines->MatchesLine("R", user);
@@ -260,7 +260,7 @@ class ModuleRLine : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void OnRehash(User *user)
+	void OnRehash(User *user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("rline");
 
@@ -293,7 +293,7 @@ class ModuleRLine : public Module
 		initing = false;
 	}
 
-	virtual ModResult OnStats(char symbol, User* user, string_list &results)
+	ModResult OnStats(char symbol, User* user, string_list &results) CXX11_OVERRIDE
 	{
 		if (symbol != 'R')
 			return MOD_RES_PASSTHRU;
@@ -302,7 +302,7 @@ class ModuleRLine : public Module
 		return MOD_RES_DENY;
 	}
 
-	virtual void OnUserPostNick(User *user, const std::string &oldnick)
+	void OnUserPostNick(User *user, const std::string &oldnick) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user))
 			return;
@@ -319,7 +319,7 @@ class ModuleRLine : public Module
 		}
 	}
 
-	virtual void OnBackgroundTimer(time_t curtime)
+	void OnBackgroundTimer(time_t curtime) CXX11_OVERRIDE
 	{
 		if (added_zline)
 		{
@@ -328,7 +328,7 @@ class ModuleRLine : public Module
 		}
 	}
 
-	void OnUnloadModule(Module* mod)
+	void OnUnloadModule(Module* mod) CXX11_OVERRIDE
 	{
 		// If the regex engine became unavailable or has changed, remove all rlines
 		if (!rxfactory)

--- a/src/modules/m_rmode.cpp
+++ b/src/modules/m_rmode.cpp
@@ -115,12 +115,12 @@ class ModuleRMode : public Module
  public:
 	ModuleRMode() : cmd(this) { }
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows glob-based removal of list modes", VF_VENDOR);
 	}

--- a/src/modules/m_sajoin.cpp
+++ b/src/modules/m_sajoin.cpp
@@ -110,12 +110,12 @@ class ModuleSajoin : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides command SAJOIN to allow opers to force-join users to channels", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_sakick.cpp
+++ b/src/modules/m_sakick.cpp
@@ -107,12 +107,12 @@ class ModuleSakick : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides a SAKICK command", VF_OPTCOMMON|VF_VENDOR);
 	}

--- a/src/modules/m_samode.cpp
+++ b/src/modules/m_samode.cpp
@@ -63,18 +63,18 @@ class ModuleSaMode : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		ServerInstance->Modules->Attach(I_OnPreMode, this);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides command SAMODE to allow opers to change modes on channels and users", VF_VENDOR);
 	}
 
-	ModResult OnPreMode(User* source,User* dest,Channel* channel, const std::vector<std::string>& parameters)
+	ModResult OnPreMode(User* source,User* dest,Channel* channel, const std::vector<std::string>& parameters) CXX11_OVERRIDE
 	{
 		if (cmd.active)
 			return MOD_RES_ALLOW;

--- a/src/modules/m_sanick.cpp
+++ b/src/modules/m_sanick.cpp
@@ -98,12 +98,12 @@ class ModuleSanick : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for SANICK command", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_sapart.cpp
+++ b/src/modules/m_sapart.cpp
@@ -109,12 +109,12 @@ class ModuleSapart : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides command SAPART to force-part users from a channel.", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_saquit.cpp
+++ b/src/modules/m_saquit.cpp
@@ -79,12 +79,12 @@ class ModuleSaquit : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for an SAQUIT command, exits user with a reason", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_sasl.cpp
+++ b/src/modules/m_sasl.cpp
@@ -256,7 +256,7 @@ class ModuleSASL : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		Implementation eventlist[] = { I_OnEvent, I_OnUserRegister, I_OnRehash };
@@ -269,12 +269,12 @@ class ModuleSASL : public Module
 			ServerInstance->Logs->Log("m_sasl", LOG_DEFAULT, "WARNING: m_services_account.so and m_cap.so are not loaded! m_sasl.so will NOT function correctly until these two modules are loaded!");
 	}
 
-	void OnRehash(User*)
+	void OnRehash(User*) CXX11_OVERRIDE
 	{
 		sasl_target = ServerInstance->Config->ConfValue("sasl")->getString("target", "*");
 	}
 
-	ModResult OnUserRegister(LocalUser *user)
+	ModResult OnUserRegister(LocalUser *user) CXX11_OVERRIDE
 	{
 		SaslAuthenticator *sasl_ = authExt.get(user);
 		if (sasl_)
@@ -286,12 +286,12 @@ class ModuleSASL : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for IRC Authentication Layer (aka: atheme SASL) via AUTHENTICATE.",VF_VENDOR);
 	}
 
-	void OnEvent(Event &ev)
+	void OnEvent(Event &ev) CXX11_OVERRIDE
 	{
 		cap.HandleEvent(ev);
 	}

--- a/src/modules/m_satopic.cpp
+++ b/src/modules/m_satopic.cpp
@@ -65,12 +65,12 @@ class ModuleSATopic : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides a SATOPIC command", VF_VENDOR);
 	}

--- a/src/modules/m_securelist.cpp
+++ b/src/modules/m_securelist.cpp
@@ -29,19 +29,19 @@ class ModuleSecureList : public Module
 	time_t WaitTime;
 
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		Implementation eventlist[] = { I_OnRehash, I_OnPreCommand, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Disallows /LIST for recently connected clients to hinder spam bots", VF_VENDOR);
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		allowlist.clear();
 
@@ -57,7 +57,7 @@ class ModuleSecureList : public Module
 	 * OnPreCommand()
 	 *   Intercept the LIST command.
 	 */
-	virtual ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		/* If the command doesnt appear to be valid, we dont want to mess with it. */
 		if (!validated)
@@ -82,7 +82,7 @@ class ModuleSecureList : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["SECURELIST"];
 	}

--- a/src/modules/m_seenicks.cpp
+++ b/src/modules/m_seenicks.cpp
@@ -26,19 +26,19 @@
 class ModuleSeeNicks : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->SNO->EnableSnomask('n',"NICK");
 		Implementation eventlist[] = { I_OnUserPostNick };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for seeing local and remote nickchanges via snomasks", VF_VENDOR);
 	}
 
-	virtual void OnUserPostNick(User* user, const std::string &oldnick)
+	void OnUserPostNick(User* user, const std::string &oldnick) CXX11_OVERRIDE
 	{
 		ServerInstance->SNO->WriteToSnoMask(IS_LOCAL(user) ? 'n' : 'N',"User %s changed their nickname to %s", oldnick.c_str(), user->nick.c_str());
 	}

--- a/src/modules/m_serverban.cpp
+++ b/src/modules/m_serverban.cpp
@@ -24,18 +24,18 @@
 class ModuleServerBan : public Module
 {
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnCheckBan, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Extban 's' - server ban",VF_OPTCOMMON|VF_VENDOR);
 	}
 
-	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask)
+	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask) CXX11_OVERRIDE
 	{
 		if ((mask.length() > 2) && (mask[0] == 's') && (mask[1] == ':'))
 		{
@@ -45,7 +45,7 @@ class ModuleServerBan : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('s');
 	}

--- a/src/modules/m_services_account.cpp
+++ b/src/modules/m_services_account.cpp
@@ -118,7 +118,7 @@ class ModuleServicesAccount : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServiceProvider* providerlist[] = { &m1, &m2, &m3, &m4, &m5, &accountname };
 		ServerInstance->Modules->AddServices(providerlist, sizeof(providerlist)/sizeof(ServiceProvider*));
@@ -128,14 +128,14 @@ class ModuleServicesAccount : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('R');
 		tokens["EXTBAN"].push_back('U');
 	}
 
 	/* <- :twisted.oscnet.org 330 w00t2 w00t2 w00t :is logged in as */
-	void OnWhois(User* source, User* dest)
+	void OnWhois(User* source, User* dest) CXX11_OVERRIDE
 	{
 		std::string *account = accountname.get(dest);
 
@@ -151,7 +151,7 @@ class ModuleServicesAccount : public Module
 		}
 	}
 
-	void OnUserPostNick(User* user, const std::string &oldnick)
+	void OnUserPostNick(User* user, const std::string &oldnick) CXX11_OVERRIDE
 	{
 		/* On nickchange, if they have +r, remove it */
 		if (user->IsModeSet('r') && assign(user->nick) != oldnick)
@@ -163,7 +163,7 @@ class ModuleServicesAccount : public Module
 		}
 	}
 
-	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user))
 			return MOD_RES_PASSTHRU;
@@ -197,7 +197,7 @@ class ModuleServicesAccount : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnCheckBan(User* user, Channel* chan, const std::string& mask)
+	ModResult OnCheckBan(User* user, Channel* chan, const std::string& mask) CXX11_OVERRIDE
 	{
 		static bool checking = false;
 		if (checking)
@@ -234,12 +234,12 @@ class ModuleServicesAccount : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return OnUserPreMessage(user, dest, target_type, text, status, exempt_list);
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		std::string *account = accountname.get(user);
 		bool is_registered = account && !account->empty();
@@ -266,7 +266,7 @@ class ModuleServicesAccount : public Module
 	// In our case we're only sending a single string around, so we just construct a std::string.
 	// Some modules will probably get much more complex and format more detailed structs and classes
 	// in a textual way for sending over the link.
-	void OnDecodeMetaData(Extensible* target, const std::string &extname, const std::string &extdata)
+	void OnDecodeMetaData(Extensible* target, const std::string &extname, const std::string &extdata) CXX11_OVERRIDE
 	{
 		User* dest = dynamic_cast<User*>(target);
 		// check if its our metadata key, and its associated with a user
@@ -290,14 +290,14 @@ class ModuleServicesAccount : public Module
 		}
 	}
 
-	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass)
+	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass) CXX11_OVERRIDE
 	{
 		if (myclass->config->getBool("requireaccount") && !accountname.get(user))
 			return MOD_RES_DENY;
 		return MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for ircu-style services accounts, including chmode +R, etc.",VF_OPTCOMMON|VF_VENDOR);
 	}

--- a/src/modules/m_servprotect.cpp
+++ b/src/modules/m_servprotect.cpp
@@ -53,19 +53,19 @@ class ModuleServProtectMode : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(bm);
 		Implementation eventlist[] = { I_OnWhois, I_OnKill, I_OnWhoisLine, I_OnRawMode, I_OnUserPreKick };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides usermode +k to protect services from kicks, kills, and mode changes.", VF_VENDOR);
 	}
 
-	void OnWhois(User* user, User* dest)
+	void OnWhois(User* user, User* dest) CXX11_OVERRIDE
 	{
 		if (dest->IsModeSet('k'))
 		{
@@ -73,7 +73,7 @@ class ModuleServProtectMode : public Module
 		}
 	}
 
-	ModResult OnRawMode(User* user, Channel* chan, const char mode, const std::string &param, bool adding, int pcnt)
+	ModResult OnRawMode(User* user, Channel* chan, const char mode, const std::string &param, bool adding, int pcnt) CXX11_OVERRIDE
 	{
 		/* Check that the mode is not a server mode, it is being removed, the user making the change is local, there is a parameter,
 		 * and the user making the change is not a uline
@@ -102,7 +102,7 @@ class ModuleServProtectMode : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnKill(User* src, User* dst, const std::string &reason)
+	ModResult OnKill(User* src, User* dst, const std::string &reason) CXX11_OVERRIDE
 	{
 		if (src == NULL)
 			return MOD_RES_PASSTHRU;
@@ -116,7 +116,7 @@ class ModuleServProtectMode : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnUserPreKick(User *src, Membership* memb, const std::string &reason)
+	ModResult OnUserPreKick(User *src, Membership* memb, const std::string &reason) CXX11_OVERRIDE
 	{
 		if (memb->user->IsModeSet('k'))
 		{
@@ -128,7 +128,7 @@ class ModuleServProtectMode : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnWhoisLine(User* src, User* dst, int &numeric, std::string &text)
+	ModResult OnWhoisLine(User* src, User* dst, int &numeric, std::string &text) CXX11_OVERRIDE
 	{
 		return ((src != dst) && (numeric == 319) && dst->IsModeSet('k')) ? MOD_RES_DENY : MOD_RES_PASSTHRU;
 	}

--- a/src/modules/m_sethost.cpp
+++ b/src/modules/m_sethost.cpp
@@ -77,7 +77,7 @@ class ModuleSetHost : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		ServerInstance->Modules->AddService(cmd);
@@ -85,7 +85,7 @@ class ModuleSetHost : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		std::string hmap = ServerInstance->Config->ConfValue("hostname")->getString("charmap", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.-_/0123456789");
 
@@ -94,7 +94,7 @@ class ModuleSetHost : public Module
 			hostmap[(unsigned char)*n] = 1;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the SETHOST command", VF_VENDOR);
 	}

--- a/src/modules/m_setident.cpp
+++ b/src/modules/m_setident.cpp
@@ -66,12 +66,12 @@ class ModuleSetIdent : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the SETIDENT command", VF_VENDOR);
 	}

--- a/src/modules/m_setidle.cpp
+++ b/src/modules/m_setidle.cpp
@@ -63,12 +63,12 @@ class ModuleSetIdle : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows opers to set their idle time", VF_VENDOR);
 	}

--- a/src/modules/m_setname.cpp
+++ b/src/modules/m_setname.cpp
@@ -62,12 +62,12 @@ class ModuleSetName : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the SETNAME command", VF_VENDOR);
 	}

--- a/src/modules/m_sha256.cpp
+++ b/src/modules/m_sha256.cpp
@@ -275,7 +275,7 @@ class ModuleSHA256 : public Module
 		ServerInstance->Modules->AddService(sha);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements SHA-256 hashing", VF_VENDOR);
 	}

--- a/src/modules/m_showwhois.cpp
+++ b/src/modules/m_showwhois.cpp
@@ -79,7 +79,7 @@ class ModuleShowwhois : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("showwhois");
 
@@ -98,12 +98,12 @@ class ModuleShowwhois : public Module
 		delete sw;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows opers to set +W to see when a user uses WHOIS on them",VF_OPTCOMMON|VF_VENDOR);
 	}
 
-	void OnWhois(User* source, User* dest)
+	void OnWhois(User* source, User* dest) CXX11_OVERRIDE
 	{
 		if (!dest->IsModeSet('W') || source == dest)
 			return;

--- a/src/modules/m_shun.cpp
+++ b/src/modules/m_shun.cpp
@@ -179,7 +179,7 @@ class ModuleShun : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->XLines->RegisterFactory(&f);
 		ServerInstance->Modules->AddService(cmd);
@@ -189,7 +189,7 @@ class ModuleShun : public Module
 		OnRehash(NULL);
 	}
 
-	virtual ~ModuleShun()
+	~ModuleShun()
 	{
 		ServerInstance->XLines->DelAll("SHUN");
 		ServerInstance->XLines->UnregisterFactory(&f);
@@ -201,7 +201,7 @@ class ModuleShun : public Module
 		ServerInstance->Modules->SetPriority(this, I_OnPreCommand, PRIORITY_BEFORE, &alias);
 	}
 
-	virtual ModResult OnStats(char symbol, User* user, string_list& out)
+	ModResult OnStats(char symbol, User* user, string_list& out) CXX11_OVERRIDE
 	{
 		if (symbol != 'H')
 			return MOD_RES_PASSTHRU;
@@ -210,7 +210,7 @@ class ModuleShun : public Module
 		return MOD_RES_DENY;
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("shun");
 		std::string cmds = tag->getString("enabledcommands");
@@ -233,7 +233,7 @@ class ModuleShun : public Module
 		affectopers = tag->getBool("affectopers", false);
 	}
 
-	virtual ModResult OnPreCommand(std::string &command, std::vector<std::string>& parameters, LocalUser* user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string>& parameters, LocalUser* user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		if (validated)
 			return MOD_RES_PASSTHRU;
@@ -274,7 +274,7 @@ class ModuleShun : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the /SHUN command, which stops a user from executing all except configured commands.",VF_VENDOR|VF_COMMON);
 	}

--- a/src/modules/m_silence.cpp
+++ b/src/modules/m_silence.cpp
@@ -302,7 +302,7 @@ class ModuleSilence : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		ServerInstance->Modules->AddService(cmdsilence);
@@ -313,14 +313,14 @@ class ModuleSilence : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		maxsilence = ServerInstance->Config->ConfValue("showwhois")->getInt("maxentries", 32);
 		if (!maxsilence)
 			maxsilence = 32;
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["ESILENCE"];
 		tokens["SILENCE"] = ConvToStr(maxsilence);
@@ -360,17 +360,17 @@ class ModuleSilence : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return PreText(user, dest, target_type, text, status, exempt_list, SILENCE_PRIVATE);
 	}
 
-	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return PreText(user, dest, target_type, text, status, exempt_list, SILENCE_NOTICE);
 	}
 
-	ModResult OnUserPreInvite(User* source,User* dest,Channel* channel, time_t timeout)
+	ModResult OnUserPreInvite(User* source,User* dest,Channel* channel, time_t timeout) CXX11_OVERRIDE
 	{
 		return MatchPattern(dest, source, SILENCE_INVITE);
 	}
@@ -393,7 +393,7 @@ class ModuleSilence : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the /SILENCE command", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_spanningtree/cachetimer.h
+++ b/src/modules/m_spanningtree/cachetimer.h
@@ -31,5 +31,5 @@ class CacheRefreshTimer : public Timer
 	SpanningTreeUtilities *Utils;
  public:
 	CacheRefreshTimer(SpanningTreeUtilities* Util);
-	virtual bool Tick(time_t TIME);
+	bool Tick(time_t TIME);
 };

--- a/src/modules/m_spanningtree/main.h
+++ b/src/modules/m_spanningtree/main.h
@@ -67,7 +67,7 @@ class ModuleSpanningTree : public Module
 	/** Constructor
 	 */
 	ModuleSpanningTree();
-	void init();
+	void init() CXX11_OVERRIDE;
 
 	/** Shows /LINKS
 	 */
@@ -141,41 +141,41 @@ class ModuleSpanningTree : public Module
 	 ** *** MODULE EVENTS ***
 	 **/
 
-	ModResult OnPreCommand(std::string &command, std::vector<std::string>& parameters, LocalUser *user, bool validated, const std::string &original_line);
-	void OnPostCommand(const std::string &command, const std::vector<std::string>& parameters, LocalUser *user, CmdResult result, const std::string &original_line);
-	void OnGetServerDescription(const std::string &servername,std::string &description);
-	void OnUserConnect(LocalUser* source);
-	void OnUserInvite(User* source,User* dest,Channel* channel, time_t);
-	void OnPostTopicChange(User* user, Channel* chan, const std::string &topic);
-	void OnWallops(User* user, const std::string &text);
-	void OnUserNotice(User* user, void* dest, int target_type, const std::string &text, char status, const CUList &exempt_list);
-	void OnUserMessage(User* user, void* dest, int target_type, const std::string &text, char status, const CUList &exempt_list);
-	void OnBackgroundTimer(time_t curtime);
-	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& excepts);
-	void OnChangeHost(User* user, const std::string &newhost);
-	void OnChangeName(User* user, const std::string &gecos);
-	void OnChangeIdent(User* user, const std::string &ident);
-	void OnUserPart(Membership* memb, std::string &partmessage, CUList& excepts);
-	void OnUserQuit(User* user, const std::string &reason, const std::string &oper_message);
-	void OnUserPostNick(User* user, const std::string &oldnick);
-	void OnUserKick(User* source, Membership* memb, const std::string &reason, CUList& excepts);
-	void OnRemoteKill(User* source, User* dest, const std::string &reason, const std::string &operreason);
-	void OnPreRehash(User* user, const std::string &parameter);
-	void OnRehash(User* user);
-	void OnOper(User* user, const std::string &opertype);
+	ModResult OnPreCommand(std::string &command, std::vector<std::string>& parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE;
+	void OnPostCommand(const std::string &command, const std::vector<std::string>& parameters, LocalUser *user, CmdResult result, const std::string &original_line) CXX11_OVERRIDE;
+	void OnGetServerDescription(const std::string &servername,std::string &description) CXX11_OVERRIDE;
+	void OnUserConnect(LocalUser* source) CXX11_OVERRIDE;
+	void OnUserInvite(User* source,User* dest,Channel* channel, time_t) CXX11_OVERRIDE;
+	void OnPostTopicChange(User* user, Channel* chan, const std::string &topic) CXX11_OVERRIDE;
+	void OnWallops(User* user, const std::string &text) CXX11_OVERRIDE;
+	void OnUserNotice(User* user, void* dest, int target_type, const std::string &text, char status, const CUList &exempt_list) CXX11_OVERRIDE;
+	void OnUserMessage(User* user, void* dest, int target_type, const std::string &text, char status, const CUList &exempt_list) CXX11_OVERRIDE;
+	void OnBackgroundTimer(time_t curtime) CXX11_OVERRIDE;
+	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& excepts) CXX11_OVERRIDE;
+	void OnChangeHost(User* user, const std::string &newhost) CXX11_OVERRIDE;
+	void OnChangeName(User* user, const std::string &gecos) CXX11_OVERRIDE;
+	void OnChangeIdent(User* user, const std::string &ident) CXX11_OVERRIDE;
+	void OnUserPart(Membership* memb, std::string &partmessage, CUList& excepts) CXX11_OVERRIDE;
+	void OnUserQuit(User* user, const std::string &reason, const std::string &oper_message) CXX11_OVERRIDE;
+	void OnUserPostNick(User* user, const std::string &oldnick) CXX11_OVERRIDE;
+	void OnUserKick(User* source, Membership* memb, const std::string &reason, CUList& excepts) CXX11_OVERRIDE;
+	void OnRemoteKill(User* source, User* dest, const std::string &reason, const std::string &operreason) CXX11_OVERRIDE;
+	void OnPreRehash(User* user, const std::string &parameter) CXX11_OVERRIDE;
+	void OnRehash(User* user) CXX11_OVERRIDE;
+	void OnOper(User* user, const std::string &opertype) CXX11_OVERRIDE;
 	void OnLine(User* source, const std::string &host, bool adding, char linetype, long duration, const std::string &reason);
-	void OnAddLine(User *u, XLine *x);
-	void OnDelLine(User *u, XLine *x);
-	void OnMode(User* user, void* dest, int target_type, const std::vector<std::string> &text, const std::vector<TranslateType> &translate);
-	ModResult OnStats(char statschar, User* user, string_list &results);
-	ModResult OnSetAway(User* user, const std::string &awaymsg);
+	void OnAddLine(User *u, XLine *x) CXX11_OVERRIDE;
+	void OnDelLine(User *u, XLine *x) CXX11_OVERRIDE;
+	void OnMode(User* user, void* dest, int target_type, const std::vector<std::string> &text, const std::vector<TranslateType> &translate) CXX11_OVERRIDE;
+	ModResult OnStats(char statschar, User* user, string_list &results) CXX11_OVERRIDE;
+	ModResult OnSetAway(User* user, const std::string &awaymsg) CXX11_OVERRIDE;
 	void ProtoSendMode(void* opaque, TargetTypeFlags target_type, void* target, const std::vector<std::string> &modeline, const std::vector<TranslateType> &translate);
 	void ProtoSendMetaData(void* opaque, Extensible* target, const std::string &extname, const std::string &extdata);
-	void OnLoadModule(Module* mod);
-	void OnUnloadModule(Module* mod);
-	ModResult OnAcceptConnection(int newsock, ListenSocket* from, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server);
+	void OnLoadModule(Module* mod) CXX11_OVERRIDE;
+	void OnUnloadModule(Module* mod) CXX11_OVERRIDE;
+	ModResult OnAcceptConnection(int newsock, ListenSocket* from, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server) CXX11_OVERRIDE;
 	CullResult cull();
 	~ModuleSpanningTree();
-	Version GetVersion();
+	Version GetVersion() CXX11_OVERRIDE;
 	void Prioritize();
 };

--- a/src/modules/m_spanningtree/protocolinterface.h
+++ b/src/modules/m_spanningtree/protocolinterface.h
@@ -28,17 +28,16 @@ class SpanningTreeProtocolInterface : public ProtocolInterface
 	void SendChannel(Channel* target, char status, const std::string &text);
  public:
 	SpanningTreeProtocolInterface(SpanningTreeUtilities* util) : Utils(util) { }
-	virtual ~SpanningTreeProtocolInterface() { }
 
-	virtual bool SendEncapsulatedData(const parameterlist &encap);
-	virtual void SendMetaData(Extensible* target, const std::string &key, const std::string &data);
-	virtual void SendTopic(Channel* channel, std::string &topic);
-	virtual void SendMode(const std::string &target, const parameterlist &modedata, const std::vector<TranslateType> &types);
-	virtual void SendSNONotice(const std::string &snomask, const std::string &text);
-	virtual void PushToClient(User* target, const std::string &rawline);
-	virtual void SendChannelPrivmsg(Channel* target, char status, const std::string &text);
-	virtual void SendChannelNotice(Channel* target, char status, const std::string &text);
-	virtual void SendUserPrivmsg(User* target, const std::string &text);
-	virtual void SendUserNotice(User* target, const std::string &text);
-	virtual void GetServerList(ProtoServerList &sl);
+	bool SendEncapsulatedData(const parameterlist &encap);
+	void SendMetaData(Extensible* target, const std::string &key, const std::string &data);
+	void SendTopic(Channel* channel, std::string &topic);
+	void SendMode(const std::string &target, const parameterlist &modedata, const std::vector<TranslateType> &types);
+	void SendSNONotice(const std::string &snomask, const std::string &text);
+	void PushToClient(User* target, const std::string &rawline);
+	void SendChannelPrivmsg(Channel* target, char status, const std::string &text);
+	void SendChannelNotice(Channel* target, char status, const std::string &text);
+	void SendUserPrivmsg(User* target, const std::string &text);
+	void SendUserNotice(User* target, const std::string &text);
+	void GetServerList(ProtoServerList &sl);
 };

--- a/src/modules/m_spanningtree/resolvers.h
+++ b/src/modules/m_spanningtree/resolvers.h
@@ -38,8 +38,8 @@ class SecurityIPResolver : public DNS::Request
 	DNS::QueryType query;
  public:
 	SecurityIPResolver(Module* me, SpanningTreeUtilities* U, DNS::Manager *mgr, const std::string &hostname, Link* x, DNS::QueryType qt);
-	void OnLookupComplete(const DNS::Query *r);
-	void OnError(const DNS::Query *q);
+	void OnLookupComplete(const DNS::Query *r) CXX11_OVERRIDE;
+	void OnError(const DNS::Query *q) CXX11_OVERRIDE;
 };
 
 /** This class is used to resolve server hostnames during /connect and autoconnect.
@@ -58,6 +58,6 @@ class ServernameResolver : public DNS::Request
 	reference<Autoconnect> myautoconnect;
  public:
 	ServernameResolver(SpanningTreeUtilities* Util, DNS::Manager *mgr, const std::string &hostname, Link* x, DNS::QueryType qt, Autoconnect* myac);
-	void OnLookupComplete(const DNS::Query *r);
-	void OnError(const DNS::Query *q);
+	void OnLookupComplete(const DNS::Query *r) CXX11_OVERRIDE;
+	void OnError(const DNS::Query *q) CXX11_OVERRIDE;
 };

--- a/src/modules/m_spanningtree/treesocket.h
+++ b/src/modules/m_spanningtree/treesocket.h
@@ -163,11 +163,11 @@ class TreeSocket : public BufferedSocket
 	 * to server docs on the inspircd.org site, the other side
 	 * will then send back its own server string.
 	 */
-	virtual void OnConnected();
+	void OnConnected();
 
 	/** Handle socket error event
 	 */
-	virtual void OnError(BufferedSocketError e);
+	void OnError(BufferedSocketError e) CXX11_OVERRIDE;
 
 	/** Sends an error to the remote server, and displays it locally to show
 	 * that it was sent.
@@ -312,10 +312,10 @@ class TreeSocket : public BufferedSocket
 
 	/** Handle socket timeout from connect()
 	 */
-	virtual void OnTimeout();
+	void OnTimeout();
 	/** Handle server quit on close
 	 */
-	virtual void Close();
+	void Close();
 
 	/** Returns true if this server was introduced to the rest of the network
 	 */

--- a/src/modules/m_sqlauth.cpp
+++ b/src/modules/m_sqlauth.cpp
@@ -40,7 +40,7 @@ class AuthQuery : public SQLQuery
 	{
 	}
 
-	void OnResult(SQLResult& res)
+	void OnResult(SQLResult& res) CXX11_OVERRIDE
 	{
 		User* user = ServerInstance->FindNick(uid);
 		if (!user)
@@ -57,7 +57,7 @@ class AuthQuery : public SQLQuery
 		}
 	}
 
-	void OnError(SQLerror& error)
+	void OnError(SQLerror& error) CXX11_OVERRIDE
 	{
 		User* user = ServerInstance->FindNick(uid);
 		if (!user)
@@ -83,7 +83,7 @@ class ModuleSQLAuth : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(pendingExt);
 		OnRehash(NULL);
@@ -91,7 +91,7 @@ class ModuleSQLAuth : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* conf = ServerInstance->Config->ConfValue("sqlauth");
 		std::string dbid = conf->getString("dbid");
@@ -105,7 +105,7 @@ class ModuleSQLAuth : public Module
 		verbose = conf->getBool("verbose");
 	}
 
-	ModResult OnUserRegister(LocalUser* user)
+	ModResult OnUserRegister(LocalUser* user) CXX11_OVERRIDE
 	{
 		// Note this is their initial (unresolved) connect block
 		ConfigTag* tag = user->MyClass->config;
@@ -144,7 +144,7 @@ class ModuleSQLAuth : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user) CXX11_OVERRIDE
 	{
 		switch (pendingExt.get(user))
 		{
@@ -159,7 +159,7 @@ class ModuleSQLAuth : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allow/Deny connections based upon an arbitrary SQL table", VF_VENDOR);
 	}

--- a/src/modules/m_sqloper.cpp
+++ b/src/modules/m_sqloper.cpp
@@ -32,7 +32,7 @@ class OpMeQuery : public SQLQuery
 	{
 	}
 
-	void OnResult(SQLResult& res)
+	void OnResult(SQLResult& res) CXX11_OVERRIDE
 	{
 		ServerInstance->Logs->Log("m_sqloper",LOG_DEBUG, "SQLOPER: result for %s", uid.c_str());
 		User* user = ServerInstance->FindNick(uid);
@@ -51,7 +51,7 @@ class OpMeQuery : public SQLQuery
 		fallback();
 	}
 
-	void OnError(SQLerror& error)
+	void OnError(SQLerror& error) CXX11_OVERRIDE
 	{
 		ServerInstance->Logs->Log("m_sqloper",LOG_DEFAULT, "SQLOPER: query failed (%s)", error.Str());
 		fallback();
@@ -113,7 +113,7 @@ class ModuleSQLOper : public Module
 public:
 	ModuleSQLOper() : SQL(this, "SQL") {}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 
@@ -121,7 +121,7 @@ public:
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("sqloper");
 
@@ -135,7 +135,7 @@ public:
 		query = tag->getString("query", "SELECT hostname as host, type FROM ircd_opers WHERE username='$username' AND password='$password'");
 	}
 
-	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		if (validated && command == "OPER" && parameters.size() >= 2)
 		{
@@ -162,7 +162,7 @@ public:
 		SQL->submit(new OpMeQuery(this, user->uuid, username, password), query, userinfo);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Allows storage of oper credentials in an SQL table", VF_VENDOR);
 	}

--- a/src/modules/m_sslinfo.cpp
+++ b/src/modules/m_sslinfo.cpp
@@ -130,7 +130,7 @@ class ModuleSSLInfo : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 
@@ -140,12 +140,12 @@ class ModuleSSLInfo : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("SSL Certificate Utilities", VF_VENDOR);
 	}
 
-	void OnWhois(User* source, User* dest)
+	void OnWhois(User* source, User* dest) CXX11_OVERRIDE
 	{
 		ssl_cert* cert = cmd.CertExt.get(dest);
 		if (cert)
@@ -158,7 +158,7 @@ class ModuleSSLInfo : public Module
 		}
 	}
 
-	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		if ((command == "OPER") && (validated))
 		{
@@ -189,7 +189,7 @@ class ModuleSSLInfo : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnUserConnect(LocalUser* user)
+	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
 	{
 		SocketCertificateRequest req(&user->eh, this);
 		if (!req.cert)
@@ -197,7 +197,7 @@ class ModuleSSLInfo : public Module
 		cmd.CertExt.set(user, req.cert);
 	}
 
-	void OnPostConnect(User* user)
+	void OnPostConnect(User* user) CXX11_OVERRIDE
 	{
 		ssl_cert *cert = cmd.CertExt.get(user);
 		if (!cert || cert->fingerprint.empty())
@@ -212,7 +212,7 @@ class ModuleSSLInfo : public Module
 		}
 	}
 
-	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass)
+	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass) CXX11_OVERRIDE
 	{
 		SocketCertificateRequest req(&user->eh, this);
 		bool ok = true;
@@ -230,7 +230,7 @@ class ModuleSSLInfo : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnRequest(Request& request)
+	void OnRequest(Request& request) CXX11_OVERRIDE
 	{
 		if (strcmp("GET_USER_CERT", request.id) == 0)
 		{

--- a/src/modules/m_sslmodes.cpp
+++ b/src/modules/m_sslmodes.cpp
@@ -85,14 +85,14 @@ class ModuleSSLModes : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(sslm);
 		Implementation eventlist[] = { I_OnUserPreJoin, I_OnCheckBan, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
 	{
 		if(chan && chan->IsModeSet('z'))
 		{
@@ -114,7 +114,7 @@ class ModuleSSLModes : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask)
+	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask) CXX11_OVERRIDE
 	{
 		if ((mask.length() > 2) && (mask[0] == 'z') && (mask[1] == ':'))
 		{
@@ -126,12 +126,12 @@ class ModuleSSLModes : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('z');
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel mode +z to allow for Secure/SSL only channels", VF_VENDOR);
 	}

--- a/src/modules/m_stripcolor.cpp
+++ b/src/modules/m_stripcolor.cpp
@@ -50,7 +50,7 @@ class ModuleStripColor : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(usc);
 		ServerInstance->Modules->AddService(csc);
@@ -58,12 +58,12 @@ class ModuleStripColor : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["EXTBAN"].push_back('S');
 	}
 
-	virtual ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreMessage(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user))
 			return MOD_RES_PASSTHRU;
@@ -93,12 +93,12 @@ class ModuleStripColor : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list)
+	ModResult OnUserPreNotice(User* user,void* dest,int target_type, std::string &text, char status, CUList &exempt_list) CXX11_OVERRIDE
 	{
 		return OnUserPreMessage(user,dest,target_type,text,status,exempt_list);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides channel +S mode (strip ansi color)", VF_VENDOR);
 	}

--- a/src/modules/m_svshold.cpp
+++ b/src/modules/m_svshold.cpp
@@ -159,7 +159,7 @@ class ModuleSVSHold : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->XLines->RegisterFactory(&s);
 		ServerInstance->Modules->AddService(cmd);
@@ -167,7 +167,7 @@ class ModuleSVSHold : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual ModResult OnStats(char symbol, User* user, string_list &out)
+	ModResult OnStats(char symbol, User* user, string_list &out) CXX11_OVERRIDE
 	{
 		if(symbol != 'S')
 			return MOD_RES_PASSTHRU;
@@ -176,7 +176,7 @@ class ModuleSVSHold : public Module
 		return MOD_RES_DENY;
 	}
 
-	virtual ModResult OnUserPreNick(User *user, const std::string &newnick)
+	ModResult OnUserPreNick(User *user, const std::string &newnick) CXX11_OVERRIDE
 	{
 		XLine *rl = ServerInstance->XLines->MatchesLine("SVSHOLD", newnick);
 
@@ -189,13 +189,13 @@ class ModuleSVSHold : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual ~ModuleSVSHold()
+	~ModuleSVSHold()
 	{
 		ServerInstance->XLines->DelAll("SVSHOLD");
 		ServerInstance->XLines->UnregisterFactory(&s);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements SVSHOLD. Like Q:Lines, but can only be added/removed by Services.", VF_COMMON | VF_VENDOR);
 	}

--- a/src/modules/m_swhois.cpp
+++ b/src/modules/m_swhois.cpp
@@ -90,7 +90,7 @@ class ModuleSWhois : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		ServerInstance->Modules->AddService(cmd.swhois);
@@ -99,7 +99,7 @@ class ModuleSWhois : public Module
 	}
 
 	// :kenny.chatspike.net 320 Brain Azhrarn :is getting paid to play games.
-	ModResult OnWhoisLine(User* user, User* dest, int &numeric, std::string &text)
+	ModResult OnWhoisLine(User* user, User* dest, int &numeric, std::string &text) CXX11_OVERRIDE
 	{
 		/* We use this and not OnWhois because this triggers for remote, too */
 		if (numeric == 312)
@@ -116,7 +116,7 @@ class ModuleSWhois : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnPostOper(User* user, const std::string &opertype, const std::string &opername)
+	void OnPostOper(User* user, const std::string &opertype, const std::string &opername) CXX11_OVERRIDE
 	{
 		if (!IS_LOCAL(user))
 			return;
@@ -130,7 +130,7 @@ class ModuleSWhois : public Module
 		ServerInstance->PI->SendMetaData(user, "swhois", swhois);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the SWHOIS command which allows setting of arbitrary WHOIS lines", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_testnet.cpp
+++ b/src/modules/m_testnet.cpp
@@ -214,14 +214,14 @@ class ModuleTest : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		if (!strstr(ServerInstance->Config->ServerName.c_str(), ".test"))
 			throw ModuleException("Don't load modules without reading their descriptions!");
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides a module for testing the server while linked in a network", VF_VENDOR|VF_OPTCOMMON);
 	}

--- a/src/modules/m_timedbans.cpp
+++ b/src/modules/m_timedbans.cpp
@@ -151,7 +151,7 @@ class ModuleTimedBans : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		Implementation eventlist[] = { I_OnBackgroundTimer };
@@ -164,7 +164,7 @@ class ModuleTimedBans : public Module
 		ServerInstance->Modes->DelModeWatcher(&banwatcher);
 	}
 
-	virtual void OnBackgroundTimer(time_t curtime)
+	void OnBackgroundTimer(time_t curtime) CXX11_OVERRIDE
 	{
 		timedbans expired;
 		for (timedbans::iterator i = TimedBanList.begin(); i != TimedBanList.end();)
@@ -200,7 +200,7 @@ class ModuleTimedBans : public Module
 		}
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Adds timed bans", VF_COMMON | VF_VENDOR);
 	}

--- a/src/modules/m_tline.cpp
+++ b/src/modules/m_tline.cpp
@@ -75,12 +75,12 @@ class ModuleTLine : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides /tline command used to test who a mask matches", VF_VENDOR);
 	}

--- a/src/modules/m_topiclock.cpp
+++ b/src/modules/m_topiclock.cpp
@@ -96,7 +96,7 @@ class FlagExtItem : public ExtensionItem
 	{
 	}
 
-	virtual ~FlagExtItem()
+	~FlagExtItem()
 	{
 	}
 
@@ -151,14 +151,14 @@ class ModuleTopicLock : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		ServerInstance->Modules->AddService(topiclock);
 		ServerInstance->Modules->Attach(I_OnPreTopicChange, this);
 	}
 
-	ModResult OnPreTopicChange(User* user, Channel* chan, const std::string &topic)
+	ModResult OnPreTopicChange(User* user, Channel* chan, const std::string &topic) CXX11_OVERRIDE
 	{
 		// Only fired for local users currently, but added a check anyway
 		if ((IS_LOCAL(user)) && (topiclock.get(chan)))
@@ -170,7 +170,7 @@ class ModuleTopicLock : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements server-side topic locks and the server-to-server command SVSTOPIC", VF_COMMON | VF_VENDOR);
 	}

--- a/src/modules/m_uhnames.cpp
+++ b/src/modules/m_uhnames.cpp
@@ -33,23 +33,23 @@ class ModuleUHNames : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		Implementation eventlist[] = { I_OnEvent, I_OnPreCommand, I_OnNamesListItem, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the UHNAMES facility.",VF_VENDOR);
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["UHNAMES"];
 	}
 
-	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line)
+	ModResult OnPreCommand(std::string &command, std::vector<std::string> &parameters, LocalUser *user, bool validated, const std::string &original_line) CXX11_OVERRIDE
 	{
 		/* We don't actually create a proper command handler class for PROTOCTL,
 		 * because other modules might want to have PROTOCTL hooks too.
@@ -67,7 +67,7 @@ class ModuleUHNames : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnNamesListItem(User* issuer, Membership* memb, std::string &prefixes, std::string &nick)
+	void OnNamesListItem(User* issuer, Membership* memb, std::string &prefixes, std::string &nick) CXX11_OVERRIDE
 	{
 		if (!cap.ext.get(issuer))
 			return;
@@ -78,7 +78,7 @@ class ModuleUHNames : public Module
 		nick = memb->user->GetFullHost();
 	}
 
-	void OnEvent(Event& ev)
+	void OnEvent(Event& ev) CXX11_OVERRIDE
 	{
 		cap.HandleEvent(ev);
 	}

--- a/src/modules/m_uninvite.cpp
+++ b/src/modules/m_uninvite.cpp
@@ -104,12 +104,12 @@ class ModuleUninvite : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the UNINVITE command which lets users un-invite other users from channels", VF_VENDOR | VF_OPTCOMMON);
 	}

--- a/src/modules/m_userip.cpp
+++ b/src/modules/m_userip.cpp
@@ -70,19 +70,19 @@ class ModuleUserIP : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 		Implementation eventlist[] = { I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["USERIP"];
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for USERIP command",VF_VENDOR);
 	}

--- a/src/modules/m_vhost.cpp
+++ b/src/modules/m_vhost.cpp
@@ -70,12 +70,12 @@ class ModuleVHost : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->AddService(cmd);
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides masking of user hostnames via traditional /VHOST command",VF_VENDOR);
 	}

--- a/src/modules/m_watch.cpp
+++ b/src/modules/m_watch.cpp
@@ -377,7 +377,7 @@ class Modulewatch : public Module
 		whos_watching_me = new watchentries();
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		OnRehash(NULL);
 		ServerInstance->Modules->AddService(cmdw);
@@ -387,14 +387,14 @@ class Modulewatch : public Module
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
-	virtual void OnRehash(User* user)
+	void OnRehash(User* user) CXX11_OVERRIDE
 	{
 		maxwatch = ServerInstance->Config->ConfValue("watch")->getInt("maxentries", 32);
 		if (!maxwatch)
 			maxwatch = 32;
 	}
 
-	virtual ModResult OnSetAway(User *user, const std::string &awaymsg)
+	ModResult OnSetAway(User *user, const std::string &awaymsg) CXX11_OVERRIDE
 	{
 		std::string numeric;
 		int inum;
@@ -422,7 +422,7 @@ class Modulewatch : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	virtual void OnUserQuit(User* user, const std::string &reason, const std::string &oper_message)
+	void OnUserQuit(User* user, const std::string &reason, const std::string &oper_message) CXX11_OVERRIDE
 	{
 		watchentries::iterator x = whos_watching_me->find(user->nick.c_str());
 		if (x != whos_watching_me->end())
@@ -462,7 +462,7 @@ class Modulewatch : public Module
 		}
 	}
 
-	virtual void OnGarbageCollect()
+	void OnGarbageCollect()
 	{
 		watchentries* old_watch = whos_watching_me;
 		whos_watching_me = new watchentries();
@@ -473,7 +473,7 @@ class Modulewatch : public Module
 		delete old_watch;
 	}
 
-	virtual void OnPostConnect(User* user)
+	void OnPostConnect(User* user) CXX11_OVERRIDE
 	{
 		watchentries::iterator x = whos_watching_me->find(user->nick.c_str());
 		if (x != whos_watching_me->end())
@@ -490,7 +490,7 @@ class Modulewatch : public Module
 		}
 	}
 
-	virtual void OnUserPostNick(User* user, const std::string &oldnick)
+	void OnUserPostNick(User* user, const std::string &oldnick) CXX11_OVERRIDE
 	{
 		watchentries::iterator new_offline = whos_watching_me->find(oldnick.c_str());
 		watchentries::iterator new_online = whos_watching_me->find(user->nick.c_str());
@@ -522,17 +522,17 @@ class Modulewatch : public Module
 		}
 	}
 
-	virtual void On005Numeric(std::map<std::string, std::string>& tokens)
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
 	{
 		tokens["WATCH"] = ConvToStr(maxwatch);
 	}
 
-	virtual ~Modulewatch()
+	~Modulewatch()
 	{
 		delete whos_watching_me;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the /WATCH command", VF_OPTCOMMON | VF_VENDOR);
 	}

--- a/src/modules/m_xline_db.cpp
+++ b/src/modules/m_xline_db.cpp
@@ -30,7 +30,7 @@ class ModuleXLineDB : public Module
 	bool dirty;
 	std::string xlinedbpath;
  public:
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		/* Load the configuration
 		 * Note:
@@ -54,7 +54,7 @@ class ModuleXLineDB : public Module
 	 * @param source The sender of the line or NULL for local server
 	 * @param line The xline being added
 	 */
-	void OnAddLine(User* source, XLine* line)
+	void OnAddLine(User* source, XLine* line) CXX11_OVERRIDE
 	{
 		dirty = true;
 	}
@@ -64,17 +64,17 @@ class ModuleXLineDB : public Module
 	 * @param source The user removing the line or NULL for local server
 	 * @param line the line being deleted
 	 */
-	void OnDelLine(User* source, XLine* line)
+	void OnDelLine(User* source, XLine* line) CXX11_OVERRIDE
 	{
 		dirty = true;
 	}
 
-	void OnExpireLine(XLine *line)
+	void OnExpireLine(XLine *line) CXX11_OVERRIDE
 	{
 		dirty = true;
 	}
 
-	void OnBackgroundTimer(time_t now)
+	void OnBackgroundTimer(time_t now) CXX11_OVERRIDE
 	{
 		if (dirty)
 		{
@@ -252,7 +252,7 @@ class ModuleXLineDB : public Module
 		return true;
 	}
 
-	virtual Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Keeps a dynamic log of all XLines created, and stores them in a separate conf file (xline.db).", VF_VENDOR);
 	}


### PR DESCRIPTION
When overriding virtual methods the virtual keyword is not needed but for some reason we were using it in a ton of modules.
