### PR TITLE
Allow opers with the channels/auspex privilege to see +i users in /NAMES...

### DIFF
--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -679,7 +679,7 @@ void Channel::UserList(User *user)
 	{
 		if (i->first->quitting)
 			continue;
-		if ((!has_user) && (i->first->IsModeSet(invisiblemode)))
+		if (!has_user && i->first->IsModeSet(invisiblemode) && !user->HasPrivPermission("channels/auspex"))
 		{
 			/*
 			 * user is +i, and source not on the channel, does not show


### PR DESCRIPTION
... from outside of channels

/WHO functions already in the same manor with users/auspex
