### PR TITLE
Fix kqueue test on non-Apple BSDs.

### DIFF
--- a/make/test/kqueue.cpp
+++ b/make/test/kqueue.cpp
@@ -16,6 +16,7 @@
  */
 
 
+#include <sys/types.h>
 #include <sys/event.h>
 
 int main() {


### PR DESCRIPTION
On non-Apple kqueue implementations, you need to include `<sys/types.h>` manually.
