### PR TITLE
Use gnutls_rnd instead of gcry_randomize on newer GnuTLS versions.

### DIFF
--- a/make/utilities.pm
+++ b/make/utilities.pm
@@ -34,6 +34,7 @@ use Fcntl;
 use File::Path;
 use File::Spec::Functions qw(rel2abs);
 use Getopt::Long;
+use POSIX;
 
 our @EXPORT = qw(module_installed prompt_bool prompt_dir prompt_string make_rpath pkgconfig_get_include_dirs pkgconfig_get_lib_dirs pkgconfig_check_version translate_functions promptstring);
 


### PR DESCRIPTION
This removes our dependancy on libgcrypt in GnuTLS versions where it is not a mandatory dependency.

I have tested this and it works on GnuTLS 3.1.10. I am not able to test on earlier versions but if it builds it will most likely work.

The ugly eval code will be cleaned up when I add the ability to do dependency version checking to the build comments.
