### PR TITLE
Correct 'seperate', trailing spaces, line length.

### DIFF
--- a/docs/conf/filter.conf.example
+++ b/docs/conf/filter.conf.example
@@ -39,12 +39,13 @@
 # o: Don't match against opers
 # c: Strip color codes from text before trying to match
 # *: Represents all of the above flags
-# -: Does nothing, a non-op for when you do not want to specify any flags 
+# -: Does nothing, a non-op for when you do not want to specify any flags
 #
-# IMPORTANT NOTE: Because the InspIRCd config reader places special meaning on the
-# '\' character, you must use '\\' if you wish to specify a '\' character in a regular
-# expression. For example, to indicate numbers, use \\d and not \d. This does not
-# apply when adding a regular expression over irc with the /FILTER command.
+# IMPORTANT NOTE: Because the InspIRCd config reader places special meaning on
+# the '\' character, you must use '\\' if you wish to specify a '\' character
+# in a regular expression. For example, to indicate numbers, use \\d and not \d.
+# This does not apply when adding a regular expression over irc with the /FILTER
+# command.
 
 # Example filters for m_filter:
 #

--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -280,21 +280,26 @@
          # localmax: Maximum local connections per IP (or CIDR mask, see below).
          localmax="3"
 
-         # globalmax: Maximum global (network-wide) connections per IP (or CIDR mask, see below).
+         # globalmax: Maximum global (network-wide) connections per IP (or CIDR
+         # mask, see below).
          globalmax="3"
 
-         # maxconnwarn: Enable warnings when localmax or globalmax is hit (defaults to on)
+         # maxconnwarn: Enable warnings when localmax or globalmax is hit
+         # (defaults to on)
          maxconnwarn="off"
 
-         # resolvehostnames: If disabled, no DNS lookups will be performed on connecting users
-         # in this class. This can save a lot of resources on very busy servers.
+         # resolvehostnames: If disabled, no DNS lookups will be performed on
+         # connecting users in this class. This can save a lot of resources on
+         # very busy servers.
          resolvehostnames="yes"
 
-         # usednsbl: Defines whether or not users in this class are subject to DNSBL. Default is yes.
+         # usednsbl: Defines whether or not users in this class are subject to
+         # DNSBL. Default is yes.
          # This setting only has effect when m_dnsbl is loaded.
          #usednsbl="yes"
 
-         # useident: Defines if users in this class MUST respond to a ident query or not.
+         # useident: Defines if users in this class MUST respond to a ident
+         # query or not.
          useident="no"
 
          # limit: How many users are allowed in this class
@@ -316,8 +321,8 @@
          # authentication; passforward and PRIVMSG NickServ happen after
          # your final connect block has been found.
 
-         # Alternate MOTD file for this connect class. The contents of this file are
-         # specified using <files secretmotd="filename"> or <execfiles ...>
+         # Alternate MOTD file for this connect class. The contents of this file
+         # are specified using <files secretmotd="filename"> or <execfiles ...>
          motd="secretmotd"
 
          # Allow color codes to be processed in the message of the day file.
@@ -350,7 +355,8 @@
          # send /nick, /user or /pass)
          timeout="10"
 
-         # pingfreq: How often (in seconds) the server tries to ping connecting clients.
+         # pingfreq: How often (in seconds) the server tries to ping connecting
+         # clients.
          pingfreq="120"
 
          # hardsendq: maximum amount of data allowed in a client's send queue
@@ -363,30 +369,34 @@
          # begins delaying their commands in order to allow the sendq to drain
          softsendq="8192"
 
-         # recvq: amount of data allowed in a client's queue before they are dropped.
+         # recvq: amount of data allowed in a client's queue before they are
+         # dropped.
          recvq="8192"
 
-         # threshold: This specifies the amount of command penalty a user is allowed to have
-         # before being quit or fakelagged due to flood. Normal commands have a penalty of 1,
-         # ones such as /OPER have penalties up to 10.
+         # threshold: This specifies the amount of command penalty a user is
+         # allowed to have before being quit or fakelagged due to flood.
+         # Normal commands have a penalty of 1, ones such as /OPER have
+         # penalties up to 10.
          #
-         # If you are not using fakelag, this should be at least 20 to avoid excess flood kills
-         # from processing some commands.
+         # If you are not using fakelag, this should be at least 20 to avoid
+         # excess flood kills from processing some commands.
          threshold="10"
 
-         # commandrate: This specifies the maximum rate that commands can be processed.
-         # If commands are sent more rapidly, the user's penalty will increase and they will
-         # either be fakelagged or killed when they reach the threshold
+         # commandrate: This specifies the maximum rate that commands can be
+         # processed. If commands are sent more rapidly, the user's penalty will
+         # increase and they will either be fakelagged or killed when they reach
+         # the threshold.
          #
          # Units are millicommands per second, so 1000 means one line per second.
          commandrate="1000"
 
          # fakelag: Use fakelag instead of killing users for excessive flood
          #
-         # Fake lag stops command processing for a user when a flood is detected rather than
-         # immediately killing them; their commands are held in the recvq and processed later
-         # as the user's command penalty drops. Note that if this is enabled, flooders will
-         # quit with "RecvQ exceeded" rather than "Excess Flood".
+         # Fake lag stops command processing for a user when a flood is detected
+         # rather than immediately killing them; their commands are held in the
+         # recvq and processed later as the user's command penalty drops.
+         # Note that if this is enabled, flooders will quit with
+         # "RecvQ exceeded" rather than "Excess Flood".
          fakelag="on"
 
          # localmax: Maximum local connections per IP.
@@ -395,11 +405,13 @@
          # globalmax: Maximum global (network-wide) connections per IP.
          globalmax="3"
 
-         # resolvehostnames: If disabled, no DNS lookups will be performed on connecting users
-         # in this class. This can save a lot of resources on very busy servers.
+         # resolvehostnames: If disabled, no DNS lookups will be performed on
+         # connecting users in this class. This can save a lot of resources on
+         # very busy servers.
          resolvehostnames="yes"
 
-         # useident: Defines if users in this class must respond to a ident query or not.
+         # useident: Defines if users in this class must respond to a ident
+         # query or not.
          useident="no"
 
          # limit: How many users are allowed in this class
@@ -573,9 +585,9 @@
          # to this value.
          #fixedpart=""
 
-         # syntaxhints: If enabled, if a user fails to send the correct parameters
-         # for a command, the ircd will give back some help text of what
-         # the correct parameters are.
+         # syntaxhints: If enabled, if a user fails to send the correct
+         # parameters for a command, the ircd will give back some help text of
+         # what the correct parameters are.
          syntaxhints="no"
 
          # cyclehostsfromuser: If enabled, the source of the mode change for
