### PR TITLE
Fix some warnings which are causing debug builds to fail.

### DIFF
--- a/include/modules/httpd.h
+++ b/include/modules/httpd.h
@@ -185,11 +185,11 @@ class HTTPRequest : public Event
  */
 class HTTPDocumentResponse
 {
+ public:
 	/** Module that generated this reply
 	 */
 	Module* const module;
 
- public:
 	std::stringstream* document;
 	unsigned int responsecode;
 

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -183,7 +183,10 @@ struct Parser
 		std::set<std::string> seen;
 		tag = ConfigTag::create(name, current.filename, current.line, items);
 
-		while (kv(items, seen));
+		while (kv(items, seen))
+		{
+			// Do nothing here (silences a GCC warning).
+		}
 
 		if (name == mandatory_tag)
 		{


### PR DESCRIPTION
- Clang: private field 'module' is not used
- GCC: suggest a space before ‘;’ or explicit braces around empty body in ‘while’ statement
