### PR TITLE
Fix m_cgiirc to set the user's host straight away when using WEBIRC.

### DIFF
--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -30,6 +30,14 @@
 
 enum CGItype { PASS, IDENT, PASSFIRST, IDENTFIRST, WEBIRC };
 
+// We need this method up here so that it can be acessed from anywhere
+static void ChangeIP(User* user, const std::string& newip)
+{
+	ServerInstance->Users->RemoveCloneCounts(user);
+	user->SetClientIP(newip.c_str());
+	ServerInstance->Users->AddLocalClone(user);
+	ServerInstance->Users->AddGlobalClone(user);
+}
 
 /** Holds a CGI site's details
  */
@@ -62,16 +70,10 @@ class CommandWebirc : public Command
 {
  public:
 	bool notify;
-	StringExtItem realhost;
-	StringExtItem realip;
-	LocalStringExt webirc_hostname;
-	LocalStringExt webirc_ip;
 
 	CGIHostlist Hosts;
 	CommandWebirc(Module* Creator)
-		: Command(Creator, "WEBIRC", 4),
-		  realhost("cgiirc_realhost", Creator), realip("cgiirc_realip", Creator),
-		  webirc_hostname("cgiirc_webirc_hostname", Creator), webirc_ip("cgiirc_webirc_ip", Creator)
+		: Command(Creator, "WEBIRC", 4)
 		{
 			works_before_reg = true;
 			this->syntax = "password client hostname ip";
@@ -87,22 +89,19 @@ class CommandWebirc : public Command
 				{
 					if(iter->type == WEBIRC && parameters[0] == iter->password)
 					{
-						realhost.set(user, user->host);
-						realip.set(user, user->GetIPString());
 
+						// TODO: Why do we have a 64 char check here, maybe we should handle this globally
 						bool host_ok = (parameters[2].length() < 64);
 						const std::string& newhost = (host_ok ? parameters[2] : parameters[3]);
 
 						if (notify)
 							ServerInstance->SNO->WriteGlobalSno('a', "Connecting user %s detected as using CGI:IRC (%s), changing real host to %s from %s", user->nick.c_str(), user->host.c_str(), newhost.c_str(), user->host.c_str());
 
-						// Check if we're happy with the provided hostname. If it's problematic then make sure we won't set a host later, just the IP
-						if (host_ok)
-							webirc_hostname.set(user, parameters[2]);
-						else
-							webirc_hostname.unset(user);
+						// Where the magic happens - change their IP
+						ChangeIP(user, parameters[3]);
+						// And follow this up by changing their host
+						user->host = user->dhost = newhost;
 
-						webirc_ip.set(user, parameters[3]);
 						return CMD_SUCCESS;
 					}
 				}
@@ -183,18 +182,8 @@ class ModuleCgiIRC : public Module
 		user->CheckClass();
 	}
 
-	static void ChangeIP(LocalUser* user, const std::string& newip)
-	{
-		ServerInstance->Users->RemoveCloneCounts(user);
-		user->SetClientIP(newip.c_str());
-		ServerInstance->Users->AddLocalClone(user);
-		ServerInstance->Users->AddGlobalClone(user);
-	}
-
 	void HandleIdentOrPass(LocalUser* user, const std::string& newip, bool was_pass)
 	{
-		cmd.realhost.set(user, user->host);
-		cmd.realip.set(user, user->GetIPString());
 		ChangeIP(user, newip);
 		user->host = user->dhost = user->GetIPString();
 		user->InvalidateCache();
@@ -225,7 +214,7 @@ public:
 	void init()
 	{
 		OnRehash(NULL);
-		ServiceProvider* providerlist[] = { &cmd, &cmd.realhost, &cmd.realip, &cmd.webirc_hostname, &cmd.webirc_ip, &waiting };
+		ServiceProvider* providerlist[] = { &cmd, &waiting };
 		ServerInstance->Modules->AddServices(providerlist, sizeof(providerlist)/sizeof(ServiceProvider*));
 
 		Implementation eventlist[] = { I_OnRehash, I_OnUserRegister, I_OnCheckReady };
@@ -286,15 +275,6 @@ public:
 		if (waiting.get(user))
 			return MOD_RES_DENY;
 
-		std::string *webirc_ip = cmd.webirc_ip.get(user);
-		if (!webirc_ip)
-			return MOD_RES_PASSTHRU;
-
-		ChangeIP(user, *webirc_ip);
-
-		std::string* webirc_hostname = cmd.webirc_hostname.get(user);
-		user->host = user->dhost = (webirc_hostname ? *webirc_hostname : user->GetIPString());
-
 		RecheckClass(user);
 		if (user->quitting)
 			return MOD_RES_DENY;
@@ -302,9 +282,6 @@ public:
 		user->CheckLines(true);
 		if (user->quitting)
 			return MOD_RES_DENY;
-
-		cmd.webirc_hostname.unset(user);
-		cmd.webirc_ip.unset(user);
 
 		return MOD_RES_PASSTHRU;
 	}


### PR DESCRIPTION
Doing this at a later time defeats the purpose of WEBIRC support in the first place - we want to know their real credentials right off the bat.