@@ -588,27 +600,28 @@
          # it will just message the user normally.
          ircumsgprefix="no"
 
-         # announcets: If set to yes, when the TimeStamp on a channel changes, all users
-         # in channel will be sent a NOTICE about it.
+         # announcets: If set to yes, when the TimeStamp on a channel changes,
+         # all users in channel will be sent a NOTICE about it.
          announcets="yes"
 
-         # allowmismatch: Setting this option to yes will allow servers to link even
-         # if they don't have the same VF_OPTCOMMON modules loaded. Setting this to
-         # yes may introduce some desyncs and weirdness.
+         # allowmismatch: Setting this option to yes will allow servers to link
+         # even if they don't have the same VF_OPTCOMMON modules loaded.
+         # Setting this to yes may introduce some desyncs and weirdness.
          allowmismatch="no"
 
-         # defaultbind: Sets the default for <bind> tags without an address. Choices are
-         # ipv4 or ipv6; if not specified, IPv6 will be used if your system has support,
-         # falling back to IPv4 otherwise.
+         # defaultbind: Sets the default for <bind> tags without an address.
+         # Choices are ipv4 or ipv6; if not specified, IPv6 will be used if your
+         # system has support, falling back to IPv4 otherwise.
          defaultbind="auto"
 
-         # hostintopic: If enabled, channels will show the host of the topicsetter
-         # in the topic. If set to no, it will only show the nick of the topicsetter.
+         # hostintopic: If enabled, channels will show the host of the
+         # topicsetter in the topic. If set to no, it will only show the nick of
+         # the topicsetter.
          hostintopic="yes"
 
          # pingwarning: If a server does not respond to a ping within x seconds,
-         # it will send a notice to opers with snomask +l informing that the server
-         # is about to ping timeout.
+         # it will send a notice to opers with snomask +l informing that the
+         # server is about to ping timeout.
          pingwarning="15"
 
          # serverpingfreq: How often pings are sent between servers (in seconds).
@@ -639,8 +652,9 @@
 #                                                                     #
 
 <performance
-             # netbuffersize: Size of the buffer used to recieve data from clients.
-             # The ircd may only read this amount of text in 1 go at any time.
+             # netbuffersize: Size of the buffer used to recieve data from
+             # clients. The ircd may only read this amount of text in 1 go at
+             # any time.
              netbuffersize="10240"
 
              # maxwho: Maximum number of results to show in a /who query.
@@ -650,28 +664,30 @@
              # in the accept queue. This is *NOT* the total maximum number of
              # connections per server. Some systems may only allow this to be up
              # to 5, while others (such as linux and *BSD) default to 128.
-             # Setting this above the limit imposed by your OS can have undesired
-             # effects.
+             # Setting this above the limit imposed by your OS can have
+             # undesired effects.
              somaxconn="128"
 
              # softlimit: This optional feature allows a defined softlimit for
              # connections. If defined, it sets a soft max connections value.
              softlimit="12800"
 
-             # clonesonconnect: If this is set to false, we won't check for clones
-             # on initial connection, but only after the DNS check is done.
+             # clonesonconnect: If this is set to false, we won't check for
+             # clones on initial connection, but only after the DNS check is
+             # done.
              # This can be useful where your main class is more restrictive
-             # than some other class a user can be assigned after DNS lookup is complete.
-             # Turning this option off will make the server spend more time on users we may
-             # potentially not want. Normally this should be neglible, though.
-             # Default value is true
+             # than some other class a user can be assigned after DNS lookup is
+             # complete. Turning this option off will make the server spend more
+             # time on users we may potentially not want. Normally this should
+             # be neglible, though.
+             # Default value is true.
              clonesonconnect="true"
 
              # quietbursts: When syncing or splitting from a network, a server
              # can generate a lot of connect and quit messages to opers with
              # +C and +Q snomasks. Setting this to yes squelches those messages,
-             # which makes it easier for opers, but degrades the functionality of
-             # bots like BOPM during netsplits.
+             # which makes it easier for opers, but degrades the functionality
+             # of bots like BOPM during netsplits.
              quietbursts="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-# SECURITY CONFIGURATION  #-#-#-#-#-#-#-#-#-#-#-#
@@ -712,9 +728,9 @@
           # shown when the format /WHOIS <nick> <nick> is used.
           hidewhois=""
 
-          # hidebans: If this value is set to yes, when a user is banned ([gkz]lined)
-          # only opers will see the ban message when the user is removed
-          # from the server.
+          # hidebans: If this value is set to yes, when a user is banned
+          # ([gkz]lined) only opers will see the ban message when the user is
+          # removed from the server.
           hidebans="no"
 
           # hidekills: If defined, replaces who set a /kill with a custom string.
@@ -729,11 +745,13 @@
           # (Commands like /notice, /privmsg, /kick, etc)
           maxtargets="20"
 
-          # customversion: A custom message to be displayed in the comments field
-          # of the VERSION command response. This does not hide the InspIRCd version.
+          # customversion: A custom message to be displayed in the comments
+          # field of the VERSION command response. This does not hide the
+          # InspIRCd version.
           customversion=""
 
-          # operspywhois: show opers (users/auspex) the +s channels a user is in. Values:
+          # operspywhois: show opers (users/auspex) the +s channels a user is in.
+          # Values:
           #  splitmsg  Split with an explanatory message
           #  yes       Split with no explanatory message
           #  no        Do not show
@@ -749,15 +767,15 @@
           # NOT SUPPORTED/NEEDED UNDER WINDOWS.
           #runasgroup=""
 
-          # restrictbannedusers: If this is set to yes, InspIRCd will not allow users
-          # banned on a channel to change nickname or message channels they are
-          # banned on.
+          # restrictbannedusers: If this is set to yes, InspIRCd will not allow
+          # users banned on a channel to change nickname or message channels
+          # they are banned on.
           restrictbannedusers="yes"
 
-          # genericoper: Setting this value to yes makes all opers on this server
-          # appear as 'is an IRC operator' in their WHOIS, regardless of their
-          # oper type, however oper types are still used internally. This only
-          # affects the display in WHOIS.
+          # genericoper: Setting this value to yes makes all opers on this
+          # server appear as 'is an IRC operator' in their WHOIS, regardless of
+          # their oper type, however oper types are still used internally.
+          # This only affects the display in WHOIS.
           genericoper="no"
 
           # userstats: /stats commands that users can run (opers can run all).
@@ -863,10 +881,11 @@
 #  - USERINPUT
 #  - USEROUTPUT
 #
-# The following log tag is highly default and uncustomised. It is recommended you
-# sort out your own log tags. This is just here so you get some output.
+# The following log tag is highly default and uncustomised. It is recommended
+# you sort out your own log tags. This is just here so you get some output.
 
