### PR TITLE
Fix a shadow warning in ConfigTag::create

### DIFF
--- a/include/configreader.h
+++ b/include/configreader.h
@@ -65,7 +65,7 @@ class CoreExport ConfigTag : public refcountbase
 
 	/** Create a new ConfigTag, giving access to the private KeyVal item list */
 	static ConfigTag* create(const std::string& Tag, const std::string& file, int line,
-		std::vector<KeyVal>*&items);
+		std::vector<KeyVal>*&itemsread);
  private:
 	ConfigTag(const std::string& Tag, const std::string& file, int line);
 };

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -472,10 +472,10 @@ std::string ConfigTag::getTagLocation()
 	return src_name + ":" + ConvToStr(src_line);
 }
 
-ConfigTag* ConfigTag::create(const std::string& Tag, const std::string& file, int line, std::vector<KeyVal>*&items)
+ConfigTag* ConfigTag::create(const std::string& Tag, const std::string& file, int line, std::vector<KeyVal>*&itemsread)
 {
 	ConfigTag* rv = new ConfigTag(Tag, file, line);
-	items = &rv->items;
+	itemsread = &rv->items;
 	return rv;
 }
 


### PR DESCRIPTION
Note: This is also present in the master branch
