### PR TITLE
Allow for skipping clone checking before DNS is complete.

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -663,6 +663,15 @@
              # connections. If defined, it sets a soft max connections value.
              softlimit="12800"
 
+             # clonesonconnect: If this is set to false, we won't check for clones
+             # on initial connection, but only after the DNS check is done.
+             # This can be useful where your main class is more restrictive
+             # than some other class a user can be assigned after DNS lookup is complete.
+             # Turning this option off will make the server spend more time on users we may
+             # potentially not want. Normally this should be neglible, though.
+             # Default value is true
+             clonesonconnect="true"
+
              # quietbursts: When syncing or splitting from a network, a server
              # can generate a lot of connect and quit messages to opers with
              # +C and +Q snomasks. Setting this to yes squelches those messages,

--- a/include/configreader.h
+++ b/include/configreader.h
@@ -373,6 +373,13 @@ class CoreExport ServerConfig
 	 */
 	int MaxConn;
 
+	/** If we should check for clones during CheckClass() in AddUser()
+	 * Setting this to false allows to not trigger on maxclones for users
+	 * that may belong to another class after DNS-lookup is complete.
+	 * It does, however, make the server spend more time on users we may potentially not want.
+	 */
+	bool CCOnConnect;
+
 	/** The soft limit value assigned to the irc server.
 	 * The IRC server will not allow more than this
 	 * number of local users.

--- a/include/users.h
+++ b/include/users.h
@@ -750,7 +750,7 @@ class CoreExport LocalUser : public User, public InviteBase
 
 	/** Call this method to find the matching \<connect> for a user, and to check them against it.
 	 */
-	void CheckClass();
+	void CheckClass(bool clone_count = true);
 
 	/** Server address and port that this user is connected to.
 	 */

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -387,6 +387,7 @@ void ServerConfig::Fill()
 	SuffixPart = options->getString("suffixpart");
 	FixedPart = options->getString("fixedpart");
 	SoftLimit = ConfValue("performance")->getInt("softlimit", ServerInstance->SE->GetMaxFds());
+	CCOnConnect = ConfValue("performance")->getBool("clonesonconnect", true);
 	MaxConn = ConfValue("performance")->getInt("somaxconn", SOMAXCONN);
 	MoronBanner = options->getString("moronbanner", "You're banned!");
 	ServerDesc = ConfValue("server")->getString("description", "Configure Me");

--- a/src/usermanager.cpp
+++ b/src/usermanager.cpp
@@ -112,7 +112,7 @@ void UserManager::AddUser(int socket, ListenSocket* via, irc::sockets::sockaddrs
 	 * Check connect class settings and initialise settings into User.
 	 * This will be done again after DNS resolution. -- w00t
 	 */
-	New->CheckClass();
+	New->CheckClass(ServerInstance->Config->CCOnConnect);
 	if (New->quitting)
 		return;
 

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -600,7 +600,7 @@ void User::UnOper()
 /*
  * Check class restrictions
  */
-void LocalUser::CheckClass()
+void LocalUser::CheckClass(bool clone_count)
 {
 	ConnectClass* a = this->MyClass;
 
@@ -614,19 +614,22 @@ void LocalUser::CheckClass()
 		ServerInstance->Users->QuitUser(this, a->config->getString("reason", "Unauthorised connection"));
 		return;
 	}
-	else if ((a->GetMaxLocal()) && (ServerInstance->Users->LocalCloneCount(this) > a->GetMaxLocal()))
+	else if (clone_count)
 	{
-		ServerInstance->Users->QuitUser(this, "No more connections allowed from your host via this connect class (local)");
-		if (a->maxconnwarn)
-			ServerInstance->SNO->WriteToSnoMask('a', "WARNING: maximum LOCAL connections (%ld) exceeded for IP %s", a->GetMaxLocal(), this->GetIPString().c_str());
-		return;
-	}
-	else if ((a->GetMaxGlobal()) && (ServerInstance->Users->GlobalCloneCount(this) > a->GetMaxGlobal()))
-	{
-		ServerInstance->Users->QuitUser(this, "No more connections allowed from your host via this connect class (global)");
-		if (a->maxconnwarn)
-			ServerInstance->SNO->WriteToSnoMask('a', "WARNING: maximum GLOBAL connections (%ld) exceeded for IP %s", a->GetMaxGlobal(), this->GetIPString().c_str());
-		return;
+		if ((a->GetMaxLocal()) && (ServerInstance->Users->LocalCloneCount(this) > a->GetMaxLocal()))
+		{
+			ServerInstance->Users->QuitUser(this, "No more connections allowed from your host via this connect class (local)");
+			if (a->maxconnwarn)
+				ServerInstance->SNO->WriteToSnoMask('a', "WARNING: maximum LOCAL connections (%ld) exceeded for IP %s", a->GetMaxLocal(), this->GetIPString().c_str());
+			return;
+		}
+		else if ((a->GetMaxGlobal()) && (ServerInstance->Users->GlobalCloneCount(this) > a->GetMaxGlobal()))
+		{
+			ServerInstance->Users->QuitUser(this, "No more connections allowed from your host via this connect class (global)");
+			if (a->maxconnwarn)
+				ServerInstance->SNO->WriteToSnoMask('a', "WARNING: maximum GLOBAL connections (%ld) exceeded for IP %s", a->GetMaxGlobal(), this->GetIPString().c_str());
+			return;
+		}
 	}
 
 	this->nping = ServerInstance->Time() + a->GetPingTime() + ServerInstance->Config->dns_timeout;


### PR DESCRIPTION
As it is now, a user will be booted if CheckClass() discovers the user's IP is past the clone limit.
This can be a problem where there is less restrictive class intended for the user, applied by DNS.
This patch allows for not checking clones before after DNS is done, hence mitigating this issue.
