### PR TITLE
[2.0] Fix bugs found by Coverity.

### DIFF
--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -116,16 +116,8 @@ int Channel::SetTopic(User *u, std::string &ntopic, bool forceset)
 	}
 
 	this->topic.assign(ntopic, 0, ServerInstance->Config->Limits.MaxTopic);
-	if (u)
-	{
-		this->setby.assign(ServerInstance->Config->FullHostInTopic ? u->GetFullHost() : u->nick, 0, 128);
-		this->WriteChannel(u, "TOPIC %s :%s", this->name.c_str(), this->topic.c_str());
-	}
-	else
-	{
-		this->setby.assign(ServerInstance->Config->ServerName);
-		this->WriteChannelWithServ(ServerInstance->Config->ServerName, "TOPIC %s :%s", this->name.c_str(), this->topic.c_str());
-	}
+	this->setby.assign(ServerInstance->Config->FullHostInTopic ? u->GetFullHost() : u->nick, 0, 128);
+	this->WriteChannel(u, "TOPIC %s :%s", this->name.c_str(), this->topic.c_str());
 
 	this->topicset = ServerInstance->Time();
 

--- a/src/modules/m_joinflood.cpp
+++ b/src/modules/m_joinflood.cpp
@@ -153,17 +153,10 @@ class JoinFlood : public ModeHandler
 						else
 						{
 							// new mode param, replace old with new
-							if ((nsecs > 0) && (njoins > 0))
-							{
-								f = new joinfloodsettings(nsecs, njoins);
-								ext.set(channel, f);
-								channel->SetModeParam('j', parameter);
-								return MODEACTION_ALLOW;
-							}
-							else
-							{
-								return MODEACTION_DENY;
-							}
+							f = new joinfloodsettings(nsecs, njoins);
+							ext.set(channel, f);
+							channel->SetModeParam('j', parameter);
+							return MODEACTION_ALLOW;
 						}
 					}
 				}

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -1549,7 +1549,7 @@ void User::SplitChanList(User* dest, const std::string &cl)
 {
 	std::string line;
 	std::ostringstream prefix;
-	std::string::size_type start, pos, length;
+	std::string::size_type start, pos;
 
 	prefix << this->nick << " " << dest->nick << " :";
 	line = prefix.str();
@@ -1557,23 +1557,13 @@ void User::SplitChanList(User* dest, const std::string &cl)
 
 	for (start = 0; (pos = cl.find(' ', start)) != std::string::npos; start = pos+1)
 	{
-		length = (pos == std::string::npos) ? cl.length() : pos;
-
-		if (line.length() + namelen + length - start > 510)
+		if (line.length() + namelen + pos - start > 510)
 		{
 			ServerInstance->SendWhoisLine(this, dest, 319, "%s", line.c_str());
 			line = prefix.str();
 		}
 
-		if(pos == std::string::npos)
-		{
-			line.append(cl.substr(start, length - start));
-			break;
-		}
-		else
-		{
-			line.append(cl.substr(start, length - start + 1));
-		}
+		line.append(cl.substr(start, pos - start + 1));
 	}
 
 	if (line.length() != prefix.str().length())


### PR DESCRIPTION
- **src/channels.cpp** -- `u` can never be `NULL` as the code higher up is setting it to the server user `ServerInstance->FakeClient` if it is `NULL`.
- **src/modules/m_joinflood.cpp** -- we are checking the value of these variables higher up and returning if they are less than 1.
- **src/users.cpp** -- `pos` can never be `std::string::npos` as this is a requirement of the loop.
