### PR TITLE
Add method for writing server notices.

### DIFF
--- a/include/users.h
+++ b/include/users.h
@@ -543,6 +543,11 @@ class CoreExport User : public Extensible
 	 */
 	void WriteServ(const char* text, ...) CUSTOM_PRINTF(2, 3);
 
+	/** Sends a server notice to this user.
+	 * @param text The contents of the message to send.
+	 */
+	void WriteNotice(const std::string& text);
+
 	void WriteNumeric(unsigned int numeric, const char* text, ...) CUSTOM_PRINTF(3, 4);
 
 	void WriteNumeric(unsigned int numeric, const std::string &text);

--- a/src/commands/cmd_eline.cpp
+++ b/src/commands/cmd_eline.cpp
@@ -60,11 +60,11 @@ CmdResult CommandEline::Handle (const std::vector<std::string>& parameters, User
 		else
 			ih = ServerInstance->XLines->IdentSplit(target);
 
-        if (ih.first.empty())
-        {
-            user->WriteServ("NOTICE %s :*** Target not found", user->nick.c_str());
-            return CMD_FAILURE;
-        }
+		if (ih.first.empty())
+		{
+			user->WriteNotice("*** Target not found");
+			return CMD_FAILURE;
+		}
 
 		if (ServerInstance->HostMatchesEveryone(ih.first+"@"+ih.second,user))
 			return CMD_FAILURE;
@@ -88,7 +88,7 @@ CmdResult CommandEline::Handle (const std::vector<std::string>& parameters, User
 		else
 		{
 			delete el;
-			user->WriteServ("NOTICE %s :*** E-Line for %s already exists",user->nick.c_str(),target.c_str());
+			user->WriteNotice("*** E-Line for " + target + " already exists");
 		}
 	}
 	else
@@ -99,7 +99,7 @@ CmdResult CommandEline::Handle (const std::vector<std::string>& parameters, User
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** E-Line %s not found in list, try /stats e.",user->nick.c_str(),target.c_str());
+			user->WriteNotice("*** E-Line " + target + " not found in list, try /stats e");
 		}
 	}
 

--- a/src/commands/cmd_gline.cpp
+++ b/src/commands/cmd_gline.cpp
@@ -63,7 +63,7 @@ CmdResult CommandGline::Handle (const std::vector<std::string>& parameters, User
 
 		if (ih.first.empty())
 		{
-			user->WriteServ("NOTICE %s :*** Target not found", user->nick.c_str());
+			user->WriteNotice("*** Target not found");
 			return CMD_FAILURE;
 		}
 
@@ -72,7 +72,7 @@ CmdResult CommandGline::Handle (const std::vector<std::string>& parameters, User
 
 		else if (target.find('!') != std::string::npos)
 		{
-			user->WriteServ("NOTICE %s :*** G-Line cannot operate on nick!user@host masks",user->nick.c_str());
+			user->WriteNotice("*** G-Line cannot operate on nick!user@host masks");
 			return CMD_FAILURE;
 		}
 
@@ -97,7 +97,7 @@ CmdResult CommandGline::Handle (const std::vector<std::string>& parameters, User
 		else
 		{
 			delete gl;
-			user->WriteServ("NOTICE %s :*** G-Line for %s already exists",user->nick.c_str(),target.c_str());
+			user->WriteNotice("** G-Line for " + target + " already exists");
 		}
 
 	}
@@ -109,7 +109,7 @@ CmdResult CommandGline::Handle (const std::vector<std::string>& parameters, User
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** G-line %s not found in list, try /stats g.",user->nick.c_str(),target.c_str());
+			user->WriteNotice("*** G-Line " + target + " not found in list, try /stats g.");
 		}
 	}
 

--- a/src/commands/cmd_hostname_lookup.cpp
+++ b/src/commands/cmd_hostname_lookup.cpp
@@ -94,7 +94,7 @@ class UserResolver : public DNS::Request
 				delete res_forward;
 				ServerInstance->Logs->Log("RESOLVER", LOG_DEBUG,"Error in resolver: %s",e.GetReason());
 
-				bound_user->WriteServ("NOTICE Auth :*** There was an internal error resolving your host, using your IP address (%s) instead.", bound_user->GetIPString().c_str());
+				bound_user->WriteNotice("*** There was an internal error resolving your host, using your IP address (" + bound_user->GetIPString() + ") instead.");
 				dl->set(bound_user, 0);
 			}
 		}
@@ -130,7 +130,7 @@ class UserResolver : public DNS::Request
 				if (hostname == NULL)
 				{
 					ServerInstance->Logs->Log("RESOLVER", LOG_DEFAULT, "ERROR: User has no hostname attached when doing a forward lookup");
-					bound_user->WriteServ("NOTICE Auth :*** There was an internal error resolving your host, using your IP address (%s) instead.", bound_user->GetIPString().c_str());
+					bound_user->WriteNotice("*** There was an internal error resolving your host, using your IP address (" + bound_user->GetIPString() + ") instead.");
 					return;
 				}
 				else if (hostname->length() < 65)
@@ -139,7 +139,7 @@ class UserResolver : public DNS::Request
 					if ((*hostname)[0] == ':')
 						hostname->insert(0, "0");
 
-					bound_user->WriteServ("NOTICE Auth :*** Found your hostname (%s)%s", hostname->c_str(), (r->cached ? " -- cached" : ""));
+					bound_user->WriteNotice("*** Found your hostname (" + *hostname + (r->cached ? ") -- cached" : ")"));
 					bound_user->host.assign(*hostname, 0, 64);
 					bound_user->dhost = bound_user->host;
 
@@ -148,14 +148,14 @@ class UserResolver : public DNS::Request
 				}
 				else
 				{
-					bound_user->WriteServ("NOTICE Auth :*** Your hostname is longer than the maximum of 64 characters, using your IP address (%s) instead.", bound_user->GetIPString().c_str());
+					bound_user->WriteNotice("*** Your hostname is longer than the maximum of 64 characters, using your IP address (" + bound_user->GetIPString() + ") instead.");
 				}
 
 				ph->unset(bound_user);
 			}
 			else
 			{
-				bound_user->WriteServ("NOTICE Auth :*** Your hostname does not match up with your IP address. Sorry, using your IP address (%s) instead.", bound_user->GetIPString().c_str());
+				bound_user->WriteNotice("*** Your hostname does not match up with your IP address. Sorry, using your IP address (" + bound_user->GetIPString() + ") instead.");
 			}
 		}
 	}
@@ -168,7 +168,7 @@ class UserResolver : public DNS::Request
 		LocalUser* bound_user = (LocalUser*)ServerInstance->FindUUID(uuid);
 		if (bound_user)
 		{
-			bound_user->WriteServ("NOTICE Auth :*** Could not resolve your hostname: %s; using your IP address (%s) instead.", this->manager->GetErrorStr(query->error).c_str(), bound_user->GetIPString().c_str());
+			bound_user->WriteNotice("*** Could not resolve your hostname: " + this->manager->GetErrorStr(query->error) + "; using your IP address (" + bound_user->GetIPString() + ") instead.");
 			dl->set(bound_user, 0);
 			ServerInstance->stats->statsDnsBad++;
 		}
