### PR TITLE
Made the launch script aware of --runasroot

### DIFF
--- a/make/template/inspircd
+++ b/make/template/inspircd
@@ -33,7 +33,7 @@ my $executable	=	"@EXECUTABLE@";
 my $version	=	"@VERSION@";
 my $uid = "@UID@";
 
-if ($< == 0 || $> == 0) {
+if (!("--runasroot" ~~ @ARGV) && ($< == 0 || $> == 0)) {
 	if ($uid !~ /^\d+$/) {
 		# Named UID, look it up
 		$uid = getpwnam $uid;


### PR DESCRIPTION
So it does not drop privs if this is specified. While running the daemon as root is stupid, the users would expect to be able to launch it as root through the script the same way the ircd itself accepts the --runasroot parameter.
