### PR TITLE
Clean up the FileReader class and all of the modules that use it.

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -1281,76 +1281,38 @@ class CoreExport Module : public classbase, public usecountbase
 	virtual void OnSetUserIP(LocalUser* user);
 };
 
-/** Caches a text file into memory and can be used to retrieve lines from it.
- * This class contains methods for read-only manipulation of a text file in memory.
- * Either use the constructor type with one parameter to load a file into memory
- * at construction, or use the LoadFile method to load a file.
- */
+/** Provides an easy method of reading a text file into memory. */
 class CoreExport FileReader : public classbase
 {
-	/** The file contents
-	 */
-	std::vector<std::string> fc;
+	/** The lines of text in the file. */
+	std::vector<std::string> lines;
 
-	/** Content size in bytes
-	 */
-	unsigned long contentsize;
-
-	/** Calculate content size in bytes
-	 */
-	void CalcSize();
+	/** Content size in bytes */
+	unsigned long totalSize;
 
  public:
-	/** Default constructor.
-	 * This method does not load any file into memory, you must use the LoadFile method
-	 * after constructing the class this way.
-	 */
-	FileReader();
+	/** Initializes a new file reader. */
+	FileReader() { }
 
-	/** Secondary constructor.
-	 * This method initialises the class with a file loaded into it ready for GetLine and
-	 * and other methods to be called. If the file could not be loaded, FileReader::FileSize
-	 * returns 0.
+	/** Initializes a new file reader and reads the specified file.
+	 * @param file The file to read into memory.
 	 */
-	FileReader(const std::string &filename);
+	FileReader(const std::string& filename);
 
-	/** Default destructor.
-	 * This deletes the memory allocated to the file.
+	/** Loads a text file from disk.
+	 * @param filename The file to read into memory.
+	 * @throw CoreException The file can not be loaded.
 	 */
-	~FileReader();
+	void Load(const std::string& filename);
 
-	/** Used to load a file.
-	 * This method loads a file into the class ready for GetLine and
-	 * and other methods to be called. If the file could not be loaded, FileReader::FileSize
-	 * returns 0.
+	/** Retrieves the entire contents of the file cache as a single string.
 	 */
-	void LoadFile(const std::string &filename);
+	std::string GetString();
 
-	/** Returns the whole content of the file as std::string
-	 */
-	std::string Contents();
+	/** Retrieves the entire contents of the file cache as a vector of strings. */
+	const std::vector<std::string>& GetVector() { return lines; }
 
-	/** Returns the entire size of the file as std::string
-	 */
-	unsigned long ContentSize();
-
-	/** Returns true if the file exists
-	 * This function will return false if the file could not be opened.
-	 */
-	bool Exists();
-
-	/** Retrieve one line from the file.
-	 * This method retrieves one line from the text file. If an empty non-NULL string is returned,
-	 * the index was out of bounds, or the line had no data on it.
-	 */
-	std::string GetLine(int x);
-
-	/** Returns the size of the file in lines.
-	 * This method returns the number of lines in the read file. If it is 0, no lines have been
-	 * read into memory, either because the file is empty or it does not exist, or cannot be
-	 * opened due to permission problems.
-	 */
-	int FileSize();
+	unsigned long TotalSize() { return totalSize; }
 };
 
 /** A list of modules

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -23,7 +23,6 @@
 
 
 #include "inspircd.h"
-#include <fstream>
 #include "xline.h"
 #include "listmode.h"
 #include "exitcodes.h"

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -360,12 +360,12 @@ class ModuleSSLGnuTLS : public Module
 
 		FileReader reader;
 
-		reader.LoadFile(certfile);
-		std::string cert_string = reader.Contents();
+		reader.Load(certfile);
+		std::string cert_string = reader.GetString();
 		gnutls_datum_t cert_datum = { (unsigned char*)cert_string.data(), static_cast<unsigned int>(cert_string.length()) };
 
-		reader.LoadFile(keyfile);
-		std::string key_string = reader.Contents();
+		reader.Load(keyfile);
+		std::string key_string = reader.GetString();
 		gnutls_datum_t key_datum = { (unsigned char*)key_string.data(), static_cast<unsigned int>(key_string.length()) };
 
 		// If this fails, no SSL port will work. At all. So, do the smart thing - throw a ModuleException
@@ -431,8 +431,8 @@ class ModuleSSLGnuTLS : public Module
 		if (!dhfile.empty())
 		{
 			// Try to load DH params from file
-			reader.LoadFile(dhfile);
-			std::string dhstring = reader.Contents();
+			reader.Load(dhfile);
+			std::string dhstring = reader.GetString();
 			gnutls_datum_t dh_datum = { (unsigned char*)dhstring.data(), static_cast<unsigned int>(dhstring.length()) };
 
 			if ((ret = gnutls_dh_params_import_pkcs3(dh_params, &dh_datum, GNUTLS_X509_FMT_PEM)) < 0)

--- a/src/modules/m_opermotd.cpp
+++ b/src/modules/m_opermotd.cpp
@@ -107,9 +107,15 @@ class ModuleOpermotd : public Module
 		ConfigTag* conf = ServerInstance->Config->ConfValue("opermotd");
 		onoper = conf->getBool("onoper", true);
 
-		FileReader f(conf->getString("file", "opermotd"));
-		for (int i=0, filesize = f.FileSize(); i < filesize; i++)
-			cmd.opermotd.push_back(f.GetLine(i));
+		try
+		{
+			FileReader reader(conf->getString("file", "opermotd"));
+			cmd.opermotd = reader.GetVector();
+		}
+		catch (CoreException&)
+		{
+			// Nothing happens here as we do the error handling in ShowOperMOTD.
+		}
 
 		if (conf->getBool("processcolors"))
 			InspIRCd::ProcessColors(cmd.opermotd);


### PR DESCRIPTION
- Modules which use this class will now have to catch a
  CoreException when opening files if they wish to ignore
  the failed loading of a file.
- m_randquote has been cleaned up massively and the RANDQUOTE
  command has been removed as it was pretty much useless.

---

Hopefully my second attempt at C++ifying this sucks less.