@@ -205,11 +205,11 @@ class ModuleHostnameLookup : public Module
 	{
 		if (!DNS || user->MyClass->nouserdns)
 		{
-			user->WriteServ("NOTICE %s :*** Skipping host resolution (disabled by server administrator)", user->nick.c_str());
+			user->WriteNotice("*** Skipping host resolution (disabled by server administrator)");
 			return;
 		}
 
-		user->WriteServ("NOTICE Auth :*** Looking up your hostname...");
+		user->WriteNotice("*** Looking up your hostname...");
 
 		UserResolver* res_reverse = new UserResolver(*this->DNS, this, user, user->GetIPString(), DNS::QUERY_PTR);
 		try

--- a/src/commands/cmd_kline.cpp
+++ b/src/commands/cmd_kline.cpp
@@ -63,7 +63,7 @@ CmdResult CommandKline::Handle (const std::vector<std::string>& parameters, User
 
         if (ih.first.empty())
         {
-            user->WriteServ("NOTICE %s :*** Target not found", user->nick.c_str());
+            user->WriteNotice("*** Target not found");
             return CMD_FAILURE;
         }
 
@@ -72,7 +72,7 @@ CmdResult CommandKline::Handle (const std::vector<std::string>& parameters, User
 
 		if (target.find('!') != std::string::npos)
 		{
-			user->WriteServ("NOTICE %s :*** K-Line cannot operate on nick!user@host masks",user->nick.c_str());
+			user->WriteNotice("*** K-Line cannot operate on nick!user@host masks");
 			return CMD_FAILURE;
 		}
 
@@ -97,7 +97,7 @@ CmdResult CommandKline::Handle (const std::vector<std::string>& parameters, User
 		else
 		{
 			delete kl;
-			user->WriteServ("NOTICE %s :*** K-Line for %s already exists",user->nick.c_str(),target.c_str());
+			user->WriteNotice("*** K-Line for " + target + " already exists");
 		}
 	}
 	else
@@ -108,7 +108,7 @@ CmdResult CommandKline::Handle (const std::vector<std::string>& parameters, User
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** K-Line %s not found in list, try /stats k.",user->nick.c_str(),target.c_str());
+			user->WriteNotice("*** K-Line " + target + " not found in list, try /stats k.");
 		}
 	}
 

--- a/src/commands/cmd_qline.cpp
+++ b/src/commands/cmd_qline.cpp
@@ -48,7 +48,7 @@ CmdResult CommandQline::Handle (const std::vector<std::string>& parameters, User
 
 		if (parameters[0].find('@') != std::string::npos || parameters[0].find('!') != std::string::npos || parameters[0].find('.') != std::string::npos)
 		{
-			user->WriteServ("NOTICE %s :*** A Q-Line only bans a nick pattern, not a nick!user@host pattern.",user->nick.c_str());
+			user->WriteNotice("*** A Q-Line only bans a nick pattern, not a nick!user@host pattern.");
 			return CMD_FAILURE;
 		}
 
@@ -72,7 +72,7 @@ CmdResult CommandQline::Handle (const std::vector<std::string>& parameters, User
 		else
 		{
 			delete ql;
-			user->WriteServ("NOTICE %s :*** Q-Line for %s already exists",user->nick.c_str(),parameters[0].c_str());
+			user->WriteNotice("*** Q-Line for " + parameters[0] + " already exists");
 		}
 	}
 	else
@@ -83,7 +83,7 @@ CmdResult CommandQline::Handle (const std::vector<std::string>& parameters, User
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** Q-Line %s not found in list, try /stats q.",user->nick.c_str(),parameters[0].c_str());
+			user->WriteNotice("*** Q-Line " + parameters[0] + " not found in list, try /stats q.");
 			return CMD_FAILURE;
 		}
 	}

--- a/src/commands/cmd_rehash.cpp
+++ b/src/commands/cmd_rehash.cpp
@@ -101,7 +101,7 @@ CmdResult CommandRehash::Handle (const std::vector<std::string>& parameters, Use
 		 * XXX, todo: we should find some way to kill runaway rehashes that are blocking, this is a major problem for unrealircd users
 		 */
 		if (IS_LOCAL(user))
-			user->WriteServ("NOTICE %s :*** Could not rehash: A rehash is already in progress.", user->nick.c_str());
+			user->WriteNotice("*** Could not rehash: A rehash is already in progress.");
 		else
 			ServerInstance->PI->SendUserNotice(user, "*** Could not rehash: A rehash is already in progress.");
 	}

--- a/src/commands/cmd_zline.cpp
+++ b/src/commands/cmd_zline.cpp
@@ -49,7 +49,7 @@ CmdResult CommandZline::Handle (const std::vector<std::string>& parameters, User
 	{
 		if (target.find('!') != std::string::npos)
 		{
-			user->WriteServ("NOTICE %s :*** You cannot include a nickname in a zline, a zline must ban only an IP mask",user->nick.c_str());
+			user->WriteNotice("*** You cannot include a nickname in a zline, a zline must ban only an IP mask");
 			return CMD_FAILURE;
 		}
 
@@ -92,7 +92,7 @@ CmdResult CommandZline::Handle (const std::vector<std::string>& parameters, User
 		else
 		{
 			delete zl;
-			user->WriteServ("NOTICE %s :*** Z-Line for %s already exists",user->nick.c_str(),ipaddr);
+			user->WriteNotice("*** Z-Line for " + std::string(ipaddr) + " already exists");
 		}
 	}
 	else
@@ -103,7 +103,7 @@ CmdResult CommandZline::Handle (const std::vector<std::string>& parameters, User
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** Z-Line %s not found in list, try /stats Z.",user->nick.c_str(),target.c_str());
+			user->WriteNotice("*** Z-Line " + target + " not found in list, try /stats Z.");
 			return CMD_FAILURE;
 		}
 	}

--- a/src/helperfuncs.cpp
+++ b/src/helperfuncs.cpp
@@ -106,8 +106,8 @@ void InspIRCd::SendError(const std::string &s)
 		User* u = *i;
 		if (u->registered == REG_ALL)
 		{
-		   	u->WriteServ("NOTICE %s :%s",u->nick.c_str(),s.c_str());
-	   	}
+			u->WriteNotice(s);
+		}
 		else
 		{
 			/* Unregistered connections receive ERROR, not a NOTICE */

--- a/src/modes/umode_s.cpp
+++ b/src/modes/umode_s.cpp
@@ -66,7 +66,5 @@ std::string ModeUserServerNoticeMask::GetUserParameter(User* user)
 
 void ModeUserServerNoticeMask::OnParameterMissing(User* user, User* dest, Channel* channel)
 {
-	user->WriteServ("NOTICE %s :*** The user mode +s requires a parameter (server notice mask). Please provide a parameter, e.g. '+s +*'.",
-			user->nick.c_str());
+	user->WriteNotice("*** The user mode +s requires a parameter (server notice mask). Please provide a parameter, e.g. '+s +*'.");
 }
-

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -745,10 +745,10 @@ class ModuleSSLGnuTLS : public Module
 
 				ssl_cert* cert = sessions[user->eh.GetFd()].cert;
 				if (cert->fingerprint.empty())
-					user->WriteServ("NOTICE %s :*** You are connected using SSL cipher \"%s\"", user->nick.c_str(), cipher.c_str());
+					user->WriteNotice("*** You are connected using SSL cipher '" + cipher + "'");
 				else
-					user->WriteServ("NOTICE %s :*** You are connected using SSL cipher \"%s\""
-						" and your SSL fingerprint is %s", user->nick.c_str(), cipher.c_str(), cert->fingerprint.c_str());
+					user->WriteNotice("*** You are connected using SSL cipher '" + cipher +
+						"' and your SSL fingerprint is " + cert->fingerprint);
 			}
 		}
 	}

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -287,10 +287,10 @@ class ModuleSSLOpenSSL : public Module
 			if (sessions[user->eh.GetFd()].sess)
 			{
 				if (!sessions[user->eh.GetFd()].cert->fingerprint.empty())
-					user->WriteServ("NOTICE %s :*** You are connected using SSL cipher \"%s\""
-						" and your SSL fingerprint is %s", user->nick.c_str(), SSL_get_cipher(sessions[user->eh.GetFd()].sess), sessions[user->eh.GetFd()].cert->fingerprint.c_str());
+					user->WriteNotice("*** You are connected using SSL cipher '" + std::string(SSL_get_cipher(sessions[user->eh.GetFd()].sess)) +
+						"' and your SSL fingerprint is " + sessions[user->eh.GetFd()].cert->fingerprint);
 				else
-					user->WriteServ("NOTICE %s :*** You are connected using SSL cipher \"%s\"", user->nick.c_str(), SSL_get_cipher(sessions[user->eh.GetFd()].sess));
+					user->WriteNotice("*** You are connected using SSL cipher '" + std::string(SSL_get_cipher(sessions[user->eh.GetFd()].sess)) + "'");
 			}
 		}
 	}

--- a/src/modules/m_callerid.cpp
+++ b/src/modules/m_callerid.cpp
@@ -258,7 +258,7 @@ public:
 		callerid_data *targ = extInfo.get(whotoadd, true);
 		targ->wholistsme.push_back(dat);
 
-		user->WriteServ("NOTICE %s :%s is now on your accept list", user->nick.c_str(), whotoadd->nick.c_str());
+		user->WriteNotice(whotoadd->nick + " is now on your accept list");
 		return true;
 	}
 
@@ -297,7 +297,7 @@ public:
 			ServerInstance->Logs->Log("m_callerid", LOG_DEFAULT, "ERROR: Inconsistency detected in callerid state, please report (4)");
 
 
-		user->WriteServ("NOTICE %s :%s is no longer on your accept list", user->nick.c_str(), whotoremove->nick.c_str());
+		user->WriteNotice(whotoremove->nick + " is no longer on your accept list");
 		return true;
 	}
 };

--- a/src/modules/m_cban.cpp
+++ b/src/modules/m_cban.cpp
@@ -101,7 +101,7 @@ class CommandCBan : public Command
 			}
 			else
 			{
-				user->WriteServ("NOTICE %s :*** CBan %s not found in list, try /stats C.",user->nick.c_str(),parameters[0].c_str());
+				user->WriteNotice("*** CBan " + parameters[0] + " not found in list, try /stats C.");
 				return CMD_FAILURE;
 			}
 		}
@@ -128,7 +128,7 @@ class CommandCBan : public Command
 			else
 			{
 				delete r;
-				user->WriteServ("NOTICE %s :*** CBan for %s already exists", user->nick.c_str(), parameters[0].c_str());
+				user->WriteNotice("*** CBan for " + parameters[0] + " already exists");
 				return CMD_FAILURE;
 			}
 		}