-<log method="file" type="* -USERINPUT -USEROUTPUT" level="default" target="ircd.log">
+<log method="file" type="* -USERINPUT -USEROUTPUT"
+     level="default" target="ircd.log">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-  WHOWAS OPTIONS   -#-#-#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #

--- a/docs/conf/links.conf.example
+++ b/docs/conf/links.conf.example
@@ -100,7 +100,7 @@
 
 # Failover autoconnect block. If you have multiple hubs, or want your network
 # to automatically link even if the hub is down, you can specify multiple
-# space seperated servers to autoconnect; they will be tried in a round
+# space separated servers to autoconnect; they will be tried in a round
 # robin fashion until one succeeds. Period defines the time for restarting
 # a single loop.
 <autoconnect period="120"

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -49,13 +49,13 @@
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # RIPEMD160 Module - Allows other modules to generate RIPEMD160 hashes,
 # usually for cryptographic uses and security.
-# 
+#
 # IMPORTANT:
 # Other modules may rely on this module being loaded to function.
 #<module name="m_ripemd160.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Abbreviation module: Provides the ability to abbreviate commands a-la 
+# Abbreviation module: Provides the ability to abbreviate commands a-la
 # BBC BASIC keywords.
 #<module name="m_abbreviation.so">
 
@@ -273,10 +273,10 @@
 #<module name="m_botmode.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# CallerID module: Adds usermode +g which activates hybrid-style 
+# CallerID module: Adds usermode +g which activates hybrid-style
 # callerid (== block all private messages unless you /accept first)
 #<module name="m_callerid.so">
-# 
+#
 #-#-#-#-#-#-#-#-#-#-#- CALLERID  CONFIGURATION -#-#-#-#-#-#-#-#-#-#-#-#
 # maxaccepts     - Maximum number of entires a user can add to his    #
 #                  /accept list. Default is 16 entries.               #
@@ -403,15 +403,14 @@
 # can be quite annoying and allow users to on occasion have a channel
 # that looks like the name of another channel on the network.
 #<module name="m_channames.so">
-
-<channames
-	# denyrange: characters or range of characters to deny in channel
-	# names.
-	denyrange="2,3"
-
-	# allowrange: characters or range of characters to specifically allow
-	# in channel names.
-	allowrange="">
+#<channames
+#	# denyrange: characters or range of characters to deny in channel
+#	# names.
+#	denyrange="2,3"
+#
+#	# allowrange: characters or range of characters to specifically allow
+#	# in channel names.
+#	allowrange="">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Channelban: Implements extended ban j:, which stops anyone in already
@@ -440,7 +439,7 @@
 # specify your own custom list of chars with the <hostname> tag:     #
 #                                                                    #
 # charmap        - A list of chars accepted as valid by the /CHGHOST #
-#                  and /SETHOST commands. Also note that the list is # 
+#                  and /SETHOST commands. Also note that the list is #
 #                  case-sensitive.                                   #
 #<hostname charmap="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-_/0123456789">
 
@@ -604,7 +603,7 @@
 #<module name="m_customtitle.so">
 #
 #-#-#-#-#-#-#-#-#-#-  CUSTOM TITLE CONFIGURATION   -#-#-#-#-#-#-#-#-#-#
-#  name              - The username used to identify 
+#  name              - The username used to identify
 #  password          - The password used to identify
 #  hash              - The hash for the specific user's password (optional)
 #                      m_password_hash.so and a hashing module must be loaded for this to work
@@ -658,7 +657,7 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Deny Channels: Deny Channels from being used by users
-#<module name="m_denychans.so"> 
+#<module name="m_denychans.so">
 #
 #-#-#-#-#-#-#-#-#-#-#-   DENYCHAN DEFINITIONS  -#-#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #
@@ -740,7 +739,8 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # GeoIP module: Allows the server admin to match users by country code.
-# This modules is in extras. Re-run configure with: ./configure --enable-extras=m_geoip.cpp
+# This modules is in extras. Re-run configure with:
+# ./configure --enable-extras=m_geoip.cpp
 # and run make install, then uncomment this module to enable it.
 # This module requires GeoIP to be installed on your system,
 # use your package manager to find the appropriate packages
@@ -847,7 +847,7 @@
 #
 # <httpdacl path="/stats*" types="password,whitelist"
 #    username="secretstuff" password="mypasshere" whitelist="127.0.0.*,10.*">
-# 
+#
 # Deny all connections to all but the main index page:
 #
 # <httpdacl path="/*" types="blacklist" blacklist="*">
@@ -892,7 +892,7 @@
 # enhancements to the client-to-server protocol. An extension is only
 # active for a client when the client specifically requests it, so this
 # module needs m_cap to work.
-# 
+#
 # Further information on these extensions can be found at the IRCv3
 # working group website:
 # http://ircv3.atheme.org/extensions/
@@ -1006,7 +1006,8 @@
 # LDAP oper configuration module: Adds the ability to authenticate    #
 # opers via LDAP. This is an extra module which must be enabled       #
 # explicitly by symlinking it from modules/extra, and requires the    #
-# OpenLDAP libs. Re-run configure with: ./configure --enable-extras=m_ldapoper.cpp
+# OpenLDAP libs. Re-run configure with:
+# ./configure --enable-extras=m_ldapoper.cpp
 # and run make install, then uncomment this module to enable it.      #
 #                                                                     #
 #<module name="m_ldapoper.so">
@@ -1057,9 +1058,10 @@
 #<module name="m_mlock.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# MsSQL module: Allows other SQL modules to access MS SQL Server 
+# MsSQL module: Allows other SQL modules to access MS SQL Server
 # through a unified API.
-# This modules is in extras. Re-run configure with: ./configure --enable-extras=m_mssql.cpp
+# This modules is in extras. Re-run configure with:
+# ./configure --enable-extras=m_mssql.cpp
 # and run make install, then uncomment this module to enable it.
 #
 #<module name="m_mssql.so">
@@ -1069,12 +1071,15 @@
 # m_mssql.so is more complex than described here, see wiki for more   #
 # info http://wiki.inspircd.org/Modules/mssql                         #
 #
-#<database module="mssql" name="db" user="user" pass="pass" host="localhost" id="db1">
-
+#<database module="mssql" name="db"
+#          user="user" pass="pass"
+#          host="localhost" id="db1">
+#
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # MySQL module: Allows other SQL modules to access MySQL databases
 # through a unified API.
-# This modules is in extras. Re-run configure with: ./configure --enable-extras=m_mysql.cpp
+# This modules is in extras. Re-run configure with:
+# ./configure --enable-extras=m_mysql.cpp
 # and run make install, then uncomment this module to enable it.
 #
 #<module name="m_mysql.so">
@@ -1084,7 +1089,9 @@
 # m_mysql.so is more complex than described here, see the wiki for    #
 # more: http://wiki.inspircd.org/Modules/mysql                        #
 #
