### PR TITLE
Fix various cases of UUID exposure.

### DIFF
--- a/include/users.h
+++ b/include/users.h
@@ -501,10 +501,16 @@ class CoreExport User : public Extensible
 	 */
 	void WriteServ(const char* text, ...) CUSTOM_PRINTF(2, 3);
 
+	/** Sends a command to this user.
+	 * @param command The command to be sent.
+	 * @param text The message to send.
+	 */
+	void WriteCommand(const char* command, const std::string& text);
+
 	/** Sends a server notice to this user.
 	 * @param text The contents of the message to send.
 	 */
-	void WriteNotice(const std::string& text);
+	void WriteNotice(const std::string& text) { this->WriteCommand("NOTICE", ":" + text); }
 
 	void WriteNumeric(unsigned int numeric, const char* text, ...) CUSTOM_PRINTF(3, 4);
 

--- a/src/modules/m_cap.cpp
+++ b/src/modules/m_cap.cpp
@@ -74,13 +74,13 @@ class CommandCAP : public Command
 			if (Data.ack.size() > 0)
 			{
 				std::string AckResult = irc::stringjoiner(Data.ack).GetJoined();
-				user->WriteServ("CAP %s ACK :%s", user->nick.c_str(), AckResult.c_str());
+				user->WriteCommand("CAP", "ACK :" + AckResult);
 			}
 
 			if (Data.wanted.size() > 0)
 			{
 				std::string NakResult = irc::stringjoiner(Data.wanted).GetJoined();
-				user->WriteServ("CAP %s NAK :%s", user->nick.c_str(), NakResult.c_str());
+				user->WriteCommand("CAP", "NAK :" + NakResult);
 			}
 		}
 		else if (subcommand == "END")
@@ -95,7 +95,7 @@ class CommandCAP : public Command
 			Data.Send();
 
 			std::string Result = irc::stringjoiner(Data.wanted).GetJoined();
-			user->WriteServ("CAP %s %s :%s", user->nick.c_str(), subcommand.c_str(), Result.c_str());
+			user->WriteCommand("CAP", parameters[0] + " :" + Result);
 		}
 		else if (subcommand == "CLEAR")
 		{
@@ -105,7 +105,7 @@ class CommandCAP : public Command
 			Data.Send();
 
 			std::string Result = irc::stringjoiner(Data.ack).GetJoined();
-			user->WriteServ("CAP %s ACK :%s", user->nick.c_str(), Result.c_str());
+			user->WriteCommand("CAP", "ACK :" + Result);
 		}
 		else
 		{

--- a/src/modules/m_cloaking.cpp
+++ b/src/modules/m_cloaking.cpp
@@ -301,7 +301,7 @@ class ModuleCloaking : public Module
 		if (u->IsModeSet(cu))
 		{
 			u->SetMode(cu, false);
-			u->WriteServ("MODE %s -%c", u->nick.c_str(), cu.GetModeChar());
+			u->WriteCommand("MODE", "-" + ConvToStr(cu.GetModeChar()));
 		}
 	}
 

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -357,7 +357,7 @@ void User::Oper(OperInfo* info)
 
 	this->SetMode(opermh, true);
 	this->oper = info;
-	this->WriteServ("MODE %s :+o", this->nick.c_str());
+	this->WriteCommand("MODE", "+o");
 	FOREACH_MOD(OnOper, (this, info->name));
 
 	std::string opername;
@@ -585,7 +585,7 @@ void LocalUser::FullConnect()
 		ServerInstance->Parser->CallHandler(command, parameters, this);
 
 	if (ServerInstance->Config->RawLog)
-		WriteServ("PRIVMSG %s :*** Raw I/O logging is enabled on this server. All messages, passwords, and commands are being recorded.", nick.c_str());
+		WriteCommand("PRIVMSG", ":*** Raw I/O logging is enabled on this server. All messages, passwords, and commands are being recorded.");
 
 	/*
 	 * We don't set REG_ALL until triggering OnUserConnect, so some module events don't spew out stuff
@@ -863,9 +863,9 @@ void User::WriteServ(const char* text, ...)
 	this->WriteServ(textbuffer);
 }
 
-void User::WriteNotice(const std::string& text)
+void User::WriteCommand(const char* command, const std::string& text)
 {
-	this->WriteServ("NOTICE " + (this->registered == REG_ALL ? this->nick : "*") + " :" + text);
+	this->WriteServ(command + (this->registered & REG_NICK ? " " + this->nick : " *") + " " + text);
 }
 
 void User::WriteNumeric(unsigned int numeric, const char* text, ...)
@@ -885,7 +885,7 @@ void User::WriteNumeric(unsigned int numeric, const std::string &text)
 		return;
 
 	const std::string message = InspIRCd::Format(":%s %03u %s %s", ServerInstance->Config->ServerName.c_str(),
-		numeric, !this->nick.empty() ? this->nick.c_str() : "*", text.c_str());
+		numeric, this->registered & REG_NICK ? this->nick.c_str() : "*", text.c_str());
 	this->Write(message);
 }
 


### PR DESCRIPTION
- Introduce WriteCommand which sends \* when the user has not registered.
- Switch a ton of code to use WriteCommand instead of WriteServ.
- Convert WriteNotice to be a wrapper around WriteCommand.
- Only send \* when NICK has not been sent instead of before registration.