--- a/src/modules/m_chanhistory.cpp
+++ b/src/modules/m_chanhistory.cpp
@@ -165,8 +165,7 @@ class ModuleChanHistory : public Module
 
 		if (sendnotice)
 		{
-			memb->user->WriteServ("NOTICE %s :Replaying up to %d lines of pre-join history spanning up to %d seconds",
-				memb->chan->name.c_str(), list->maxlen, list->maxtime);
+			memb->user->WriteNotice("Replaying up to " + ConvToStr(list->maxlen) + " lines of pre-join history spanning up to " + ConvToStr(list->maxtime) + " seconds");
 		}
 
 		for(std::deque<HistoryItem>::iterator i = list->lines.begin(); i != list->lines.end(); ++i)

--- a/src/modules/m_chghost.cpp
+++ b/src/modules/m_chghost.cpp
@@ -43,7 +43,7 @@ class CommandChghost : public Command
 
 		if (parameters[1].length() > 63)
 		{
-			user->WriteServ("NOTICE %s :*** CHGHOST: Host too long", user->nick.c_str());
+			user->WriteNotice("*** CHGHOST: Host too long");
 			return CMD_FAILURE;
 		}
 
@@ -51,7 +51,7 @@ class CommandChghost : public Command
 		{
 			if (!hostmap[(unsigned char)*x])
 			{
-				user->WriteServ("NOTICE "+user->nick+" :*** CHGHOST: Invalid characters in hostname");
+				user->WriteNotice("*** CHGHOST: Invalid characters in hostname");
 				return CMD_FAILURE;
 			}
 		}

--- a/src/modules/m_chgident.cpp
+++ b/src/modules/m_chgident.cpp
@@ -49,13 +49,13 @@ class CommandChgident : public Command
 
 		if (parameters[1].length() > ServerInstance->Config->Limits.IdentMax)
 		{
-			user->WriteServ("NOTICE %s :*** CHGIDENT: Ident is too long", user->nick.c_str());
+			user->WriteNotice("*** CHGIDENT: Ident is too long");
 			return CMD_FAILURE;
 		}
 
 		if (!ServerInstance->IsIdent(parameters[1].c_str()))
 		{
-			user->WriteServ("NOTICE %s :*** CHGIDENT: Invalid characters in ident", user->nick.c_str());
+			user->WriteNotice("*** CHGIDENT: Invalid characters in ident");
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_chgname.cpp
+++ b/src/modules/m_chgname.cpp
@@ -47,13 +47,13 @@ class CommandChgname : public Command
 
 		if (parameters[1].empty())
 		{
-			user->WriteServ("NOTICE %s :*** CHGNAME: GECOS must be specified", user->nick.c_str());
+			user->WriteNotice("*** CHGNAME: GECOS must be specified");
 			return CMD_FAILURE;
 		}
 
 		if (parameters[1].length() > ServerInstance->Config->Limits.MaxGecos)
 		{
-			user->WriteServ("NOTICE %s :*** CHGNAME: GECOS too long", user->nick.c_str());
+			user->WriteNotice("*** CHGNAME: GECOS too long");
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_cloaking.cpp
+++ b/src/modules/m_cloaking.cpp
@@ -398,7 +398,7 @@ CmdResult CommandCloak::Handle(const std::vector<std::string> &parameters, User 
 	else
 		cloak = mod->GenCloak(sa, "", parameters[0]);
 
-	user->WriteServ("NOTICE %s :*** Cloak for %s is %s", user->nick.c_str(), parameters[0].c_str(), cloak.c_str());
+	user->WriteNotice("*** Cloak for " + parameters[0] + " is " + cloak);
 
 	return CMD_SUCCESS;
 }

--- a/src/modules/m_close.cpp
+++ b/src/modules/m_close.cpp
@@ -50,13 +50,14 @@ class CommandClose : public Command
 		int total = 0;
 		for (std::map<std::string,int>::iterator ci = closed.begin(); ci != closed.end(); ci++)
 		{
-			src->WriteServ("NOTICE %s :*** Closed %d unknown connection%s from [%s]",src->nick.c_str(),(*ci).second,((*ci).second>1)?"s":"",(*ci).first.c_str());
-			total += (*ci).second;
+			src->WriteNotice("*** Closed " + ConvToStr(ci->second) + " unknown " + (ci->second == 1 ? "connection" : "connections") +
+				" from [" + ci->first + "]");
+			total += ci->second;
 		}
 		if (total)
-			src->WriteServ("NOTICE %s :*** %i unknown connection%s closed",src->nick.c_str(),total,(total>1)?"s":"");
+			src->WriteNotice("*** " + ConvToStr(total) + " unknown " + (total == 1 ? "connection" : "connections") + " closed");
 		else
-			src->WriteServ("NOTICE %s :*** No unknown connections found",src->nick.c_str());
+			src->WriteNotice("*** No unknown connections found");
 
 		return CMD_SUCCESS;
 	}

--- a/src/modules/m_conn_waitpong.cpp
+++ b/src/modules/m_conn_waitpong.cpp
@@ -60,7 +60,7 @@ class ModuleWaitPong : public Module
 		user->Write("PING :%s", pingrpl.c_str());
 
 		if(sendsnotice)
-			user->WriteServ("NOTICE %s :*** If you are having problems connecting due to ping timeouts, please type /quote PONG %s or /raw PONG %s now.", user->nick.c_str(), pingrpl.c_str(), pingrpl.c_str());
+			user->WriteNotice("*** If you are having problems connecting due to ping timeouts, please type /quote PONG " + pingrpl + " or /raw PONG " + pingrpl + " now.");
 
 		ext.set(user, pingrpl);
 		return MOD_RES_PASSTHRU;

--- a/src/modules/m_customtitle.cpp
+++ b/src/modules/m_customtitle.cpp
@@ -76,13 +76,13 @@ class CommandTitle : public Command
 				if (!vhost.empty())
 					user->ChangeDisplayedHost(vhost.c_str());
 
-				user->WriteServ("NOTICE %s :Custom title set to '%s'",user->nick.c_str(), title.c_str());
+				user->WriteNotice("Custom title set to '" + title + "'");
 
 				return CMD_SUCCESS;
 			}
 		}
 
-		user->WriteServ("NOTICE %s :Invalid title credentials",user->nick.c_str());
+		user->WriteNotice("Invalid title credentials");
 		return CMD_SUCCESS;
 	}
 

--- a/src/modules/m_cycle.cpp
+++ b/src/modules/m_cycle.cpp
@@ -61,7 +61,7 @@ class CommandCycle : public SplitCommand
 				if (channel->GetPrefixValue(user) < VOICE_VALUE && channel->IsBanned(user))
 				{
 					/* banned, boned. drop the message. */
-					user->WriteServ("NOTICE "+user->nick+" :*** You may not cycle, as you are banned on channel " + channel->name);
+					user->WriteNotice("*** You may not cycle, as you are banned on channel " + channel->name);
 					return CMD_FAILURE;
 				}
 

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -365,16 +365,16 @@ class ModuleDCCAllow : public Module
 						if ((!found) && (defaultaction == "allow"))
 							return MOD_RES_PASSTHRU;
 
-						user->WriteServ("NOTICE %s :The user %s is not accepting DCC SENDs from you. Your file %s was not sent.", user->nick.c_str(), u->nick.c_str(), filename.c_str());
-						u->WriteServ("NOTICE %s :%s (%s@%s) attempted to send you a file named %s, which was blocked.", u->nick.c_str(), user->nick.c_str(), user->ident.c_str(), user->dhost.c_str(), filename.c_str());
-						u->WriteServ("NOTICE %s :If you trust %s and were expecting this, you can type /DCCALLOW HELP for information on the DCCALLOW system.", u->nick.c_str(), user->nick.c_str());
+						user->WriteNotice("The user " + u->nick + " is not accepting DCC SENDs from you. Your file " + filename + " was not sent.");
+						u->WriteNotice(user->nick + " (" + user->ident + "@" + user->dhost + ") attempted to send you a file named " + filename + ", which was blocked.");
+						u->WriteNotice("If you trust " + user->nick + " and were expecting this, you can type /DCCALLOW HELP for information on the DCCALLOW system.");
 						return MOD_RES_DENY;
 					}
 					else if ((type == "CHAT") && (blockchat))
 					{
-						user->WriteServ("NOTICE %s :The user %s is not accepting DCC CHAT requests from you.", user->nick.c_str(), u->nick.c_str());
-						u->WriteServ("NOTICE %s :%s (%s@%s) attempted to initiate a DCC CHAT session, which was blocked.", u->nick.c_str(), user->nick.c_str(), user->ident.c_str(), user->dhost.c_str());
-						u->WriteServ("NOTICE %s :If you trust %s and were expecting this, you can type /DCCALLOW HELP for information on the DCCALLOW system.", u->nick.c_str(), user->nick.c_str());
+						user->WriteNotice("The user " + u->nick + " is not accepting DCC CHAT requests from you.");
+						u->WriteNotice(user->nick + " (" + user->ident + "@" + user->dhost + ") attempted to initiate a DCC CHAT session, which was blocked.");
+						u->WriteNotice("If you trust " + user->nick + " and were expecting this, you can type /DCCALLOW HELP for information on the DCCALLOW system.");
 						return MOD_RES_DENY;
 					}
 				}