-#<database module="mysql" name="mydb" user="myuser" pass="mypass" host="localhost" id="my_database2">
+#<database module="mysql" name="mydb"
+#          user="myuser" pass="mypass"
+#          host="localhost" id="my_database2">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Named Modes module: This module allows for the display and set/unset
@@ -1185,7 +1192,7 @@
 # If you are using the m_operjoin.so module, specify options here:    #
 #                                                                     #
 # channel     -      The channel name to join, can also be a comma    #
-#                    seperated list eg. "#channel1,#channel2".        #
+#                    separated list eg. "#channel1,#channel2".        #
 #                                                                     #
 # override    -      Lets the oper join walking thru any modes that   #
 #                    might be set, even bans. Use "yes" or "no".      #
@@ -1217,7 +1224,7 @@
 #<operprefix prefix="!">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Oper MOTD module: Provides support for seperate message of the day
+# Oper MOTD module: Provides support for separate message of the day
 # on oper-up
 # This module is oper-only.
 #<module name="m_opermotd.so">
@@ -1265,25 +1272,24 @@
 # module is usually used to authenticate users with nickserv using their
 # connect password.
 #<module name="m_passforward.so">
-
-<passforward
-		# nick: nick to forward connect passwords to.
-		nick="NickServ"
-
-		# forwardmsg: Message to send to users using a connect password.
-		# $nick will be the users' nick, $nickrequired will be the nick
-		# of where the password is going (the nick above).
-		# You can also use $user for the user ident string.
-		forwardmsg="NOTICE $nick :*** Forwarding PASS to $nickrequired"
-
-		# cmd: Command for the nick to run when it recieves a connect
-		# password. 
-		cmd="PRIVMSG $nickrequired :IDENTIFY $pass">
+#<passforward
+#		# nick: nick to forward connect passwords to.
+#		nick="NickServ"
+#
+#		# forwardmsg: Message to send to users using a connect password.
+#		# $nick will be the users' nick, $nickrequired will be the nick
+#		# of where the password is going (the nick above).
+#		# You can also use $user for the user ident string.
+#		forwardmsg="NOTICE $nick :*** Forwarding PASS to $nickrequired"
+#
+#		# cmd: Command for the nick to run when it recieves a connect
+#		# password.
+#		cmd="PRIVMSG $nickrequired :IDENTIFY $pass">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Password hash module: Allows hashed passwords to be used.
 # To be useful, a hashing module like m_sha256.so also needs to be loaded.
-# 
+#
 #<module name="m_password_hash.so">
 #
 #-#-#-#-#-#-#-#-#-# PASSWORD HASH CONFIGURATION #-#-#-#-#-#-#-#-#-#-#-#
@@ -1296,7 +1302,7 @@
 #           hash="sha256"
 #           password="01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
 #           type="NetAdmin">
-# 
+#
 # Starting from 2.0, you can use a more secure salted hash that prevents simply
 # looking up the hash's value in a rainbow table built for the hash.
 #    hash="hmac-sha256" password="lkS1Nbtp$CyLd/WPQXizsbxFUTqFRoMvaC+zhOULEeZaQkUJj+Gg"
@@ -1327,7 +1333,8 @@
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # PostgreSQL module: Allows other SQL modules to access PgSQL databases
 # through a unified API.
-# This modules is in extras. Re-run configure with: ./configure --enable-extras=m_pgsql.cpp
+# This modules is in extras. Re-run configure with:
+# ./configure --enable-extras=m_pgsql.cpp
 # and run make install, then uncomment this module to enable it.
 #
 #<module name="m_pgsql.so">
@@ -1337,7 +1344,11 @@
 # m_pgsql.so is more complex than described here, see the wiki for    #
 # more: http://wiki.inspircd.org/Modules/pgsql                        #
 #
-#<database module="pgsql" name="mydb" user="myuser" pass="mypass" host="localhost" id="my_database" ssl="no">
+# Note: When using a socket connection, omit the host parameter.
+#
+#<database module="pgsql" name="mydb"
+#          user="myuser" pass="mypass"
+#          host="localhost" id="my_database" ssl="no">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Muteban: Implements extended ban m:, which stops anyone matching
@@ -1347,7 +1358,7 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Random Quote module: provides a random quote on connect.
-# NOTE: Some of these may mimic fatal errors and confuse users and 
+# NOTE: Some of these may mimic fatal errors and confuse users and
 # opers alike! - BEWARE!
 #<module name="m_randquote.so">
 #
@@ -1436,22 +1447,28 @@
 #<module name="m_remove.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# A module to block, kick or ban upon similiar messages being uttered several times.
+# A module to block, kick or ban upon similiar messages being uttered
+# several times.
 # Syntax [~*][lines]:[sec]{[:difference]}{[:matchlines]}
 # ~ is to block, * is to ban, default is kick.
-# lines - In mode 1 the amount of lines that has to match consecutively - In mode 2 the size of the backlog to keep for matching
+# lines - In mode 1 the amount of lines that has to match consecutively
+#       - In mode 2 the size of the backlog to keep for matching
 # seconds - How old the message has to be before it's invalidated.
 # distance - Edit distance, in percent, between two strings to trigger on.
-# matchlines - When set, the function goes into mode 2. In this mode the function will trigger if this many of the last <lines> matches.
+# matchlines - When set, the function goes into mode 2. In this mode the
+#              function will trigger if this many of the last <lines> matches.
 #
 # As this module can be rather CPU-intensive, it comes with some options.
-# maxbacklog - Maximum size that can be specified for backlog. 0 disables multiline matching.
-# maxdistance - Max percentage of difference between two lines we'll allow to match. Set to 0 to disable edit-distance matching.
+# maxbacklog - Maximum size that can be specified for backlog.
+#              0 disables multiline matching.
+# maxdistance - Max percentage of difference between two lines we'll allow
+#               to match. Set to 0 to disable edit-distance matching.
 # maxlines - Max lines of backlog to match against.
 # maxsecs - Maximum value of seconds a user can set. 0 to allow any.
-# size - Maximum number of characters to check for, can be used to truncate messages
-# before they are checked, resulting in less CPU usage. Increasing this beyond 512
-# doesn't have any effect, as the maximum length of a message on IRC cannot exceed that.
+# size - Maximum number of characters to check for, can be used to truncate
+#        messages before they are checked, resulting in less CPU usage.
+#        Increasing this beyond 512 doesn't have any effect, as the maximum
+#        length of a message on IRC cannot exceed that.
 #<repeat maxbacklog="20" maxlines="20" maxdistance="50" maxsecs="0" size="512">
 #<module name="m_repeat.so">
 
