### PR TITLE
Add a connect block option 'forceident' for m_ident which will force the given ident upon any user in the connect block.

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -277,6 +277,9 @@
          # useident: Defines if users in this class MUST respond to a ident query or not.
          useident="no"
 
+         # forceident: Defines the ident which all users in this class will get
+         forceident=""
+
          # limit: How many users are allowed in this class
          limit="5000"
 

--- a/src/modules/m_ident.cpp
+++ b/src/modules/m_ident.cpp
@@ -311,6 +311,13 @@ class ModuleIdent : public Module
 		if (!tag->getBool("useident", true))
 			return;
 
+		std::string forcedident = tag->getString("forceident");
+		if (!forcedident.empty())
+		{
+			user->ident = forcedident;
+			return;
+		}
+
 		user->WriteServ("NOTICE Auth :*** Looking up your ident...");
 
 		try


### PR DESCRIPTION
This is useful for say, forcing all webchat users to have the ident "webchat".