@@ -432,7 +432,7 @@ class ModuleDCCAllow : public Module
 						if (i->nickname == user->nick)
 						{
 
-							u->WriteServ("NOTICE %s :%s left the network or changed their nickname and has been removed from your DCCALLOW list", u->nick.c_str(), i->nickname.c_str());
+							u->WriteNotice(i->nickname + " left the network or changed their nickname and has been removed from your DCCALLOW list");
 							u->WriteNumeric(995, "%s %s :Removed %s from your DCCALLOW list", u->nick.c_str(), u->nick.c_str(), i->nickname.c_str());
 							dl->erase(i);
 							break;

--- a/src/modules/m_deaf.cpp
+++ b/src/modules/m_deaf.cpp
@@ -36,7 +36,7 @@ class User_d : public ModeHandler
 		{
 			if (!dest->IsModeSet('d'))
 			{
-				dest->WriteServ("NOTICE %s :*** You have enabled usermode +d, deaf mode. This mode means you WILL NOT receive any messages from any channels you are in. If you did NOT mean to do this, use /mode %s -d.", dest->nick.c_str(), dest->nick.c_str());
+				dest->WriteNotice("*** You have enabled usermode +d, deaf mode. This mode means you WILL NOT receive any messages from any channels you are in. If you did NOT mean to do this, use /mode " + dest->nick + " -d.");
 				dest->SetMode('d',true);
 				return MODEACTION_ALLOW;
 			}

--- a/src/modules/m_denychans.cpp
+++ b/src/modules/m_denychans.cpp
@@ -48,7 +48,7 @@ class ModuleDenyChannels : public Module
 				if (!ServerInstance->IsChannel(redirect, ServerInstance->Config->Limits.ChanMax))
 				{
 					if (user)
-						user->WriteServ("NOTICE %s :Invalid badchan redirect '%s'", user->nick.c_str(), redirect.c_str());
+						user->WriteNotice("Invalid badchan redirect '" + redirect + "'");
 					throw ModuleException("Invalid badchan redirect, not a channel");
 				}
 
@@ -68,7 +68,7 @@ class ModuleDenyChannels : public Module
 						{
 							/* <badchan:redirect> is a badchan */
 							if (user)
-								user->WriteServ("NOTICE %s :Badchan %s redirects to badchan %s", user->nick.c_str(), name.c_str(), redirect.c_str());
+								user->WriteNotice("Badchan " + name + " redirects to badchan " + redirect);
 							throw ModuleException("Badchan redirect loop");
 						}
 					}

--- a/src/modules/m_filter.cpp
+++ b/src/modules/m_filter.cpp
@@ -209,13 +209,13 @@ CmdResult CommandFilter::Handle(const std::vector<std::string> &parameters, User
 		Module *me = creator;
 		if (static_cast<ModuleFilter *>(me)->DeleteFilter(parameters[0]))
 		{
-			user->WriteServ("NOTICE %s :*** Removed filter '%s'", user->nick.c_str(), parameters[0].c_str());
+			user->WriteNotice("*** Removed filter '" + parameters[0] + "'");
 			ServerInstance->SNO->WriteToSnoMask(IS_LOCAL(user) ? 'a' : 'A', "FILTER: "+user->nick+" removed filter '"+parameters[0]+"'");
 			return CMD_SUCCESS;
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** Filter '%s' not found in list, try /stats s.", user->nick.c_str(), parameters[0].c_str());
+			user->WriteNotice("*** Filter '" + parameters[0] + "' not found in list, try /stats s.");
 			return CMD_FAILURE;
 		}
 	}
@@ -232,7 +232,7 @@ CmdResult CommandFilter::Handle(const std::vector<std::string> &parameters, User
 
 			if (!ModuleFilter::StringToFilterAction(parameters[1], type))
 			{
-				user->WriteServ("NOTICE %s :*** Invalid filter type '%s'. Supported types are 'gline', 'none', 'block', 'silent' and 'kill'.", user->nick.c_str(), parameters[1].c_str());
+				user->WriteNotice("*** Invalid filter type '" + parameters[1] + "'. Supported types are 'gline', 'none', 'block', 'silent' and 'kill'.");
 				return CMD_FAILURE;
 			}
 
@@ -245,7 +245,7 @@ CmdResult CommandFilter::Handle(const std::vector<std::string> &parameters, User
 				}
 				else
 				{
-					user->WriteServ("NOTICE %s :*** Not enough parameters: When setting a gline type filter, a gline duration must be specified as the third parameter.", user->nick.c_str());
+					user->WriteNotice("*** Not enough parameters: When setting a gline type filter, a gline duration must be specified as the third parameter.");
 					return CMD_FAILURE;
 				}
 			}
@@ -258,9 +258,9 @@ CmdResult CommandFilter::Handle(const std::vector<std::string> &parameters, User
 			std::pair<bool, std::string> result = static_cast<ModuleFilter *>(me)->AddFilter(freeform, type, parameters[reasonindex], duration, flags);
 			if (result.first)
 			{
-				user->WriteServ("NOTICE %s :*** Added filter '%s', type '%s'%s%s, flags '%s', reason: '%s'", user->nick.c_str(), freeform.c_str(),
-						parameters[1].c_str(), (duration ? ", duration " : ""), (duration ? parameters[3].c_str() : ""),
-						flags.c_str(), parameters[reasonindex].c_str());
+				user->WriteNotice("*** Added filter '" + freeform + "', type '" + parameters[1] + "'" +
+					(duration ? ", duration " +  parameters[3] : "") + ", flags '" + flags + "', reason: '" +
+					parameters[reasonindex] + "'");
 
 				ServerInstance->SNO->WriteToSnoMask(IS_LOCAL(user) ? 'a' : 'A', "FILTER: "+user->nick+" added filter '"+freeform+"', type '"+parameters[1]+"', "+(duration ? "duration "+parameters[3]+", " : "")+"flags '"+flags+"', reason: "+parameters[reasonindex]);
 
@@ -268,13 +268,13 @@ CmdResult CommandFilter::Handle(const std::vector<std::string> &parameters, User
 			}
 			else
 			{
-				user->WriteServ("NOTICE %s :*** Filter '%s' could not be added: %s", user->nick.c_str(), freeform.c_str(), result.second.c_str());
+				user->WriteNotice("*** Filter '" + freeform + "' could not be added: " + result.second);
 				return CMD_FAILURE;
 			}
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** Not enough parameters.", user->nick.c_str());
+			user->WriteNotice("*** Not enough parameters.");
 			return CMD_FAILURE;
 		}
 
@@ -364,14 +364,14 @@ ModResult ModuleFilter::OnUserPreNotice(User* user,void* dest,int target_type, s
 			if (target_type == TYPE_CHANNEL)
 				user->WriteNumeric(404, "%s %s :Message to channel blocked and opers notified (%s)",user->nick.c_str(), target.c_str(), f->reason.c_str());
 			else
-				user->WriteServ("NOTICE "+user->nick+" :Your message to "+target+" was blocked and opers notified: "+f->reason);
+				user->WriteNotice("Your message to "+target+" was blocked and opers notified: "+f->reason);
 		}
 		else if (f->action == FA_SILENT)
 		{
 			if (target_type == TYPE_CHANNEL)
 				user->WriteNumeric(404, "%s %s :Message to channel blocked (%s)",user->nick.c_str(), target.c_str(), f->reason.c_str());
 			else
-				user->WriteServ("NOTICE "+user->nick+" :Your message to "+target+" was blocked: "+f->reason);
+				user->WriteNotice("Your message to "+target+" was blocked: "+f->reason);
 		}
 		else if (f->action == FA_KILL)
 		{
@@ -446,7 +446,7 @@ ModResult ModuleFilter::OnPreCommand(std::string &command, std::vector<std::stri
 			/* Are they parting, if so, kill is applicable */
 			if ((parting) && (f->action == FA_KILL))
 			{
-				user->WriteServ("NOTICE %s :*** Your PART message was filtered: %s", user->nick.c_str(), f->reason.c_str());
+				user->WriteNotice("*** Your PART message was filtered: " + f->reason);
 				ServerInstance->Users->QuitUser(user, "Filtered: " + f->reason);
 			}
 			if (f->action == FA_GLINE)

--- a/src/modules/m_hostchange.cpp
+++ b/src/modules/m_hostchange.cpp
@@ -159,9 +159,9 @@ class ModuleHostChange : public Module
 				}
 				if (!newhost.empty())
 				{
-					user->WriteServ("NOTICE "+user->nick+" :Setting your virtual host: " + newhost);
+					user->WriteNotice("Setting your virtual host: " + newhost);
 					if (!user->ChangeDisplayedHost(newhost.c_str()))
-						user->WriteServ("NOTICE "+user->nick+" :Could not set your virtual host: " + newhost);
+						user->WriteNotice("Could not set your virtual host: " + newhost);
 					return;
 				}
 			}

--- a/src/modules/m_ident.cpp
+++ b/src/modules/m_ident.cpp
@@ -307,7 +307,7 @@ class ModuleIdent : public Module
 		if (!tag->getBool("useident", true))
 			return;
 
-		user->WriteServ("NOTICE Auth :*** Looking up your ident...");
+		user->WriteNotice("*** Looking up your ident...");
 
 		try
 		{
@@ -343,7 +343,7 @@ class ModuleIdent : public Module
 		if (ServerInstance->Time() >= compare)
 		{
 			/* Ident timeout */
-			user->WriteServ("NOTICE Auth :*** Ident request timed out.");
+			user->WriteNotice("*** Ident request timed out.");
 			ServerInstance->Logs->Log("m_ident",LOG_DEBUG, "Timeout");
 		}
 		else if (!isock->HasResult())
@@ -359,12 +359,12 @@ class ModuleIdent : public Module
 		if (isock->result.empty())
 		{
 			user->ident.insert(0, 1, '~');
-			user->WriteServ("NOTICE Auth :*** Could not find your ident, using %s instead.", user->ident.c_str());
+			user->WriteNotice("*** Could not find your ident, using " + user->ident + " instead.");
 		}
 		else
 		{
 			user->ident = isock->result;
-			user->WriteServ("NOTICE Auth :*** Found your ident, '%s'", user->ident.c_str());
+			user->WriteNotice("*** Found your ident, '" + user->ident + "'");
 		}
 
 		user->InvalidateCache();

--- a/src/modules/m_jumpserver.cpp
+++ b/src/modules/m_jumpserver.cpp
@@ -53,9 +53,9 @@ class CommandJumpserver : public Command
 		if (!parameters.size())
 		{
 			if (port)
-				user->WriteServ("NOTICE %s :*** Disabled jumpserver (previously set to '%s:%d')", user->nick.c_str(), redirect_to.c_str(), port);
+				user->WriteNotice("*** Disabled jumpserver (previously set to '" + redirect_to + ":" + ConvToStr(port) + "')");
 			else
-				user->WriteServ("NOTICE %s :*** Jumpserver was not enabled.", user->nick.c_str());
+				user->WriteNotice("*** Jumpserver was not enabled.");
 
 			port = 0;
 			redirect_to.clear();
@@ -84,7 +84,7 @@ class CommandJumpserver : public Command
 						redirect_new_users = direction;
 					break;
 					default:
-						user->WriteServ("NOTICE %s :*** Invalid JUMPSERVER flag: %c", user->nick.c_str(), *n);
+						user->WriteNotice("*** Invalid JUMPSERVER flag: " + ConvToStr(*n));
 						return CMD_FAILURE;
 					break;
 				}
@@ -92,7 +92,7 @@ class CommandJumpserver : public Command
 
 			if (!atoi(parameters[1].c_str()))
 			{
-				user->WriteServ("NOTICE %s :*** Invalid port number", user->nick.c_str());
+				user->WriteNotice("*** Invalid port number");
 				return CMD_FAILURE;
 			}
 
@@ -121,13 +121,9 @@ class CommandJumpserver : public Command
 				port = atoi(parameters[1].c_str());
 			}
 
-			user->WriteServ("NOTICE %s :*** Set jumpserver to server '%s' port '%s', flags '+%s%s'%s%s%s: %s", user->nick.c_str(), parameters[0].c_str(), parameters[1].c_str(),
-					redirect_all_immediately ? "a" : "",
-					redirect_new_users ? "n" : "",
-					n_done ? " (" : "",
-					n_done ? n_done_s.c_str() : "",
-					n_done ? " user(s) redirected)" : "",
-					reason.c_str());
+			user->WriteNotice("*** Set jumpserver to server '" + parameters[0] + "' port '" + parameters[1] + "', flags '+" +
+				(redirect_all_immediately ? "a" : "") + (redirect_new_users ? "n'" : "'") +
+				(n_done ? " (" + n_done_s + "user(s) redirected): " : ": ") + reason);
 		}
 
 		return CMD_SUCCESS;

--- a/src/modules/m_knock.cpp
+++ b/src/modules/m_knock.cpp
@@ -70,7 +70,7 @@ class CommandKnock : public Command
 		if (sendnumeric)
 			c->WriteChannelWithServ(ServerInstance->Config->ServerName, "710 %s %s %s :is KNOCKing: %s", c->name.c_str(), c->name.c_str(), user->GetFullHost().c_str(), parameters[1].c_str());
 
-		user->WriteServ("NOTICE %s :KNOCKing on %s", user->nick.c_str(), c->name.c_str());
+		user->WriteNotice("KNOCKing on " + c->name);
 		return CMD_SUCCESS;
 	}
 

