### PR TITLE
set LDAP_OPT_REFERRALS option as LDAP_OPT_OFF.

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -952,6 +952,7 @@
 #           searchscope="subtree"                                     #
 #           binddn="cn=Manager,dc=brainbox,dc=cc"                     #
 #           bindauth="mysecretpass"                                   #
+#           followreferrals="yes"                                     #
 #           verbose="yes"                                             #
 #           host="$uid.$ou.inspircd.org">                             #
 #                                                                     #
@@ -977,6 +978,8 @@
 #                                                                     #
 # The searchscope value indicates the subtree to search under. On our #
 # test system this is 'subtree'. Your mileage may vary.               #
+#                                                                     #
+# Setting the followreferrals no to turn off LDAP referrals.          #
 #                                                                     #
 # Setting the verbose value causes an oper notice to be sent out for  #
 # every failed authentication to the server, with an error string.    #
@@ -1020,6 +1023,7 @@
 #           searchscope="subtree"
 #           binddn="cn=Manager,dc=brainbox,dc=cc"
 #           bindauth="mysecretpass"
+#           followreferrals="yes"
 #           attribute="uid">
 #                                                                     #
 # Available configuration items are identical to the same items in    #
@@ -1028,6 +1032,7 @@
 # Please always specify a password in your <oper> tags even if the    #
 # opers are to be authenticated via LDAP, so in case this module is   #
 # not loaded the oper accounts are still protected by a password.     #
+# Setting the followreferrals no to turn off LDAP referrals.          #
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Lock server module: Adds /LOCKSERV and /UNLOCKSERV commands that is #

--- a/src/modules/extra/m_ldapauth.cpp
+++ b/src/modules/extra/m_ldapauth.cpp
@@ -106,6 +106,7 @@ class ModuleLDAPAuth : public Module
 	std::vector<std::string> whitelistedcidrs;
 	std::vector<std::pair<std::string, std::string> > requiredattributes;
 	int searchscope;
+	bool followreferrals;
 	bool verbose;
 	bool useusername;
 	LDAP *conn;
@@ -145,6 +146,7 @@ public:
 		username		= tag->getString("binddn");
 		password		= tag->getString("bindauth");
 		vhost			= tag->getString("host");
+		followreferrals		= tag->getBool("followreferrals", true);
 		verbose			= tag->getBool("verbose");		/* Set to true if failed connects should be reported to operators */
 		useusername		= tag->getBool("userfield");
 
@@ -191,7 +193,18 @@ public:
 			conn = NULL;
 			return false;
 		}
-
+		if (!followreferrals)
+		{
+			res = ldap_set_option(conn, LDAP_OPT_REFERRALS, LDAP_OPT_OFF);
+			if (res != LDAP_SUCCESS)
+			{
+				if (verbose)
+					ServerInstance->SNO->WriteToSnoMask('c', "Failed to turn LDAP referrals off: %s", ldap_err2string(res));
+				ldap_unbind_ext(conn, NULL, NULL);
+				conn = NULL;
+				return false;
+			}
+		}
 		res = ldap_set_option(conn, LDAP_OPT_PROTOCOL_VERSION, (void *)&v);
 		if (res != LDAP_SUCCESS)
 		{


### PR DESCRIPTION
Some of LDAP servers return 'Search failed' w/ LDAP_OPT_REFERRALS is LDAP_OPT_ON.
And many LDAP clients are also disabling follow referrals option.

I wanna set off this option also in InspIRCd.

Thank you.
