### PR TITLE
Clean up the build system properties and related code.

### DIFF
--- a/configure
+++ b/configure
@@ -41,7 +41,7 @@ use Getopt::Long;
 use make::configure;
 use make::utilities;
 
-our ($opt_use_gnutls, $opt_use_openssl, $opt_nointeractive, $opt_socketengine, $opt_freebsd_port,
+our ($opt_use_gnutls, $opt_use_openssl, $opt_nointeractive, $opt_socketengine,
      $opt_system, $opt_uid, $opt_base_dir, $opt_config_dir, $opt_module_dir, $opt_binary_dir,
      $opt_data_dir, $opt_log_dir);
 
@@ -61,7 +61,6 @@ GetOptions (
 	'enable-openssl' => \$opt_use_openssl,
 	'disable-interactive' => \$opt_nointeractive,
 	'socketengine=s' => \$opt_socketengine,
-	'enable-freebsd-ports-openssl' => \$opt_freebsd_port,
 	'prefix=s' => \$opt_base_dir,
 	'config-dir=s' => \$opt_config_dir,
 	'module-dir=s' => \$opt_module_dir,
@@ -99,8 +98,7 @@ our $interactive = !(
 	(defined $opt_use_openssl) ||
 	(defined $opt_system) ||
 	(defined $opt_uid) ||
-	(defined $opt_use_gnutls) ||
-	(defined $opt_freebsd_port)
+	(defined $opt_use_gnutls)
 );
 
 our $topdir = getcwd();
@@ -149,28 +147,8 @@ if (defined $opt_data_dir) {
 if (defined $opt_log_dir) {
 	$config{LOG_DIR} = $opt_log_dir;
 }
-chomp($config{HAS_GNUTLS}   = `pkg-config --modversion gnutls 2>/dev/null`); # GNUTLS Version.
-
-if (defined $opt_freebsd_port)
-{
-	chomp($config{HAS_OPENSSL} = `pkg-config --modversion openssl 2>/dev/null`);
-	chomp($config{HAS_OPENSSL_PORT}  = `pkg-config --modversion openssl 2>/dev/null`);
-	$config{USE_FREEBSD_BASE_SSL} = "n";
-}
-else
-{
-	if ($^O eq "freebsd")
-	{
-		# default: use base ssl
-		chomp($config{HAS_OPENSSL} = `openssl version | cut -d ' ' -f 2`);			# OpenSSL version, freebsd specific
-		chomp($config{HAS_OPENSSL_PORT}  = `pkg-config --modversion openssl 2>/dev/null`);	# Port version, may be different
-	}
-	else
-	{
-		chomp($config{HAS_OPENSSL}  = `pkg-config --modversion openssl 2>/dev/null`);		# Openssl version, others
-		$config{HAS_OPENSSL_PORT} = "";
-	}
-}
+chomp($config{HAS_GNUTLS}   = `pkg-config --modversion gnutls 2>/dev/null`);
+chomp($config{HAS_OPENSSL}  = `pkg-config --modversion openssl 2>/dev/null`);
 
 chomp(our $gnutls_ver = $config{HAS_GNUTLS});
 chomp(our $openssl_ver = $config{HAS_OPENSSL});
@@ -402,28 +380,6 @@ STOP
 		$config{SOCKETENGINE} = "select";
 	}
 
-	$config{USE_FREEBSD_BASE_SSL} = "n";
-	$config{USE_FREEBSD_PORTS_SSL} = "n";
-	if ($config{HAS_OPENSSL_PORT} ne "")
-	{
-		$config{USE_FREEBSD_PORTS_SSL} = "y";
-		print "I have detected the OpenSSL FreeBSD port installed on your system,\n";
-		print "version \e[1;32m".$config{HAS_OPENSSL_PORT}."\e[0m. Your base system OpenSSL is version \e[1;32m".$openssl_ver."\e[0m.\n\n";
-		yesno('USE_FREEBSD_PORTS_SSL', "Do you want to use the FreeBSD ports version?");
-		print "\n";
-		$config{USE_FREEBSD_BASE_SSL} = "y" if ($config{USE_FREEBSD_PORTS_SSL} eq "n");
-
-		if ($config{USE_FREEBSD_BASE_SSL} eq "n")
-		{
-			# update to port version
-			$openssl_ver = $config{HAS_OPENSSL_PORT};
-		}
-	}
-	else
-	{
-		$config{USE_FREEBSD_BASE_SSL} = "y" if ($^O eq "freebsd");
-	}
-
 	$config{USE_SSL} = "n";
 
 	if ($config{HAS_GNUTLS} eq "y" || $config{HAS_OPENSSL} eq "y")
@@ -465,12 +421,12 @@ symlink "extra/m_regex_posix.cpp", "src/modules/m_regex_posix.cpp";
 
 if (($config{USE_GNUTLS} eq "y") && ($config{HAS_GNUTLS} ne "y"))
 {
-	print "Sorry, but i couldn't detect gnutls. Make sure gnutls-config is in your path.\n";
+	print "Sorry, but i couldn't detect gnutls. Make sure pkg-config is in your path.\n";
 	exit 1;
 }
 if (($config{USE_OPENSSL} eq "y") && ($config{HAS_OPENSSL} ne "y"))
 {
-	print "Sorry, but i couldn't detect openssl. Make sure openssl is in your path.\n";
+	print "Sorry, but i couldn't detect openssl. Make sure pkg-config is in your path.\n";
 	exit 1;
 }
 
@@ -531,7 +487,7 @@ if (($config{USE_GNUTLS} eq "n") && ($config{USE_OPENSSL} eq "n")) {
 	print "Skipping SSL Certificate generation, SSL support is not available.\n\n";
 }
 
-depcheck();
+getmodules();
 writefiles();
 makecache();
 dumphash();
@@ -732,15 +688,6 @@ EOF
 	chmod 0755, 'inspircd';
 }
 
-sub depcheck
-{
-	getmodules();
-	for my $mod (@modlist) {
-		getcompilerflags("src/modules/m_$mod.cpp");
-		getlinkerflags("src/modules/m_$mod.cpp");
-	}
-}
-
 # Routine to list out the extra/ modules that have been enabled.
 # Note: when getting any filenames out and comparing, it's important to lc it if the
 # file system is not case-sensitive (== Epoc, MacOS, OS/2 (incl DOS/DJGPP), VMS, Win32
@@ -804,7 +751,7 @@ EXTRA:	for my $extra (@extras) {
 	for my $extra (keys(%extras)) {
 		next unless $extras{$extra} =~ m/enabled/; # only process enabled extras.
 		my $abs_extra = File::Spec->catfile($abs_srcdir, "extra", $extra);
-		my @deps = split / +/, getdependencies($abs_extra);
+		my @deps = split /\s+/, get_property($abs_extra, 'ModDep');
 		for my $dep (@deps) {
 			if (exists($extras{$dep})) {
 				my $ref = \$extras{$dep}; # Take reference.
@@ -851,7 +798,7 @@ sub enable_extras (@) {
 			next;
 		}
 		# Get dependencies, and add them to be processed.
-		my @deps = split / +/, getdependencies($extrapath);
+		my @deps = split /\s+/, get_property($extrapath, 'ModDep');
 		for my $dep (@deps) {
 			next if scalar(grep { $_ eq $dep } (@extras)) > 0; # Skip if we're going to be enabling it anyway.
 			if (!-e "src/modules/$dep" && !-e "include/$dep") {
@@ -887,7 +834,7 @@ EXTRA:	for my $extra (@extras) {
 		}
 		# Check if anything needs this.
 		for my $file (@files) {
-			my @deps = split / +/, getdependencies("src/modules/extra/$file");
+			my @deps = split /\s+/, get_property("src/modules/extra/$file", 'ModDep');
 			# File depends on this extra...
 			if (scalar(grep { $_ eq $extra } @deps) > 0) {
 				# And is both enabled and not about to be disabled.

--- a/make/unit-cc.pl
+++ b/make/unit-cc.pl
@@ -52,7 +52,7 @@ exit 1;
 sub do_static_find {
 	my @flags;
 	for my $file (@ARGV) {
-		push @flags, getlinkerflags($file);
+		push @flags, get_property($file, 'LinkerFlags');
 	}
 	open F, '>', $out;
 	print F join ' ', @flags;
@@ -97,9 +97,7 @@ sub do_compile {
 	my $libs = '';
 	my $binary = $ENV{RUNCC};
 	if ($do_compile) {
-		$flags = $ENV{CORECXXFLAGS};
-		$flags =~ s/ -pedantic// if nopedantic($file);
-		$flags .= ' ' . getcompilerflags($file);
+		$flags = $ENV{CORECXXFLAGS} . ' ' . get_property($file, 'CompileFlags');
 
 		if ($file =~ m#(?:^|/)((?:m|cmd)_[^/. ]+)(?:\.cpp|/.*\.cpp)$#) {
 			$flags .= ' -DMODNAME=\\"'.$1.'\\"';
@@ -110,7 +108,7 @@ sub do_compile {
 
 	if ($do_link) {
 		$flags = join ' ', $flags, $ENV{PICLDFLAGS};
-		$libs = join ' ', getlinkerflags($file);
+		$libs = get_property($file, 'LinkerFlags');
 	} else {
 		$flags .= ' -c';
 	}

--- a/make/utilities.pm
+++ b/make/utilities.pm
@@ -108,15 +108,6 @@ sub pkgconfig_get_include_dirs($$$;$)
 {
 	my ($packagename, $headername, $defaults, $module) = @_;
 
-	my $key = "default_includedir_$packagename";
-	if (exists $main::config{$key})
-	{
-		print "Locating include directory for package \e[1;32m$packagename\e[0m for module \e[1;32m$module\e[0m... ";
-		my $ret = $main::config{$key};
-		print "\e[1;32m$ret\e[0m (cached)\n";
-		return $ret;
-	}
-
 	extend_pkg_path();
 
 	print "Locating include directory for package \e[1;32m$packagename\e[0m for module \e[1;32m$module\e[0m... ";
@@ -222,15 +213,6 @@ sub pkgconfig_check_version($$;$)
 sub pkgconfig_get_lib_dirs($$$;$)
 {
 	my ($packagename, $libname, $defaults, $module) = @_;
-
-	my $key = "default_libdir_$packagename";
-	if (exists $main::config{$key})
-	{
-		print "Locating library directory for package \e[1;32m$packagename\e[0m for module \e[1;32m$module\e[0m... ";
-		my $ret = $main::config{$key};
-		print "\e[1;32m$ret\e[0m (cached)\n";
-		return $ret;
-	}
 
 	extend_pkg_path();
 

--- a/src/modules/extra/m_sqlite3.cpp
+++ b/src/modules/extra/m_sqlite3.cpp
@@ -28,9 +28,8 @@
 # pragma comment(lib, "sqlite3.lib")
 #endif
 
-/* $CompileFlags: pkgconfversion("sqlite3","3.3") pkgconfincludes("sqlite3","/sqlite3.h","") */
+/* $CompileFlags: pkgconfversion("sqlite3","3.3") pkgconfincludes("sqlite3","/sqlite3.h","") -Wno-pedantic */
 /* $LinkerFlags: pkgconflibs("sqlite3","/libsqlite3.so","-lsqlite3") */
-/* $NoPedantic */
 
 class SQLConn;
 typedef std::map<std::string, SQLConn*> ConnMap;

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -44,9 +44,8 @@
 # pragma comment(lib, "gdi32.lib")
 #endif
 
-/* $CompileFlags: pkgconfincludes("gnutls","/gnutls/gnutls.h","") exec("libgcrypt-config --cflags") */
+/* $CompileFlags: pkgconfincludes("gnutls","/gnutls/gnutls.h","") exec("libgcrypt-config --cflags") -Wno-pedantic */
 /* $LinkerFlags: rpath("pkg-config --libs gnutls") pkgconflibs("gnutls","/libgnutls.so","-lgnutls") exec("libgcrypt-config --libs") */
-/* $NoPedantic */
 
 // These don't exist in older GnuTLS versions
 #if ((GNUTLS_VERSION_MAJOR > 2) || (GNUTLS_VERSION_MAJOR == 2 && GNUTLS_VERSION_MINOR > 1) || (GNUTLS_VERSION_MAJOR == 2 && GNUTLS_VERSION_MINOR == 1 && GNUTLS_VERSION_MICRO >= 7))

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -48,12 +48,8 @@
 # define MAX_DESCRIPTORS 10000
 #endif
 
-/* $LinkerFlags: if("USE_FREEBSD_BASE_SSL") -lssl -lcrypto */
-/* $CompileFlags: if(!"USE_FREEBSD_BASE_SSL") pkgconfversion("openssl","0.9.7") pkgconfincludes("openssl","/openssl/ssl.h","") */
-/* $LinkerFlags: if(!"USE_FREEBSD_BASE_SSL") rpath("pkg-config --libs openssl") pkgconflibs("openssl","/libssl.so","-lssl -lcrypto -ldl") */
-
-/* $NoPedantic */
-
+/* $CompileFlags: pkgconfversion("openssl","0.9.7") pkgconfincludes("openssl","/openssl/ssl.h","") -Wno-pedantic */
+/* $LinkerFlags: rpath("pkg-config --libs openssl") pkgconflibs("openssl","/libssl.so","-lssl -lcrypto") */
 
 enum issl_status { ISSL_NONE, ISSL_HANDSHAKING, ISSL_OPEN };
 

--- a/src/threadengine.cpp
+++ b/src/threadengine.cpp
@@ -17,10 +17,6 @@
  */
 
 
-/*********        DEFAULTS       **********/
-/* $ExtraSources: threadengines/threadengine_pthread.cpp */
-/* $ExtraObjects: threadengine_pthread.o */
-
 #include "inspircd.h"
 #include "threadengine.h"
 


### PR DESCRIPTION
- Deduplicate getcompilerflags, getdependancies, getlinkerflags.
- Remove $NoPedantic (add -Wno-pedantic to $CompileFlags instead).
- Remove --enable-freebsd-ports-openssl and all related code (this
  will be replaced with --no-pkg-config=[name] in the future).
- Remove some unused build system properties.
- Remove support for caching third party include and library paths
  (can cause unexpected problems when they change).
