### PR TITLE
[WIP] Remove InvalidateCache and cached_* from User class.

### DIFF
--- a/include/users.h
+++ b/include/users.h
@@ -219,22 +219,6 @@ struct CoreExport ConnectClass : public refcountbase
 class CoreExport User : public Extensible
 {
  private:
-	/** Cached nick!ident@dhost value using the displayed hostname
-	 */
-	std::string cached_fullhost;
-
-	/** Cached ident@ip value using the real IP address
-	 */
-	std::string cached_hostip;
-
-	/** Cached ident@realhost value using the real hostname
-	 */
-	std::string cached_makehost;
-
-	/** Cached nick!ident@realhost value using the real hostname
-	 */
-	std::string cached_fullrealhost;
-
 	/** Set by GetIPString() to avoid constantly re-grabbing IP via sockets voodoo.
 	 */
 	std::string cachedip;
@@ -377,11 +361,6 @@ class CoreExport User : public Extensible
 	 * @return The full real host of the user
 	 */
 	virtual const std::string& GetFullRealHost();
-
-	/** This clears any cached results that are used for GetFullRealHost() etc.
-	 * The results of these calls are cached as generating them can be generally expensive.
-	 */
-	void InvalidateCache();
 
 	/** Returns whether this user is currently away or not. If true,
 	 * further information can be found in User::awaymsg and User::awaytime

--- a/src/commands/cmd_hostname_lookup.cpp
+++ b/src/commands/cmd_hostname_lookup.cpp
@@ -142,9 +142,6 @@ class UserResolver : public DNS::Request
 					bound_user->WriteNotice("*** Found your hostname (" + *hostname + (r->cached ? ") -- cached" : ")"));
 					bound_user->host.assign(*hostname, 0, 64);
 					bound_user->dhost = bound_user->host;
-
-					/* Invalidate cache */
-					bound_user->InvalidateCache();
 				}
 				else
 				{

--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -147,7 +147,6 @@ class CGIResolver : public DNS::Request
 				ServerInstance->SNO->WriteGlobalSno('a', "Connecting user %s detected as using CGI:IRC (%s), changing real host to %s from %s", them->nick.c_str(), them->host.c_str(), ans_record.rdata.c_str(), typ.c_str());
 
 			them->host = them->dhost = ans_record.rdata;
-			them->InvalidateCache();
 			lu->CheckLines(true);
 		}
 	}
@@ -202,7 +201,6 @@ class ModuleCgiIRC : public Module
 		cmd.realip.set(user, user->GetIPString());
 		ChangeIP(user, newip);
 		user->host = user->dhost = user->GetIPString();
-		user->InvalidateCache();
 		RecheckClass(user);
 
 		// Don't create the resolver if the core couldn't put the user in a connect class or when dns is disabled

--- a/src/modules/m_ident.cpp
+++ b/src/modules/m_ident.cpp
@@ -345,7 +345,6 @@ class ModuleIdent : public Module
 			user->WriteNotice("*** Found your ident, '" + user->ident + "'");
 		}
 
-		user->InvalidateCache();
 		isock->Close();
 		ext.unset(user);
 		return MOD_RES_PASSTHRU;

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -108,42 +108,22 @@ User::~User()
 
 const std::string& User::MakeHost()
 {
-	if (!this->cached_makehost.empty())
-		return this->cached_makehost;
-
-	// XXX: Is there really a need to cache this?
-	this->cached_makehost = ident + "@" + host;
-	return this->cached_makehost;
+	return ident + "@" + host;
 }
 
 const std::string& User::MakeHostIP()
 {
-	if (!this->cached_hostip.empty())
-		return this->cached_hostip;
-
-	// XXX: Is there really a need to cache this?
-	this->cached_hostip = ident + "@" + this->GetIPString();
-	return this->cached_hostip;
+	return ident + "@" + this->GetIPString();
 }
 
 const std::string& User::GetFullHost()
 {
-	if (!this->cached_fullhost.empty())
-		return this->cached_fullhost;
-
-	// XXX: Is there really a need to cache this?
-	this->cached_fullhost = nick + "!" + ident + "@" + dhost;
-	return this->cached_fullhost;
+	return nick + "!" + ident + "@" + dhost;
 }
 
 const std::string& User::GetFullRealHost()
 {
-	if (!this->cached_fullrealhost.empty())
-		return this->cached_fullrealhost;
-
-	// XXX: Is there really a need to cache this?
-	this->cached_fullrealhost = nick + "!" + ident + "@" + host;
-	return this->cached_fullrealhost;
+	return nick + "!" + ident + "@" + host;
 }
 
 InviteList& LocalUser::GetInviteList()
@@ -619,15 +599,6 @@ void LocalUser::FullConnect()
 	CommandFloodPenalty = 0;
 }
 
-void User::InvalidateCache()
-{
-	/* Invalidate cache */
-	cached_fullhost.clear();
-	cached_hostip.clear();
-	cached_makehost.clear();
-	cached_fullrealhost.clear();
-}
-
 bool User::ChangeNick(const std::string& newnick, bool force)
 {
 	if (quitting)
@@ -715,7 +686,6 @@ bool User::ChangeNick(const std::string& newnick, bool force)
 				(*(ServerInstance->Users->clientlist))[InUse->uuid] = InUse;
 
 				InUse->nick = InUse->uuid;
-				InUse->InvalidateCache();
 				InUse->registered &= ~REG_NICK;
 			}
 			else
@@ -732,7 +702,6 @@ bool User::ChangeNick(const std::string& newnick, bool force)
 	std::string oldnick = nick;
 	nick = newnick;
 
-	InvalidateCache();
 	ServerInstance->Users->clientlist->erase(oldnick);
 	(*(ServerInstance->Users->clientlist))[newnick] = this;
 
@@ -785,15 +754,11 @@ irc::sockets::cidr_mask User::GetCIDRMask()
 
 bool User::SetClientIP(const char* sip, bool recheck_eline)
 {
-	cachedip.clear();
-	cached_hostip.clear();
 	return irc::sockets::aptosa(sip, 0, client_sa);
 }
 
 void User::SetClientIP(const irc::sockets::sockaddrs& sa, bool recheck_eline)
 {
-	cachedip.clear();
-	cached_hostip.clear();
 	memcpy(&client_sa, &sa, sizeof(irc::sockets::sockaddrs));
 }
 
@@ -1137,7 +1102,6 @@ bool User::ChangeDisplayedHost(const std::string& shost)
 	FOREACH_MOD(OnChangeHost, (this,shost));
 
 	this->dhost.assign(shost, 0, 64);
-	this->InvalidateCache();
 
 	if (IS_LOCAL(this))
 		this->WriteNumeric(RPL_YOURDISPLAYEDHOST, "%s :is now your displayed host", this->dhost.c_str());
@@ -1153,7 +1117,6 @@ bool User::ChangeIdent(const std::string& newident)
 	FOREACH_MOD(OnChangeIdent, (this,newident));
 
 	this->ident.assign(newident, 0, ServerInstance->Config->Limits.IdentMax);
-	this->InvalidateCache();
 
 	return true;
 }


### PR DESCRIPTION
This was useful when we used `const char*` as concatenating C strings
is messy. However, concatenating `std::string` is easy and this code
gives no noticeable performance increase.
