### PR TITLE
Add support for detecting C++11 variadic templates.

### DIFF
--- a/include/caller.h
+++ b/include/caller.h
@@ -21,8 +21,7 @@
 
 #pragma once
 
-/* Pending some sort of C++11 support */
-#if 0
+#if defined HAS_CXX11_VARIADIC_TEMPLATES
 
 template<typename ReturnType, typename... Args> class CoreExport Handler : public classbase
 {

--- a/include/compat.h
+++ b/include/compat.h
@@ -72,6 +72,24 @@
 #endif
 
 /**
+ * These macros enable the detection of the C++11 variadic templates in
+ * compilers which support them.
+ */
+#if __cplusplus >= 201103L
+# define HAS_CXX11_VARIADIC_TEMPLATES
+#elif defined __clang__
+# if __has_feature(cxx_variadic_templates)
+#  define HAS_CXX11_VARIADIC_TEMPLATES
+# endif
+#elif (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
+# if defined __GXX_EXPERIMENTAL_CXX0X__
+#  define HAS_CXX11_VARIADIC_TEMPLATES
+# endif
+#elif _MSC_VER >= 1700
+# define HAS_CXX11_VARIADIC_TEMPLATES
+#endif
+
+/**
  * This macro allows methods to be marked as deprecated. To use this, wrap the
  * method declaration in the header file with the macro.
  */


### PR DESCRIPTION
Also, enable support for it in `caller.h`.