@@ -1544,7 +1561,7 @@
 #<module name="m_satopic.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# SASL authentication module: Provides support for IRC Authentication 
+# SASL authentication module: Provides support for IRC Authentication
 # Layer (aka: atheme SASL) via AUTHENTICATE.
 #<module name="m_sasl.so">
 
@@ -1558,10 +1575,10 @@
 # Securelist can be harmful to some irc search engines such as        #
 # netsplit.de and searchirc.com. To prevent securelist blocking these #
 # sites from listing, define exception tags as shown below:           #
-<securehost exception="*@*.searchirc.org">
-<securehost exception="*@*.netsplit.de">
-<securehost exception="*@echo940.server4you.de">
-<securehost exception="*@*.ircdriven.com">
+#<securehost exception="*@*.searchirc.org">
+#<securehost exception="*@*.netsplit.de">
+#<securehost exception="*@echo940.server4you.de">
+#<securehost exception="*@*.ircdriven.com">
 #                                                                     #
 # Define the following variable to change how long a user must wait   #
 # before issuing a LIST. If not defined, defaults to 60 seconds.      #
@@ -1591,7 +1608,7 @@
 # and is similar in operation to the way asuka and ircu handle services.
 #
 # At the same time, this offers +r for users and channels to mark them
-# as identified seperately from the idea of a master account, which
+# as identified separately from the idea of a master account, which
 # can be useful for services which are heavily nick-as-account centric.
 #
 # This replaces m_services from 1.1 and earlier.
@@ -1600,7 +1617,7 @@
 # +b R: (stop matching account names from joining)
 # +b M: (stop matching account names from speaking)
 # +b U:n!u@h (blocks matching unregistered users)
-#                                                                       
+#
 #<module name="m_services_account.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
@@ -1684,7 +1701,7 @@
 # SSL Info module: Allows users to retrieve information about other
 # user's peer SSL certificates and keys. This can be used by client
 # scripts to validate users. For this to work, one of m_ssl_gnutls.so
-# or m_ssl_openssl.so must be loaded. This module also adds the 
+# or m_ssl_openssl.so must be loaded. This module also adds the
 # "* <user> is using a secure connection" whois line, the ability for
 # opers to use SSL fingerprints to verify their identity and the ability
 # to force opers to use SSL connections in order to oper up.
@@ -1727,8 +1744,9 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # SQLite3 module: Allows other SQL modules to access SQLite3          #
-# databases through a unified API. 
-# This modules is in extras. Re-run configure with: ./configure --enable-extras=m_sqlite.cpp
+# databases through a unified API.
+# This modules is in extras. Re-run configure with:
+# ./configure --enable-extras=m_sqlite.cpp
 # and run make install, then uncomment this module to enable it.      #
 #
 #<module name="m_sqlite3.so">
@@ -1743,7 +1761,8 @@
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # SQL authentication module: Allows IRCd connections to be tied into
 # a database table (for example a forum).
-# This modules is in extras. Re-run configure with: ./configure --enable-extras=m_sqlauth.cpp
+# This modules is in extras. Re-run configure with:
+# ./configure --enable-extras=m_sqlauth.cpp
 # and run make install, then uncomment this module to enable it.
 #
 #<module name="m_sqlauth.so">
@@ -1755,7 +1774,8 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # SQL oper module: Allows you to store oper credentials in an SQL table
-# This modules is in extras. Re-run configure with: ./configure --enable-extras=m_sqloper.cpp
+# This modules is in extras. Re-run configure with:i
+# ./configure --enable-extras=m_sqloper.cpp
 # and run make install, then uncomment this module to enable it.
 #
 #<module name="m_sqloper.so">
@@ -1843,7 +1863,7 @@
 #<vhost user="foo" password="fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9" hash="sha256" host="some.other.host">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Watch module: Adds the WATCH command, which is used by clients to 
+# Watch module: Adds the WATCH command, which is used by clients to
 # maintain notify lists.
 #<module name="m_watch.so">
 #

--- a/docs/conf/modules/charybdis.conf.example
+++ b/docs/conf/modules/charybdis.conf.example
@@ -164,7 +164,7 @@
 #   quitmsg="Throttled" bootwait="10">
 
 <module name="m_deaf.so">
-<module name="m_dnsbl.so">                                           
+<module name="m_dnsbl.so">
 <module name="m_gecosban.so">
 <module name="m_globalload.so">
 <module name="m_ident.so">
@@ -246,7 +246,7 @@
 <showwhois opersonly="yes" showfromopers="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Spy module: Provides the ability to see the complete names list of 
+# Spy module: Provides the ability to see the complete names list of
 # channels an oper is not a member of
 # This module is oper-only.
 #<module name="m_spy.so">
@@ -276,7 +276,7 @@
 # SSL Info module: Allows users to retrieve information about other
 # user's peer SSL certificates and keys. This can be used by client
 # scripts to validate users. For this to work, one of m_ssl_gnutls.so
-# or m_ssl_openssl.so must be loaded. This module also adds the 
+# or m_ssl_openssl.so must be loaded. This module also adds the
 # "* <user> is using a secure connection" whois line, the ability for
 # opers to use SSL fingerprints to verify their identity and the ability
 # to force opers to use SSL connections in order to oper up.

--- a/docs/conf/modules/unrealircd.conf.example
+++ b/docs/conf/modules/unrealircd.conf.example
@@ -165,7 +165,7 @@
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 
 <module name="m_deaf.so">
-<module name="m_denychans.so"> 
+<module name="m_denychans.so">
 #<badchan name="#gods*" allowopers="yes" reason="Tortoises!">         #
 #<badchan name="#heaven" redirect="#hell" reason="Nice try!">         #
 
@@ -187,7 +187,7 @@
 # posix - POSIX regexps, provided via m_regex_posix.so, not availale  #
 #         on windows, no dependencies on other operating systems.     #
 #                                                                     #
-<filteropts engine="glob">                                           
+<filteropts engine="glob">
 #                                                                     #
 # Your choice of regex engine must match on all servers network-wide.
 #
@@ -239,7 +239,7 @@
 # If you are using the m_operjoin.so module, specify options here:    #
 #                                                                     #
 # channel     -      The channel name to join, can also be a comma    #
-#                    seperated list eg. "#channel1,#channel2".        #
+#                    separated list eg. "#channel1,#channel2".        #
 #                                                                     #
 # override    -      Lets the oper join walking thru any modes that   #
 #                    might be set, even bans. Use "yes" or "no".      #
@@ -254,7 +254,7 @@
 <module name="m_operlog.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Oper MOTD module: Provides support for seperate message of the day
+# Oper MOTD module: Provides support for separate message of the day
 # on oper-up
 # This module is oper-only.
 #<module name="m_opermotd.so">
