### PR TITLE
Add support for optional modules.

### DIFF
--- a/src/modmanager_dynamic.cpp
+++ b/src/modmanager_dynamic.cpp
@@ -220,7 +220,7 @@ void ModuleManager::LoadAll()
 		std::string name = tag->getString("name");
 		std::cout << "[" << con_green << "*" << con_reset << "] Loading module:\t" << con_green << name << con_reset << std::endl;
 
-		if (!this->Load(name, true))
+		if (!this->Load(name, true) && !tag->getBool("optional"))
 		{
 			ServerInstance->Logs->Log("MODULE", LOG_DEFAULT, this->LastError());
 			std::cout << std::endl << "[" << con_red << "*" << con_reset << "] " << this->LastError() << std::endl << std::endl;

--- a/src/modmanager_static.cpp
+++ b/src/modmanager_static.cpp
@@ -195,7 +195,7 @@ void ModuleManager::LoadAll()
 		std::string name = tag->getString("name");
 		std::cout << "[" << con_green << "*" << con_reset << "] Loading module:\t" << con_green << name << con_reset << std::endl;
 
-		if (!this->Load(name, true))
+		if (!this->Load(name, true) && !tag->getBool("optional"))
 		{
 			ServerInstance->Logs->Log("MODULE", LOG_DEFAULT, this->LastError());
 			std::cout << std::endl << "[" << con_red << "*" << con_reset << "] " << this->LastError() << std::endl << std::endl;


### PR DESCRIPTION
A user can mark a module optional like so:

```
<module name="m_ssl_gnutls.so" optional="yes">
```

This allows the IRC server to start up even if a specific module fails to load.
