### PR TITLE
Adjust example addresses in configs

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -236,7 +236,7 @@
 
 <connect
          # deny: Will not let people connect if they have specified host/IP.
-         deny="69.254.*">
+         deny="192.0.2.*">
 
 # connect:reason is the message that users will see if they match a deny block
 <connect deny="3ffe::0/32" reason="The 6bone address space is deprecated">
@@ -253,7 +253,7 @@
          parent="main"
 
          # allow: What IP addresses/hosts to allow for this block.
-         allow="196.12.*"
+         allow="203.0.113.*"
 
          # hash: what hash this password is hashed with. requires the module
          # for selected hash (m_md5.so, m_sha256.so or m_ripemd160.so) be
@@ -894,7 +894,7 @@
 
 <badip
        # ipmask: IP range to ban. Wildcards and CIDR can be used.
-       ipmask="69.69.69.69"
+       ipmask="192.0.2.69"
 
        # reason: Reason to display when user is disconnected.
        reason="No porn here thanks.">
@@ -913,22 +913,22 @@
 <badhost
          # host: ident@hostname to ban.
          # Wildcards and CIDR (if you specify an IP) can be used.
-         host="*@hundredz.n.hundredz.o.1337.kiddies.com"
+         host="*@hundredz.n.hundredz.o.1337.kiddies.example.net"
 
          # reason: Reason to display when user is disconnected
          reason="Too many 1337 kiddiots">
 
-<badhost host="root@*" reason="Don't irc as root!">
-<badhost host="*@172.32.0.0/16" reason="This subnet is bad.">
+<badhost host="root@*" reason="Don't IRC as root!">
+<badhost host="*@198.51.100.0/24" reason="This subnet is bad.">
 
 # exception: Hosts that are exempt from [kgz]lines.
 <exception
            # host: ident@hostname to exempt.
            # Wildcards and CIDR (if you specify an IP) can be used.
-           host="*@ircop.host.com"
+           host="*@ircop.example.com"
 
            # reason: Reason for exception. Only shown in /stats e
-           reason="Opers hostname">
+           reason="Oper's hostname">
 
 #-#-#-#-#-#-#-#-#-#-#- INSANE BAN OPTIONS  -#-#-#-#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #

--- a/docs/conf/links.conf.example
+++ b/docs/conf/links.conf.example
@@ -29,7 +29,7 @@
 
       # allowmask: Range of IP addresses to allow for this link.
       # Can be a CIDR (see example).
-      allowmask="69.58.44.0/24 127.0.0.0/8"
+      allowmask="203.0.113.0/24 127.0.0.0/8 2001:db8::/32"
 
       # timeout: If defined, this option defines how long the server
       # will wait to consider the connect attempt failed and try the
@@ -74,7 +74,7 @@
 <link name="hub.penguin.org"
       ipaddr="penguin.box.com"
       port="7000"
-      allowmask="69.58.44.0/24"
+      allowmask="203.0.113.0/24"
       timeout="300"
       ssl="gnutls"
       bind="1.2.3.4"

--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -90,7 +90,7 @@
       # Multiple options can be separated by spaces and CIDR's are allowed.
       # You CAN use just * or *@* for this section, but it is not recommended
       # for security reasons.
-      host="ident@dialup15.isp.com *@localhost *@server.com *@3ffe::0/16"
+      host="yourident@dialup15.isp.com *@localhost *@example.com *@2001:db8::/32"
 
       # ** ADVANCED ** This option is disabled by default.
       # fingerprint: When using the m_sslinfo module, you may specify
@@ -127,7 +127,7 @@
 <oper
       name="Brain"
       password="s3cret"
-      host="ident@dialup15.isp.com *@localhost *@server.com *@3ffe::0/16"
+      host="yourident@dialup15.isp.com *@localhost *@example.com *@2001:db8::/32"
       #fingerprint="67cb9dc013248a829bb2171ed11becd4"
       type="NetAdmin">
 
@@ -155,7 +155,7 @@
       # Multiple options can be separated by spaces and CIDR's are allowed.
       # You CAN use just * or *@* for this section, but it is not recommended
       # for security reasons.
-      host="ident@dialup15.isp.com *@localhost *@server.com *@3ffe::0/16"
+      host="yourident@dialup15.isp.com *@localhost *@example.com *@2001:db8::/32"
 
       # type: What oper type this oline is. See the block above for list
       # of types. NOTE: This is case-sensitive as well.


### PR DESCRIPTION
`2001:db8::/32` is the [standard](http://tools.ietf.org/html/rfc3849) IPv6 example address range, using
it also makes it clear when the user has just copy-pasted the example
config and didn't actually whitelist 6BONE for some strange reason.

Similarly, there are example addresses for [IPv4](http://tools.ietf.org/html/rfc5737) and [DNS](http://tools.ietf.org/html/rfc2606).
