### PR TITLE
Prevent m_cgiirc from blocking registration indefinitely

### DIFF
--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -207,8 +207,8 @@ class ModuleCgiIRC : public Module
 		{
 			bool cached;
 			CGIResolver* r = new CGIResolver(this, cmd.notify, newip, user, (was_pass ? "PASS" : "IDENT"), cached, waiting);
-			ServerInstance->AddResolver(r, cached);
 			waiting.set(user, waiting.get(user) + 1);
+			ServerInstance->AddResolver(r, cached);
 		}
 		catch (...)
 		{


### PR DESCRIPTION
I encountered an issue with 2.0.13 (and earlier) where m_cgiirc would block indefinitely, resulting in registration timeouts when using e.g. Mibbit with the ident method.

I added a bunch of debug logging to look at this, and it looks like the CGIResolver instance gets destroyed somewhere in the AddResolver call... which seems weird to me, so maybe there's a better way to fix this, but this seemed to work in my (quite brief) testing.  If someone who knows more about Insp internals wants to tackle this better (in AddResolver?), go ahead and close this and do that.