@@ -281,7 +281,7 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Random Quote module: provides a random quote on connect.
-# NOTE: Some of these may mimic fatal errors and confuse users and 
+# NOTE: Some of these may mimic fatal errors and confuse users and
 # opers alike! - BEWARE!
 #<module name="m_randquote.so">
 #

--- a/docs/conf/rules.txt.example
+++ b/docs/conf/rules.txt.example
@@ -1,3 +1,3 @@
-This is the InspIRCd rules file. 
- 
-Place any network or server rules here :) 
+This is the InspIRCd rules file.
+
+Place any network or server rules here :)

--- a/include/command_parse.h
+++ b/include/command_parse.h
@@ -24,7 +24,7 @@
 
 /** This class handles command management and parsing.
  * It allows you to add and remove commands from the map,
- * call command handlers by name, and chop up comma seperated
+ * call command handlers by name, and chop up comma separated
  * parameters into multiple calls.
  */
 class CoreExport CommandParser
@@ -63,7 +63,7 @@ class CoreExport CommandParser
 	 */
 	Command* GetHandler(const std::string &commandname);
 
-	/** LoopCall is used to call a command handler repeatedly based on the contents of a comma seperated list.
+	/** LoopCall is used to call a command handler repeatedly based on the contents of a comma separated list.
 	 * There are two ways to call this method, either with one potential list or with two potential lists.
 	 * We need to handle two potential lists for JOIN, because a JOIN may contain two lists of items at once:
 	 * the channel names and their keys as follows:
@@ -93,8 +93,8 @@ class CoreExport CommandParser
 	 * @param user The user who sent the command
 	 * @param handler The command handler to call for each parameter in the list
 	 * @param parameters Parameter list as a vector of strings
-	 * @param splithere The first parameter index to split as a comma seperated list
-	 * @param extra The second parameter index to split as a comma seperated list, or -1 (the default) if there is only one list
+	 * @param splithere The first parameter index to split as a comma separated list
+	 * @param extra The second parameter index to split as a comma separated list, or -1 (the default) if there is only one list
 	 * @param usemax True to limit the command to MaxTargets targets (default), or false to process all tokens
 	 * @return This function returns true when it identified a list in the given parameter and finished calling the
 	 * command handler for each entry on the list. When this occurs, the caller should return without doing anything,

--- a/include/configreader.h
+++ b/include/configreader.h
@@ -274,12 +274,12 @@ class CoreExport ServerConfig
 	CommandLineConf cmdline;
 
 	/** Clones CIDR range for ipv4 (0-32)
-	 * Defaults to 32 (checks clones on all IPs seperately)
+	 * Defaults to 32 (checks clones on all IPs separately)
 	 */
 	int c_ipv4_range;
 
 	/** Clones CIDR range for ipv6 (0-128)
-	 * Defaults to 128 (checks on all IPs seperately)
+	 * Defaults to 128 (checks on all IPs separately)
 	 */
 	int c_ipv6_range;
 
@@ -368,7 +368,7 @@ class CoreExport ServerConfig
 	 */
 	bool DisabledDontExist;
 
-	/** This variable contains a space-seperated list
+	/** This variable contains a space-separated list
 	 * of commands which are disabled by the
 	 * administrator of the server for non-opers.
 	 */

--- a/include/ctables.h
+++ b/include/ctables.h
@@ -154,7 +154,7 @@ class CoreExport CommandBase : public ServiceProvider
 	 * @param cmd Command name. This must be UPPER CASE.
 	 * @param minpara Minimum parameters required for the command.
 	 * @param maxpara Maximum number of parameters this command may have - extra parameters
-	 * will be tossed into one last space-seperated param.
+	 * will be tossed into one last space-separated param.
 	 */
 	CommandBase(Module* me, const std::string &cmd, int minpara = 0, int maxpara = 0) :
 		ServiceProvider(me, cmd, SERVICE_COMMAND), flags_needed(0), min_params(minpara), max_params(maxpara),

--- a/include/hashcomp.h
+++ b/include/hashcomp.h
@@ -178,8 +178,8 @@ namespace irc
 	 public:
 
 		/** Join all elements of a vector, in the resulting string
-		 * each element will be seperated by a single space character.
-		 * @param sequence Zero or more items to seperate
+		 * each element will be separated by a single space character.
+		 * @param sequence Zero or more items to separate
 		 */
 		stringjoiner(const std::vector<std::string>& sequence);
 
@@ -250,7 +250,7 @@ namespace irc
 		 * @param result The vector to populate. This will not
 		 * be cleared before it is used.
 		 * @param max_line_size The maximum size of the line
-		 * to build, in characters, seperate to MAXMODES.
+		 * to build, in characters, separate to MAXMODES.
 		 * @return The number of elements in the deque.
 		 * The function should be called repeatedly until it
 		 * returns 0, in case there are multiple lines of
@@ -260,7 +260,7 @@ namespace irc
 
 	};
 
-	/** irc::sepstream allows for splitting token seperated lists.
+	/** irc::sepstream allows for splitting token separated lists.
 	 * Each successive call to sepstream::GetToken() returns
 	 * the next token, until none remain, at which point the method returns
 	 * an empty string.
@@ -302,7 +302,7 @@ namespace irc
 		bool StreamEnd();
 	};
 
-	/** A derived form of sepstream, which seperates on commas
+	/** A derived form of sepstream, which separates on commas
 	 */
 	class CoreExport commasepstream : public sepstream
 	{
@@ -314,7 +314,7 @@ namespace irc
 		}
 	};
 
-	/** A derived form of sepstream, which seperates on spaces
+	/** A derived form of sepstream, which separates on spaces
 	 */
 	class CoreExport spacesepstream : public sepstream
 	{
@@ -370,7 +370,7 @@ namespace irc
 		bool GetToken(long &token);
 	};
 
-	/** The portparser class seperates out a port range into integers.
+	/** The portparser class separates out a port range into integers.
 	 * A port range may be specified in the input string in the form
 	 * "6660,6661,6662-6669,7020". The end of the stream is indicated by
 	 * a return value of 0 from portparser::GetToken(). If you attempt

--- a/include/mode.h
+++ b/include/mode.h
@@ -576,7 +576,7 @@ class CoreExport ModeParser
 	 */
 	ModeHandler* FindPrefix(unsigned const char pfxletter);
 
-	/** Returns a list of modes, space seperated by type:
+	/** Returns a list of modes, space separated by type:
 	 * 1. User modes
 	 * 2. Channel modes
 	 * 3. Channel modes that require a parameter when set
@@ -584,7 +584,7 @@ class CoreExport ModeParser
 	 */
 	const std::string& GetModeListFor004Numeric();
 