--- a/src/modules/m_lockserv.cpp
+++ b/src/modules/m_lockserv.cpp
@@ -41,7 +41,7 @@ class CommandLockserv : public Command
 	{
 		if (locked)
 		{
-			user->WriteServ("NOTICE %s :The server is already locked.", user->nick.c_str());
+			user->WriteNotice("The server is already locked.");
 			return CMD_FAILURE;
 		}
 
@@ -66,7 +66,7 @@ class CommandUnlockserv : public Command
 	{
 		if (!locked)
 		{
-			user->WriteServ("NOTICE %s :The server isn't locked.", user->nick.c_str());
+			user->WriteNotice("The server isn't locked.");
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_maphide.cpp
+++ b/src/modules/m_maphide.cpp
@@ -41,7 +41,7 @@ class ModuleMapHide : public Module
 	{
 		if (validated && !user->IsOper() && !url.empty() && (command == "MAP" || command == "LINKS"))
 		{
-			user->WriteServ("NOTICE %s :/%s has been disabled; visit %s", user->nick.c_str(), command.c_str(), url.c_str());
+			user->WriteNotice("/" + command + " has been disabled; visit " + url);
 			return MOD_RES_DENY;
 		}
 		else

--- a/src/modules/m_nicklock.cpp
+++ b/src/modules/m_nicklock.cpp
@@ -44,7 +44,7 @@ class CommandNicklock : public Command
 
 		if ((!target) || (target->registered != REG_ALL))
 		{
-			user->WriteServ("NOTICE %s :*** No such nickname: '%s'", user->nick.c_str(), parameters[0].c_str());
+			user->WriteNotice("*** No such nickname: '" + parameters[0] + "'");
 			return CMD_FAILURE;
 		}
 
@@ -53,7 +53,7 @@ class CommandNicklock : public Command
 		{
 			if (!ServerInstance->IsNick(parameters[1], ServerInstance->Config->Limits.NickMax))
 			{
-				user->WriteServ("NOTICE %s :*** Invalid nickname '%s'", user->nick.c_str(), parameters[1].c_str());
+				user->WriteNotice("*** Invalid nickname '" + parameters[1] + "'");
 				return CMD_FAILURE;
 			}
 
@@ -107,7 +107,7 @@ class CommandNickunlock : public Command
 
 		if (!target)
 		{
-			user->WriteServ("NOTICE %s :*** No such nickname: '%s'", user->nick.c_str(), parameters[0].c_str());
+			user->WriteNotice("*** No such nickname: '" + parameters[0] + "'");
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_ojoin.cpp
+++ b/src/modules/m_ojoin.cpp
@@ -62,7 +62,7 @@ class CommandOjoin : public SplitCommand
 		// Make sure the channel name is allowable.
 		if (!ServerInstance->IsChannel(parameters[0], ServerInstance->Config->Limits.ChanMax))
 		{
-			user->WriteServ("NOTICE "+user->nick+" :*** Invalid characters in channel name or name too long");
+			user->WriteNotice("*** Invalid characters in channel name or name too long");
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_operlevels.cpp
+++ b/src/modules/m_operlevels.cpp
@@ -50,7 +50,7 @@ class ModuleOperLevels : public Module
 				if (dest_level > source_level)
 				{
 					if (IS_LOCAL(source)) ServerInstance->SNO->WriteGlobalSno('a', "Oper %s (level %ld) attempted to /kill a higher oper: %s (level %ld): Reason: %s",source->nick.c_str(),source_level,dest->nick.c_str(),dest_level,reason.c_str());
-					dest->WriteServ("NOTICE %s :*** Oper %s attempted to /kill you!",dest->nick.c_str(),source->nick.c_str());
+					dest->WriteNotice("*** Oper " + source->nick + " attempted to /kill you!");
 					source->WriteNumeric(ERR_NOPRIVILEGES, "%s :Permission Denied - Oper %s is a higher level than you",source->nick.c_str(),dest->nick.c_str());
 					return MOD_RES_DENY;
 				}

--- a/src/modules/m_override.cpp
+++ b/src/modules/m_override.cpp
@@ -129,7 +129,7 @@ class ModuleOverride : public Module
 						if (RequireKey && keygiven != "override")
 						{
 							// Can't join normally -- must use a special key to bypass restrictions
-							user->WriteServ("NOTICE %s :*** You may not join normally. You must join with a key of 'override' to oper override.", user->nick.c_str());
+							user->WriteNotice("*** You may not join normally. You must join with a key of 'override' to oper override.");
 							return MOD_RES_PASSTHRU;
 						}
 
@@ -145,7 +145,7 @@ class ModuleOverride : public Module
 					if (RequireKey && keygiven != "override")
 					{
 						// Can't join normally -- must use a special key to bypass restrictions
-						user->WriteServ("NOTICE %s :*** You may not join normally. You must join with a key of 'override' to oper override.", user->nick.c_str());
+						user->WriteNotice("*** You may not join normally. You must join with a key of 'override' to oper override.");
 						return MOD_RES_PASSTHRU;
 					}
 
@@ -160,7 +160,7 @@ class ModuleOverride : public Module
 					if (RequireKey && keygiven != "override")
 					{
 						// Can't join normally -- must use a special key to bypass restrictions
-						user->WriteServ("NOTICE %s :*** You may not join normally. You must join with a key of 'override' to oper override.", user->nick.c_str());
+						user->WriteNotice("*** You may not join normally. You must join with a key of 'override' to oper override.");
 						return MOD_RES_PASSTHRU;
 					}
 
@@ -175,7 +175,7 @@ class ModuleOverride : public Module
 					if (RequireKey && keygiven != "override")
 					{
 						// Can't join normally -- must use a special key to bypass restrictions
-						user->WriteServ("NOTICE %s :*** You may not join normally. You must join with a key of 'override' to oper override.", user->nick.c_str());
+						user->WriteNotice("*** You may not join normally. You must join with a key of 'override' to oper override.");
 						return MOD_RES_PASSTHRU;
 					}
 

--- a/src/modules/m_password_hash.cpp
+++ b/src/modules/m_password_hash.cpp
@@ -42,15 +42,14 @@ class CommandMkpasswd : public Command
 			HashProvider* hp = ServerInstance->Modules->FindDataService<HashProvider>("hash/" + type);
 			if (!hp)
 			{
-				user->WriteServ("NOTICE %s :Unknown hash type", user->nick.c_str());
+				user->WriteNotice("Unknown hash type");
 				return;
 			}
 			std::string salt = ServerInstance->GenRandomStr(6, false);
 			std::string target = hp->hmac(salt, stuff);
 			std::string str = BinToBase64(salt) + "$" + BinToBase64(target, NULL, 0);
 
-			user->WriteServ("NOTICE %s :%s hashed password for %s is %s",
-				user->nick.c_str(), algo.c_str(), stuff.c_str(), str.c_str());
+			user->WriteNotice(algo + " hashed password for " + stuff + " is " + str);
 			return;
 		}
 		HashProvider* hp = ServerInstance->Modules->FindDataService<HashProvider>("hash/" + algo);
@@ -58,12 +57,11 @@ class CommandMkpasswd : public Command
 		{
 			/* Now attempt to generate a hash */
 			std::string hexsum = hp->hexsum(stuff);
-			user->WriteServ("NOTICE %s :%s hashed password for %s is %s",
-				user->nick.c_str(), algo.c_str(), stuff.c_str(), hexsum.c_str());
+			user->WriteNotice(algo + " hashed password for " + stuff + " is " + hexsum);
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :Unknown hash type", user->nick.c_str());
+			user->WriteNotice("Unknown hash type");
 		}
 	}
 

--- a/src/modules/m_randquote.cpp
+++ b/src/modules/m_randquote.cpp
@@ -46,7 +46,7 @@ class CommandRandquote : public Command
 
 		fsize = quotes->FileSize();
 		str = quotes->GetLine(ServerInstance->GenRandomInt(fsize));
-		user->WriteServ("NOTICE %s :%s%s%s",user->nick.c_str(),prefix.c_str(),str.c_str(),suffix.c_str());
+		user->WriteNotice(prefix + str + suffix);
 
 		return CMD_SUCCESS;
 	}

--- a/src/modules/m_remove.cpp
+++ b/src/modules/m_remove.cpp
@@ -117,7 +117,7 @@ class RemoveBase : public Command
 				reason = "Removed by " + user->nick + ": " + reasonparam;
 
 				channel->WriteChannelWithServ(ServerInstance->Config->ServerName, "NOTICE %s :%s removed %s from the channel", channel->name.c_str(), user->nick.c_str(), target->nick.c_str());
-				target->WriteServ("NOTICE %s :*** %s removed you from %s with the message: %s", target->nick.c_str(), user->nick.c_str(), channel->name.c_str(), reasonparam.c_str());
+				target->WriteNotice("*** " + user->nick + " removed you from " + channel->name + " with the message: " + reasonparam);
 
 				channel->PartUser(target, reason);
 			}

--- a/src/modules/m_rline.cpp
+++ b/src/modules/m_rline.cpp
@@ -180,7 +180,7 @@ class CommandRLine : public Command
 				else
 				{
 					delete r;
-					user->WriteServ("NOTICE %s :*** R-Line for %s already exists", user->nick.c_str(), parameters[0].c_str());
+					user->WriteNotice("*** R-Line for " + parameters[0] + " already exists");
 				}
 			}
 		}
@@ -192,7 +192,7 @@ class CommandRLine : public Command
 			}
 			else
 			{
-				user->WriteServ("NOTICE %s :*** R-Line %s not found in list, try /stats R.",user->nick.c_str(),parameters[0].c_str());
+				user->WriteNotice("*** R-Line " + parameters[0] + " not found in list, try /stats R.");
 			}
 		}
 

