### PR TITLE
Option to select if chanhistory is on for bots

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -384,7 +384,8 @@
 # This is the hard limit for 'X'.
 # If notice is set to yes, joining users will get a NOTICE before playback
 # telling them about the following lines being the pre-join history.
-#<chanhistory maxlines="20" notice="yes">
+# If bots is set to yes, it will also send to users marked with +B
+#<chanhistory maxlines="20" notice="yes" bots="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Channel logging module: used to send snotice output to channels, to

--- a/src/modules/m_chanhistory.cpp
+++ b/src/modules/m_chanhistory.cpp
@@ -107,8 +107,10 @@ class ModuleChanHistory : public Module
 {
 	HistoryMode m;
 	bool sendnotice;
+	UserModeReference botmode;
+	bool dobots;
  public:
-	ModuleChanHistory() : m(this)
+	ModuleChanHistory() : m(this), botmode(this, "bot")
 	{
 	}
 
@@ -125,6 +127,7 @@ class ModuleChanHistory : public Module
 		ConfigTag* tag = ServerInstance->Config->ConfValue("chanhistory");
 		m.maxlines = tag->getInt("maxlines", 50);
 		sendnotice = tag->getBool("notice", true);
+		dobots = tag->getBool("bots", true);
 	}
 
 	void OnUserMessage(User* user, void* dest, int target_type, const std::string &text, char status, const CUList&, MessageType msgtype) CXX11_OVERRIDE
@@ -146,6 +149,9 @@ class ModuleChanHistory : public Module
 	void OnPostJoin(Membership* memb) CXX11_OVERRIDE
 	{
 		if (IS_REMOTE(memb->user))
+			return;
+
+		if (memb->user->IsModeSet(botmode) && !dobots)
 			return;
 
 		HistoryList* list = m.ext.get(memb->chan);


### PR DESCRIPTION
I saw @krsnapc fork inspircd and add this possibility: https://github.com/krsnapc/inspircd/commit/b3e00f587f312031eb735e33e9f292d15038c17a

I think he solved it in an unelegant way, but I agree it's sensible functionality, so here's my take on it.