-	/** Generates a list of modes, comma seperated by type:
+	/** Generates a list of modes, comma separated by type:
 	 *  1; Listmodes EXCEPT those with a prefix
 	 *  2; Modes that take a param when adding or removing
 	 *  3; Modes that only take a param when adding

--- a/include/users.h
+++ b/include/users.h
@@ -334,7 +334,7 @@ class CoreExport User : public Extensible
 
 	/** If this is set to true, then all socket operations for the user
 	 * are dropped into the bit-bucket.
-	 * This value is set by QuitUser, and is not needed seperately from that call.
+	 * This value is set by QuitUser, and is not needed separately from that call.
 	 * Please note that setting this value alone will NOT cause the user to quit.
 	 */
 	unsigned int quitting:1;

--- a/include/xline.h
+++ b/include/xline.h
@@ -106,7 +106,7 @@ class CoreExport XLine : public classbase
 	 * e.g. '*\@foo' or '*baz*'. This must always return the full pattern
 	 * in a form which can be used to construct an entire derived xline,
 	 * even if it is stored differently internally (e.g. GLine stores the
-	 * ident and host parts seperately but will still return ident\@host
+	 * ident and host parts separately but will still return ident\@host
 	 * for its Displayable() method).
 	 */
 	virtual const std::string& Displayable() = 0;
@@ -423,7 +423,7 @@ class CoreExport XLineManager
 	 */
 	~XLineManager();
 
-	/** Split an ident and host into two seperate strings.
+	/** Split an ident and host into two separate strings.
 	 * This allows for faster matching.
 	 */
 	IdentHostPair IdentSplit(const std::string &ident_and_host);

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -650,7 +650,7 @@ const char* Channel::ChanModes(bool showkey)
 	return scratch.c_str();
 }
 
-/* compile a userlist of a channel into a string, each nick seperated by
+/* compile a userlist of a channel into a string, each nick separated by
  * spaces and op, voice etc status shown as @ and +, and send it to 'user'
  */
 void Channel::UserList(User *user)