--- a/src/modules/m_rmode.cpp
+++ b/src/modules/m_rmode.cpp
@@ -41,20 +41,20 @@ class CommandRMode : public Command
 
 		if (chan == NULL)
 		{
-			user->WriteServ("NOTICE %s :The channel %s does not exist.", user->nick.c_str(), parameters[0].c_str());
+			user->WriteNotice("The channel " + parameters[0] + " does not exist.");
 			return CMD_FAILURE;
 		}
 
 		mh = ServerInstance->Modes->FindMode(modeletter, MODETYPE_CHANNEL);
 		if (mh == NULL || parameters[1].size() > 1)
 		{
-			user->WriteServ("NOTICE %s :%s is not a valid channel mode.", user->nick.c_str(), parameters[1].c_str());
+			user->WriteNotice(parameters[1] + " is not a valid channel mode.");
 			return CMD_FAILURE;
 		}
 
 		if (chan->GetPrefixValue(user) < mh->GetLevelRequired())
 		{
-			user->WriteServ("NOTICE %s :You do not have access to unset %c on %s.", user->nick.c_str(), modeletter, chan->name.c_str());
+			user->WriteNotice("You do not have access to unset " + ConvToStr(modeletter) + " on " +  chan->name + ".");
 			return CMD_FAILURE;
 		}
 
@@ -92,7 +92,7 @@ class CommandRMode : public Command
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :Could not remove channel mode %c", user->nick.c_str(), modeletter);
+			user->WriteNotice("Could not remove channel mode " + ConvToStr(modeletter));
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_sajoin.cpp
+++ b/src/modules/m_sajoin.cpp
@@ -48,7 +48,7 @@ class CommandSajoin : public Command
 			if (IS_LOCAL(user) && !ServerInstance->IsChannel(parameters[1].c_str(), ServerInstance->Config->Limits.ChanMax))
 			{
 				/* we didn't need to check this for each character ;) */
-				user->WriteServ("NOTICE "+user->nick+" :*** Invalid characters in channel name or name too long");
+				user->WriteNotice("*** Invalid characters in channel name or name too long");
 				return CMD_FAILURE;
 			}
 
@@ -69,13 +69,13 @@ class CommandSajoin : public Command
 					}
 					else
 					{
-						user->WriteServ("NOTICE "+user->nick+" :*** Could not join "+dest->nick+" to "+parameters[1]+" (User is probably banned, or blocking modes)");
+						user->WriteNotice("*** Could not join "+dest->nick+" to "+parameters[1]+" (User is probably banned, or blocking modes)");
 						return CMD_FAILURE;
 					}
 				}
 				else
 				{
-					user->WriteServ("NOTICE "+user->nick+" :*** Could not join "+dest->nick+" to "+parameters[1]);
+					user->WriteNotice("*** Could not join "+dest->nick+" to "+parameters[1]);
 					return CMD_FAILURE;
 				}
 			}
@@ -87,7 +87,7 @@ class CommandSajoin : public Command
 		}
 		else
 		{
-			user->WriteServ("NOTICE "+user->nick+" :*** No such nickname "+parameters[0]);
+			user->WriteNotice("*** No such nickname "+parameters[0]);
 			return CMD_FAILURE;
 		}
 	}

--- a/src/modules/m_sakick.cpp
+++ b/src/modules/m_sakick.cpp
@@ -68,7 +68,7 @@ class CommandSakick : public Command
 				if (n && n->HasUser(dest))
 				{
 					/* Sort-of-bug: If the command was issued remotely, this message won't be sent */
-					user->WriteServ("NOTICE %s :*** Unable to kick %s from %s", user->nick.c_str(), dest->nick.c_str(), parameters[0].c_str());
+					user->WriteNotice("*** Unable to kick " + dest->nick + " from " + parameters[0]);
 					return CMD_FAILURE;
 				}
 			}
@@ -83,7 +83,7 @@ class CommandSakick : public Command
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** Invalid nickname or channel", user->nick.c_str());
+			user->WriteNotice("*** Invalid nickname or channel");
 		}
 
 		return CMD_FAILURE;

