### PR TITLE
[Blatant RFC Violation] src/users: Comply to RFC standards

### DIFF
--- a/src/users.cpp
+++ b/src/users.cpp
@@ -274,7 +274,6 @@ void UserIOHandler::OnDataReady()
 				c = ' ';
 				break;
 			case '\r':
-				continue;
 			case '\n':
 				goto eol_found;
 			}


### PR DESCRIPTION
\r == \n

This closes issue #648: [security] BufferedSocket::GetNextLine() rfc1459 framing overrun