--- a/src/cidr.cpp
+++ b/src/cidr.cpp
@@ -51,7 +51,7 @@ bool irc::sockets::MatchCIDR(const std::string &address, const std::string &cidr
 
 	/* The caller is trying to match ident@<mask>/bits.
 	 * Chop off the ident@ portion, use match() on it
-	 * seperately.
+	 * separately.
 	 */
 	if (match_with_username)
 	{

--- a/src/command_parse.cpp
+++ b/src/command_parse.cpp
@@ -229,7 +229,7 @@ void CommandParser::ProcessCommand(LocalUser *user, std::string &cmd)
 		// Iterator to the first excess parameter
 		const std::vector<std::string>::iterator firstexcess = lastkeep + 1;
 
-		// Append all excess parameter(s) to the last parameter, seperated by spaces
+		// Append all excess parameter(s) to the last parameter, separated by spaces
 		for (std::vector<std::string>::const_iterator i = firstexcess; i != command_p.end(); ++i)
 		{
 			lastkeep->push_back(' ');
@@ -241,7 +241,7 @@ void CommandParser::ProcessCommand(LocalUser *user, std::string &cmd)
 	}
 
 	/*
-	 * We call OnPreCommand here seperately if the command exists, so the magic above can
+	 * We call OnPreCommand here separately if the command exists, so the magic above can
 	 * truncate to max_params if necessary. -- w00t
 	 */
 	ModResult MOD_RESULT;

--- a/src/commands/cmd_ison.cpp
+++ b/src/commands/cmd_ison.cpp
@@ -70,7 +70,7 @@ CmdResult CommandIson::Handle (const std::vector<std::string>& parameters, User 
 		{
 			if ((i == parameters.size() - 1) && (parameters[i].find(' ') != std::string::npos))
 			{
-				/* Its a space seperated list of nicks (RFC1459 says to support this)
+				/* Its a space separated list of nicks (RFC1459 says to support this)
 				 */
 				irc::spacesepstream list(parameters[i]);
 				std::string item;

--- a/src/commands/cmd_kill.cpp
+++ b/src/commands/cmd_kill.cpp
@@ -69,7 +69,7 @@ class CommandKill : public Command
  */
 CmdResult CommandKill::Handle (const std::vector<std::string>& parameters, User *user)
 {
-	/* Allow comma seperated lists of users for /KILL (thanks w00t) */
+	/* Allow comma separated lists of users for /KILL (thanks w00t) */
 	if (CommandParser::LoopCall(user, this, parameters, 0))
 	{
 		// If we got a colon delimited list of nicks then the handler ran for each nick,

--- a/src/inspircd.cpp
+++ b/src/inspircd.cpp
@@ -443,7 +443,7 @@ InspIRCd::InspIRCd(int argc, char** argv) :
 	SE->RecoverFromFork();
 
 	/* During startup we read the configuration now, not in
-	 * a seperate thread
+	 * a separate thread
 	 */
 	this->Config->Read();
 	this->Config->Apply(NULL, "");

--- a/src/listensocket.cpp
+++ b/src/listensocket.cpp
@@ -101,7 +101,7 @@ ListenSocket::~ListenSocket()
 	}
 }
 
-/* Just seperated into another func for tidiness really.. */
+/* Just separated into another func for tidiness really.. */
 void ListenSocket::AcceptInternal()
 {
 	irc::sockets::sockaddrs client;

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -658,7 +658,7 @@ class ModuleSSLGnuTLS : public Module
 					 * Found an SSL port for clients that is not bound to 127.0.0.1 and handled by us, display
 					 * the IP:port in ISUPPORT.
 					 *
-					 * We used to advertise all ports seperated by a ';' char that matched the above criteria,
+					 * We used to advertise all ports separated by a ';' char that matched the above criteria,
 					 * but this resulted in too long ISUPPORT lines if there were lots of ports to be displayed.
 					 * To solve this by default we now only display the first IP:port found and let the user
 					 * configure the exact value for the 005 token, if necessary.

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -529,7 +529,7 @@ class ModuleSSLOpenSSL : public Module
 					 * Found an SSL port for clients that is not bound to 127.0.0.1 and handled by us, display
 					 * the IP:port in ISUPPORT.
 					 *
-					 * We used to advertise all ports seperated by a ';' char that matched the above criteria,
+					 * We used to advertise all ports separated by a ';' char that matched the above criteria,
 					 * but this resulted in too long ISUPPORT lines if there were lots of ports to be displayed.
 					 * To solve this by default we now only display the first IP:port found and let the user
 					 * configure the exact value for the 005 token, if necessary.

--- a/src/modules/m_callerid.cpp
+++ b/src/modules/m_callerid.cpp
@@ -184,7 +184,7 @@ public:
 		parameter = (action.second ? "" : "-") + action.first->uuid;
 	}
 
-	/** Will take any number of nicks (up to MaxTargets), which can be seperated by commas.
+	/** Will take any number of nicks (up to MaxTargets), which can be separated by commas.
 	 * - in front of any nick removes, and an * lists. This effectively means you can do:
 	 * /accept nick1,nick2,nick3,*
 	 * to add 3 nicks and then show your list
@@ -225,7 +225,7 @@ public:
 	RouteDescriptor GetRouting(User* user, const std::vector<std::string>& parameters)
 	{
 		// There is a list in parameters[0] in two cases:
-		// Either when the source is remote, this happens because 2.0 servers send comma seperated uuid lists,
+		// Either when the source is remote, this happens because 2.0 servers send comma separated uuid lists,
 		// we don't split those but broadcast them, as before.
 		//
 		// Or if the source is local then LoopCall() runs OnPostCommand() after each entry in the list,

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -59,7 +59,7 @@ class CommandDccallow : public Command
 	CommandDccallow(Module* parent) : Command(parent, "DCCALLOW", 0)
 	{
 		syntax = "{[+|-]<nick> <time>|HELP|LIST}";
-		/* XXX we need to fix this so it can work with translation stuff (i.e. move +- into a seperate param */
+		/* XXX we need to fix this so it can work with translation stuff (i.e. move +- into a separate param */
 	}
 
 	CmdResult Handle(const std::vector<std::string> &parameters, User *user)

--- a/src/modules/m_spanningtree/capab.cpp
+++ b/src/modules/m_spanningtree/capab.cpp
@@ -155,7 +155,7 @@ void TreeSocket::SendCapabilities(int phase)
 	this->WriteLine("CAPAB END");
 }
 
-/* Isolate and return the elements that are different between two comma seperated lists */
+/* Isolate and return the elements that are different between two comma separated lists */
 void TreeSocket::ListDifference(const std::string &one, const std::string &two, char sep,
 		std::string& mleft, std::string& mright)
 {

--- a/src/modules/m_spanningtree/commands.h
+++ b/src/modules/m_spanningtree/commands.h
@@ -104,7 +104,7 @@ class TreeSocket;
 class CommandFJoin : public ServerCommand
 {
 	/** Remove all modes from a channel, including statusmodes (+qaovh etc), simplemodes, parameter modes.
-	 * This does not update the timestamp of the target channel, this must be done seperately.
+	 * This does not update the timestamp of the target channel, this must be done separately.
 	 */
 	static void RemoveStatus(Channel* c);
 	static void ApplyModeStack(User* srcuser, Channel* c, irc::modestacker& stack);

--- a/src/modules/m_spanningtree/resolvers.cpp
+++ b/src/modules/m_spanningtree/resolvers.cpp
@@ -29,7 +29,7 @@
 #include "treesocket.h"
 
 /** This class is used to resolve server hostnames during /connect and autoconnect.
- * As of 1.1, the resolver system is seperated out from BufferedSocket, so we must do this
+ * As of 1.1, the resolver system is separated out from BufferedSocket, so we must do this
  * resolver step first ourselves if we need it. This is totally nonblocking, and will
  * callback to OnLookupComplete or OnError when completed. Once it has completed we
  * will have an IP address which we can then use to continue our connection.

--- a/src/modules/m_spanningtree/resolvers.h
+++ b/src/modules/m_spanningtree/resolvers.h
@@ -42,7 +42,7 @@ class SecurityIPResolver : public DNS::Request
 };
 
 /** This class is used to resolve server hostnames during /connect and autoconnect.
- * As of 1.1, the resolver system is seperated out from BufferedSocket, so we must do this
+ * As of 1.1, the resolver system is separated out from BufferedSocket, so we must do this
  * resolver step first ourselves if we need it. This is totally nonblocking, and will
  * callback to OnLookupComplete or OnError when completed. Once it has completed we
  * will have an IP address which we can then use to continue our connection.

--- a/src/modules/m_watch.cpp
+++ b/src/modules/m_watch.cpp
@@ -63,7 +63,7 @@
  * and Om by reading their 'watched by' list. When this occurs, their online status
  * in each of these users lists (see below) is also updated.
  *
- * Each user also has a seperate (smaller) map attached to their User whilst they
+ * Each user also has a separate (smaller) map attached to their User whilst they
  * have any watch entries, which is managed by class Extensible. When they add or remove
  * a watch entry from their list, it is inserted here, as well as the main list being
  * maintained. This map also contains the user's online status. For users that are

--- a/src/snomasks.cpp
+++ b/src/snomasks.cpp
@@ -136,7 +136,7 @@ void Snomask::Send(char letter, const std::string& desc, const std::string& msg)
 	for (std::list<User*>::const_iterator i = opers.begin(); i != opers.end(); ++i)
 	{
 		User* user = *i;
-		// IsNoticeMaskSet() returns false for opers who aren't +s, no need to check for it seperately
+		// IsNoticeMaskSet() returns false for opers who aren't +s, no need to check for it separately
 		if (IS_LOCAL(user) && user->IsNoticeMaskSet(letter))
 			user->WriteNotice(finalmsg);
 	}

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -559,7 +559,7 @@ void LocalUser::FullConnect()
 	/*
 	 * You may be thinking "wtf, we checked this in User::AddClient!" - and yes, we did, BUT.
 	 * At the time AddClient is called, we don't have a resolved host, by here we probably do - which
-	 * may put the user into a totally seperate class with different restrictions! so we *must* check again.
+	 * may put the user into a totally separate class with different restrictions! so we *must* check again.
 	 * Don't remove this! -- w00t
 	 */
 	MyClass = NULL;

--- a/src/xline.cpp
+++ b/src/xline.cpp
@@ -114,7 +114,7 @@ class ZLineFactory : public XLineFactory
  *  was added, it iterated every existing line for every existing user. Ow. Expiry was also
  *  expensive, as the lists were NOT sorted.
  *
- *  Version 2 moved permanent lines into a seperate list from non-permanent to help optimize
+ *  Version 2 moved permanent lines into a separate list from non-permanent to help optimize
  *  matching speed, but matched in the same way.
  *  Expiry was also sped up by sorting the list by expiry (meaning just remove the items at the
  *  head of the list that are outdated.)

--- a/win/win32service.cpp
+++ b/win/win32service.cpp
@@ -38,7 +38,7 @@ struct Service_Data {
 static Service_Data g_ServiceData;
 
 /** The main part of inspircd runs within this thread function. This allows the service part to run
- * seperately on its own and to be able to kill the worker thread when its time to quit.
+ * separately on its own and to be able to kill the worker thread when its time to quit.
  */
 DWORD WINAPI WorkerThread(LPVOID param)
 {


### PR DESCRIPTION
- Limit some more lines to (close to) 80 characters.
- Comment all of modules.conf(.example)

Please feel free to cherry-pick any or all changes.