--- a/src/modules/m_sanick.cpp
+++ b/src/modules/m_sanick.cpp
@@ -50,13 +50,13 @@ class CommandSanick : public Command
 
 			if ((!target) || (target->registered != REG_ALL))
 			{
-				user->WriteServ("NOTICE %s :*** No such nickname: '%s'", user->nick.c_str(), parameters[0].c_str());
+				user->WriteNotice("*** No such nickname: '" + parameters[0] + "'");
 				return CMD_FAILURE;
 			}
 
 			if (!ServerInstance->IsNick(parameters[1], ServerInstance->Config->Limits.NickMax))
 			{
-				user->WriteServ("NOTICE %s :*** Invalid nickname '%s'", user->nick.c_str(), parameters[1].c_str());
+				user->WriteNotice("*** Invalid nickname '" + parameters[1] + "'");
 				return CMD_FAILURE;
 			}
 		}

--- a/src/modules/m_sapart.cpp
+++ b/src/modules/m_sapart.cpp
@@ -74,7 +74,7 @@ class CommandSapart : public Command
 					}
 					else
 					{
-						user->WriteServ("NOTICE %s :*** Unable to make %s part %s",user->nick.c_str(), dest->nick.c_str(), parameters[1].c_str());
+						user->WriteNotice("*** Unable to make " + dest->nick + " part " + parameters[1]);
 						return CMD_FAILURE;
 					}
 				}
@@ -84,7 +84,7 @@ class CommandSapart : public Command
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** Invalid nickname or channel", user->nick.c_str());
+			user->WriteNotice("*** Invalid nickname or channel");
 		}
 
 		return CMD_FAILURE;

--- a/src/modules/m_saquit.cpp
+++ b/src/modules/m_saquit.cpp
@@ -56,7 +56,7 @@ class CommandSaquit : public Command
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** Invalid nickname '%s'", user->nick.c_str(), parameters[0].c_str());
+			user->WriteNotice("*** Invalid nickname '" + parameters[0] + "'");
 			return CMD_FAILURE;
 		}
 	}

--- a/src/modules/m_securelist.cpp
+++ b/src/modules/m_securelist.cpp
@@ -71,7 +71,7 @@ class ModuleSecureList : public Module
 					return MOD_RES_PASSTHRU;
 
 			/* Not exempt, BOOK EM DANNO! */
-			user->WriteServ("NOTICE %s :*** You cannot list within the first %lu seconds of connecting. Please try again later.",user->nick.c_str(), (unsigned long) WaitTime);
+			user->WriteNotice("*** You cannot list within the first " + ConvToStr(WaitTime) + " seconds of connecting. Please try again later.");
 			/* Some crap clients (read: mIRC, various java chat applets) muck up if they don't
 			 * receive these numerics whenever they send LIST, so give them an empty LIST to mull over.
 			 */

--- a/src/modules/m_sethost.cpp
+++ b/src/modules/m_sethost.cpp
@@ -44,14 +44,14 @@ class CommandSethost : public Command
 		{
 			if (!hostmap[(const unsigned char)*x])
 			{
-				user->WriteServ("NOTICE "+user->nick+" :*** SETHOST: Invalid characters in hostname");
+				user->WriteNotice("*** SETHOST: Invalid characters in hostname");
 				return CMD_FAILURE;
 			}
 		}
 
 		if (len > 64)
 		{
-			user->WriteServ("NOTICE %s :*** SETHOST: Host too long",user->nick.c_str());
+			user->WriteNotice("*** SETHOST: Host too long");
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_setident.cpp
+++ b/src/modules/m_setident.cpp
@@ -40,13 +40,13 @@ class CommandSetident : public Command
 	{
 		if (parameters[0].size() > ServerInstance->Config->Limits.IdentMax)
 		{
-			user->WriteServ("NOTICE %s :*** SETIDENT: Ident is too long", user->nick.c_str());
+			user->WriteNotice("*** SETIDENT: Ident is too long");
 			return CMD_FAILURE;
 		}
 
 		if (!ServerInstance->IsIdent(parameters[0].c_str()))
 		{
-			user->WriteServ("NOTICE %s :*** SETIDENT: Invalid characters in ident", user->nick.c_str());
+			user->WriteNotice("*** SETIDENT: Invalid characters in ident");
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_setname.cpp
+++ b/src/modules/m_setname.cpp
@@ -39,7 +39,7 @@ class CommandSetname : public Command
 	{
 		if (parameters[0].size() > ServerInstance->Config->Limits.MaxGecos)
 		{
-			user->WriteServ("NOTICE %s :*** SETNAME: GECOS too long", user->nick.c_str());
+			user->WriteNotice("*** SETNAME: GECOS too long");
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_showwhois.cpp
+++ b/src/modules/m_showwhois.cpp
@@ -46,9 +46,9 @@ class WhoisNoticeCmd : public Command
 
 	void HandleFast(User* dest, User* src)
 	{
-		dest->WriteServ("NOTICE %s :*** %s (%s@%s) did a /whois on you",
-			dest->nick.c_str(), src->nick.c_str(), src->ident.c_str(),
-			dest->HasPrivPermission("users/auspex") ? src->host.c_str() : src->dhost.c_str());
+		dest->WriteNotice("*** " + src->nick + " (" + src->ident + "@" +
+			(dest->HasPrivPermission("users/auspex") ? src->host : src->dhost) +
+			") did a /whois on you");
 	}
 
 	CmdResult Handle(const std::vector<std::string> &parameters, User *user)

--- a/src/modules/m_shun.cpp
+++ b/src/modules/m_shun.cpp
@@ -111,7 +111,7 @@ class CommandShun : public Command
 			}
 			else
 			{
-				user->WriteServ("NOTICE %s :*** Shun %s not found in list, try /stats H.",user->nick.c_str(),target.c_str());
+				user->WriteNotice("*** Shun " + target + " not found in list, try /stats H.");
 				return CMD_FAILURE;
 			}
 		}
@@ -150,7 +150,7 @@ class CommandShun : public Command
 			else
 			{
 				delete r;
-				user->WriteServ("NOTICE %s :*** Shun for %s already exists", user->nick.c_str(), target.c_str());
+				user->WriteNotice("*** Shun for " + target + " already exists");
 				return CMD_FAILURE;
 			}
 		}
@@ -255,7 +255,7 @@ class ModuleShun : public Module
 		if (i == ShunEnabledCommands.end())
 		{
 			if (NotifyOfShun)
-				user->WriteServ("NOTICE %s :*** Command %s not processed, as you have been blocked from issuing commands (SHUN)", user->nick.c_str(), command.c_str());
+				user->WriteNotice("*** Command " + command + " not processed, as you have been blocked from issuing commands (SHUN)");
 			return MOD_RES_DENY;
 		}
 

--- a/src/modules/m_silence.cpp
+++ b/src/modules/m_silence.cpp
@@ -149,7 +149,7 @@ class CommandSilence : public Command
 
 			if (pattern == 0)
 			{
-				user->WriteServ("NOTICE %s :Bad SILENCE pattern",user->nick.c_str());
+				user->WriteNotice("Bad SILENCE pattern");
 				return CMD_INVALID;
 			}
 

--- a/src/modules/m_spanningtree/main.cpp
+++ b/src/modules/m_spanningtree/main.cpp
@@ -388,7 +388,7 @@ void ModuleSpanningTree::RemoteMessage(User* user, const char* format, ...)
 	va_end(argsPtr);
 
 	if (IS_LOCAL(user))
-		user->WriteServ("NOTICE %s :%s", user->nick.c_str(), text);
+		user->WriteNotice(text);
 	else
 		ServerInstance->PI->SendUserNotice(user, text);
 }

--- a/src/modules/m_spanningtree/override_squit.cpp
+++ b/src/modules/m_spanningtree/override_squit.cpp
@@ -36,7 +36,7 @@ ModResult ModuleSpanningTree::HandleSquit(const std::vector<std::string>& parame
 	{
 		if (s == Utils->TreeRoot)
 		{
-			user->WriteServ("NOTICE %s :*** SQUIT: Foolish mortal, you cannot make a server SQUIT itself! (%s matches local server name)",user->nick.c_str(),parameters[0].c_str());
+			user->WriteNotice("*** SQUIT: Foolish mortal, you cannot make a server SQUIT itself! (" + parameters[0] + " matches local server name)");
 			return MOD_RES_DENY;
 		}
 
@@ -51,12 +51,12 @@ ModResult ModuleSpanningTree::HandleSquit(const std::vector<std::string>& parame
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** SQUIT may not be used to remove remote servers. Please use RSQUIT instead.",user->nick.c_str());
+			user->WriteNotice("*** SQUIT may not be used to remove remote servers. Please use RSQUIT instead.");
 		}
 	}
 	else
 	{
-		 user->WriteServ("NOTICE %s :*** SQUIT: The server \002%s\002 does not exist on the network.",user->nick.c_str(),parameters[0].c_str());
+		 user->WriteNotice("*** SQUIT: The server \002" + parameters[0] + "\002 does not exist on the network.");
 	}
 	return MOD_RES_DENY;
 }

--- a/src/modules/m_spanningtree/rconnect.cpp
+++ b/src/modules/m_spanningtree/rconnect.cpp
@@ -61,7 +61,7 @@ CmdResult CommandRConnect::Handle (const std::vector<std::string>& parameters, U
 		 */
 		if (IS_LOCAL(user))
 		{
-			user->WriteServ("NOTICE %s :*** RCONNECT: Sending remote connect to \002%s\002 to connect server \002%s\002.",user->nick.c_str(),parameters[0].c_str(),parameters[1].c_str());
+			user->WriteNotice("*** RCONNECT: Sending remote connect to \002 " + parameters[0] + "\002 to connect server \002" + parameters[1] + "\002.");
 		}
 	}
 	return CMD_SUCCESS;

--- a/src/modules/m_sslinfo.cpp
+++ b/src/modules/m_sslinfo.cpp
@@ -99,23 +99,23 @@ class CommandSSLInfo : public Command
 		bool operonlyfp = ServerInstance->Config->ConfValue("sslinfo")->getBool("operonly");
 		if (operonlyfp && !user->IsOper() && target != user)
 		{
-			user->WriteServ("NOTICE %s :*** You cannot view SSL certificate information for other users", user->nick.c_str());
+			user->WriteNotice("*** You cannot view SSL certificate information for other users");
 			return CMD_FAILURE;
 		}
 		ssl_cert* cert = CertExt.get(target);
 		if (!cert)
 		{
-			user->WriteServ("NOTICE %s :*** No SSL certificate for this user", user->nick.c_str());
+			user->WriteNotice("*** No SSL certificate for this user");
 		}
 		else if (cert->GetError().length())
 		{
-			user->WriteServ("NOTICE %s :*** No SSL certificate information for this user (%s).", user->nick.c_str(), cert->GetError().c_str());
+			user->WriteNotice("*** No SSL certificate information for this user (" + cert->GetError() + ").");
 		}
 		else
 		{
-			user->WriteServ("NOTICE %s :*** Distinguished Name: %s", user->nick.c_str(), cert->GetDN().c_str());
-			user->WriteServ("NOTICE %s :*** Issuer:             %s", user->nick.c_str(), cert->GetIssuer().c_str());
-			user->WriteServ("NOTICE %s :*** Key Fingerprint:    %s", user->nick.c_str(), cert->GetFingerprint().c_str());
+			user->WriteNotice("*** Distinguished Name: " + cert->GetDN());
+			user->WriteNotice("*** Issuer:             " + cert->GetIssuer());
+			user->WriteNotice("*** Key Fingerprint:    " + cert->GetFingerprint());
 		}
 		return CMD_SUCCESS;
 	}

