### PR TITLE
m_sasl: properly handle bad-mechanism failures

### DIFF
--- a/src/modules/m_sasl.cpp
+++ b/src/modules/m_sasl.cpp
@@ -99,13 +99,17 @@ class SaslAuthenticator
 			if (msg[0] != this->agent)
 				return this->state;
 
-			if (msg[2] != "D")
+			if (msg[2] == "C")
 				this->user->Write("AUTHENTICATE %s", msg[3].c_str());
-			else
+			else if (msg[2] == "D")
 			{
 				this->state = SASL_DONE;
 				this->result = this->GetSaslResult(msg[3]);
 			}
+			else if (msg[2] == "M")
+				this->user->WriteNumeric(908, "%s %s :are available SASL mechanisms", this->user->nick.c_str(), msg[3].c_str());
+			else
+				ServerInstance->Logs->Log("m_sasl", DEFAULT, "Services sent an unknown SASL message \"%s\" \"%s\"", msg[2].c_str(), msg[3].c_str());
 
 			break;
 		 case SASL_DONE:


### PR DESCRIPTION
When the client requested a bad SASL mechanism, with Anope the ircd would send the services reply raw instead of sending the apropriate numeric. With Atheme, it _accidentally_ worked because the extra "known mechanisms" reply would move to the apropriate state.

This e-note makes message handling the same in both SASL_INIT and SASL_COMM states and adds the "available SASL mechanisms" numeric.
