### PR TITLE
Fix some Windows-related problems.

### DIFF
--- a/include/compat.h
+++ b/include/compat.h
@@ -41,7 +41,6 @@
 #if defined __clang__ || defined __GNUC__
 # define CUSTOM_PRINTF(stringpos, firstpos) __attribute__((format(printf, stringpos, firstpos)))
 #else
-# pragma message ("Warning! CUSTOM_PRINTF() does not work on your compiler!")
 # define CUSTOM_PRINTF(stringpos, firstpos)
 #endif
 
@@ -98,7 +97,6 @@
 #elif defined _MSC_VER
 # define DEPRECATED_METHOD(function) __declspec(deprecated) function
 #else
-# pragma message ("Warning! DEPRECATED_METHOD() does not work on your compiler!")
 # define DEPRECATED_METHOD(function) function
 #endif
 

--- a/include/hashcomp.h
+++ b/include/hashcomp.h
@@ -148,7 +148,7 @@ namespace irc
 		 * @return similar to strcmp, zero for equal, less than zero for str1
 		 * being less and greater than zero for str1 being greater than str2.
 		 */
-		static CoreExport int compare(const char* str1, const char* str2, size_t n);
+		static int compare(const char* str1, const char* str2, size_t n);
 
 		/** Find a char within a string up to position n.
 		 * @param s1 String to find in
@@ -156,7 +156,7 @@ namespace irc
 		 * @param c Character to search for
 		 * @return Pointer to the first occurance of c in s1
 		 */
-		static CoreExport const char* find(const char* s1, int  n, char c);
+		static const char* find(const char* s1, int  n, char c);
 	};
 
 	/** This typedef declares irc::string based upon irc_char_traits.

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -300,7 +300,7 @@ void ParseStack::DoInclude(ConfigTag* tag, int flags)
 			flags |= FLAG_NO_INC;
 		if (tag->getBool("noexec", false))
 			flags |= FLAG_NO_EXEC;
-		if (!ParseFile(name, flags, mandatorytag))
+		if (!ParseFile(ServerInstance->Config->Paths.PrependConfig(name), flags, mandatorytag))
 			throw CoreException("Included");
 	}
 	else if (tag->readString("executable", name))
@@ -344,13 +344,12 @@ void ParseStack::DoReadFile(const std::string& key, const std::string& name, int
 	}
 }
 
-bool ParseStack::ParseFile(const std::string& name, int flags, const std::string& mandatory_tag)
+bool ParseStack::ParseFile(const std::string& path, int flags, const std::string& mandatory_tag)
 {
-	std::string path = ServerInstance->Config->Paths.PrependConfig(name);
 	ServerInstance->Logs->Log("CONFIG", LOG_DEBUG, "Reading file %s", path.c_str());
 	for (unsigned int t = 0; t < reading.size(); t++)
 	{
-		if (std::string(name) == reading[t])
+		if (path == reading[t])
 		{
 			throw CoreException("File " + path + " is included recursively (looped inclusion)");
 		}

--- a/src/modules/m_spanningtree/utils.cpp
+++ b/src/modules/m_spanningtree/utils.cpp
@@ -227,7 +227,7 @@ void SpanningTreeUtilities::RefreshIPCache()
 			continue;
 		}
 
-		std::copy(L->AllowMasks.begin(), L->AllowMasks.end(), std::back_inserter(ValidIPs));
+		ValidIPs.insert(ValidIPs.end(), L->AllowMasks.begin(), L->AllowMasks.end());
 
 		irc::sockets::sockaddrs dummy;
 		bool ipvalid = irc::sockets::aptosa(L->IPAddr, L->Port, dummy);


### PR DESCRIPTION
- Fix an error relating to the unavailability of std::back_inserter.
- Fix loading configuration files when using relative paths.
- Fix two methods in hashcomp being exported twice.
- Remove some unimportant error messages.