--- a/src/modules/m_svshold.cpp
+++ b/src/modules/m_svshold.cpp
@@ -108,7 +108,7 @@ class CommandSvshold : public Command
 			}
 			else
 			{
-				user->WriteServ("NOTICE %s :*** SVSHOLD %s not found in list, try /stats S.",user->nick.c_str(),parameters[0].c_str());
+				user->WriteNotice("*** SVSHOLD " + parameters[0] + " not found in list, try /stats S.");
 			}
 		}
 		else

--- a/src/modules/m_timedbans.cpp
+++ b/src/modules/m_timedbans.cpp
@@ -70,7 +70,7 @@ class CommandTban : public Command
 		unsigned long expire = duration + ServerInstance->Time();
 		if (duration < 1)
 		{
-			user->WriteServ("NOTICE "+user->nick+" :Invalid ban time");
+			user->WriteNotice("Invalid ban time");
 			return CMD_FAILURE;
 		}
 		std::string mask = parameters[2];
@@ -87,7 +87,7 @@ class CommandTban : public Command
 		ServerInstance->Parser->CallHandler("MODE",setban,user);
 		if (ServerInstance->Modes->GetLastParse().empty())
 		{
-			user->WriteServ("NOTICE "+user->nick+" :Invalid ban mask");
+			user->WriteNotice("Invalid ban mask");
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_vhost.cpp
+++ b/src/modules/m_vhost.cpp
@@ -49,14 +49,14 @@ class CommandVhost : public Command
 			{
 				if (!mask.empty())
 				{
-					user->WriteServ("NOTICE "+user->nick+" :Setting your VHost: " + mask);
+					user->WriteNotice("Setting your VHost: " + mask);
 					user->ChangeDisplayedHost(mask.c_str());
 					return CMD_SUCCESS;
 				}
 			}
 		}
 
-		user->WriteServ("NOTICE "+user->nick+" :Invalid username or password.");
+		user->WriteNotice("Invalid username or password.");
 		return CMD_FAILURE;
 	}
 };

--- a/src/snomasks.cpp
+++ b/src/snomasks.cpp
@@ -120,7 +120,7 @@ void Snomask::SendMessage(const std::string &message, char mysnomask)
 				User* a = *i;
 				if (IS_LOCAL(a) && a->IsModeSet('s') && a->IsNoticeMaskSet(mysnomask) && !a->quitting)
 				{
-					a->WriteServ("NOTICE %s :*** %s: %s", a->nick.c_str(), desc.c_str(), message.c_str());
+					a->WriteNotice("*** " + desc + ": " + message);
 				}
 
 				i++;
@@ -155,7 +155,7 @@ void Snomask::Flush()
 				User* a = *i;
 				if (IS_LOCAL(a) && a->IsModeSet('s') && a->IsNoticeMaskSet(LastLetter) && !a->quitting)
 				{
-					a->WriteServ("NOTICE %s :*** %s: %s", a->nick.c_str(), desc.c_str(), mesg.c_str());
+					a->WriteNotice("*** " + desc + ": " + mesg);
 				}
 
 				i++;

--- a/src/usermanager.cpp
+++ b/src/usermanager.cpp
@@ -110,7 +110,7 @@ void UserManager::AddUser(int socket, ListenSocket* via, irc::sockets::sockaddrs
 			/* user banned */
 			ServerInstance->Logs->Log("BANCACHE", LOG_DEBUG, "BanCache: Positive hit for " + New->GetIPString());
 			if (!ServerInstance->Config->MoronBanner.empty())
-				New->WriteServ("NOTICE %s :*** %s", New->nick.c_str(), ServerInstance->Config->MoronBanner.c_str());
+				New->WriteNotice("*** " +  ServerInstance->Config->MoronBanner);
 			this->QuitUser(New, b->Reason);
 			return;
 		}
@@ -140,7 +140,7 @@ void UserManager::AddUser(int socket, ListenSocket* via, irc::sockets::sockaddrs
 	}
 
 	if (ServerInstance->Config->RawLog)
-		New->WriteServ("NOTICE Auth :*** Raw I/O logging is enabled on this server. All messages, passwords, and commands are being recorded.");
+		New->WriteNotice("*** Raw I/O logging is enabled on this server. All messages, passwords, and commands are being recorded.");
 
 	FOREACH_MOD(I_OnSetUserIP,OnSetUserIP(New));
 	if (New->quitting)

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -388,7 +388,7 @@ bool LocalUser::HasPrivPermission(const std::string &privstr, bool noisy)
 	if (!this->IsOper())
 	{
 		if (noisy)
-			this->WriteServ("NOTICE %s :You are not an oper", this->nick.c_str());
+			this->WriteNotice("You are not an oper");
 		return false;
 	}
 
@@ -402,7 +402,8 @@ bool LocalUser::HasPrivPermission(const std::string &privstr, bool noisy)
 	}
 
 	if (noisy)
-		this->WriteServ("NOTICE %s :Oper type %s does not have access to priv %s", this->nick.c_str(), oper->NameStr(), privstr.c_str());
+		this->WriteNotice("Oper type " + std::string(oper->NameStr()) + " does not have access to priv " + privstr);
+
 	return false;
 }
 
@@ -1047,6 +1048,10 @@ void User::WriteServ(const char* text, ...)
 	this->WriteServ(std::string(textbuffer));
 }
 
+void User::WriteNotice(const std::string& text)
+{
+	this->WriteServ("NOTICE " + (this->registered == REG_ALL ? this->nick : "*") + " :" + text);
+}
 
 void User::WriteNumeric(unsigned int numeric, const char* text, ...)
 {

--- a/src/xline.cpp
+++ b/src/xline.cpp
@@ -534,7 +534,7 @@ void XLine::DefaultApply(User* u, const std::string &line, bool bancache)
 	char sreason[MAXBUF];
 	snprintf(sreason, MAXBUF, "%s-Lined: %s", line.c_str(), this->reason.c_str());
 	if (!ServerInstance->Config->MoronBanner.empty())
-		u->WriteServ("NOTICE %s :*** %s", u->nick.c_str(), ServerInstance->Config->MoronBanner.c_str());
+		u->WriteNotice("*** " + ServerInstance->Config->MoronBanner);
 
 	if (ServerInstance->Config->HideBans)
 		ServerInstance->Users->QuitUser(u, line + "-Lined", sreason);


### PR DESCRIPTION
This allows us to send a server notice to a user without worrying about whether they are registered or not.

If a user receives a server notice and they are not registered then the nickname field will contain an asterisk instead of their nick name.

We previously sent 'Auth' instead of an asterisk but this was a non-standard feature which there was no consensus on how it must be implemented.

This change modifies the way we implement it to be the same as Charybdis. This is more sensible because:
1. It is used for a similar job by other parts of the protocol.
2. It is not a valid nickname character.
