### PR TITLE
Convert irc::stringjoiner to be a method instead of a class.

### DIFF
--- a/include/hashcomp.h
+++ b/include/hashcomp.h
@@ -168,31 +168,11 @@ namespace irc
 	 */
 	typedef std::basic_string<char, irc_char_traits, std::allocator<char> > string;
 
-	/** irc::stringjoiner joins string lists into a string, using
-	 * space as the separator.
-	 * This class can join a vector of std::string.
+	/** Joins the contents of a vector to a string.
+	 * @param sequence Zero or more items to seperate.
+	 * @separator The character to place between the items.
 	 */
-	class CoreExport stringjoiner
-	{
-	 private:
-
-		/** Output string
-		 */
-		std::string joined;
-
-	 public:
-
-		/** Join all elements of a vector, in the resulting string
-		 * each element will be seperated by a single space character.
-		 * @param sequence Zero or more items to seperate
-		 */
-		stringjoiner(const std::vector<std::string>& sequence);
-
-		/** Get the joined sequence
-		 * @return A constant reference to the joined string
-		 */
-		const std::string& GetJoined() const { return joined; }
-	};
+   	std::string CoreExport stringjoiner(const std::vector<std::string>& sequence, char separator = ' ');
 
 	/** irc::modestacker stacks mode sequences into a list.
 	 * It can then reproduce this list, clamped to a maximum of MAXMODES

--- a/src/hashcomp.cpp
+++ b/src/hashcomp.cpp
@@ -414,14 +414,16 @@ int irc::modestacker::GetStackedLine(std::vector<std::string> &result, int max_l
 	return n;
 }
 
-irc::stringjoiner::stringjoiner(const std::vector<std::string>& sequence)
+std::string irc::stringjoiner(const std::vector<std::string>& sequence, char separator)
 {
-	if (sequence.empty())
-		return; // nothing to do here
-
+	std::string buffer;
 	for (std::vector<std::string>::const_iterator i = sequence.begin(); i != sequence.end(); ++i)
-		joined.append(*i).push_back(' ');
-	joined.erase(joined.end()-1);
+	{
+		if (!buffer.empty())
+			buffer += separator;
+		buffer += *i;
+	}
+	return buffer;
 }
 
 irc::portparser::portparser(const std::string &source, bool allow_overlapped)

--- a/src/modules/m_cap.cpp
+++ b/src/modules/m_cap.cpp
@@ -73,13 +73,13 @@ class CommandCAP : public Command
 
 			if (Data.ack.size() > 0)
 			{
-				std::string AckResult = irc::stringjoiner(Data.ack).GetJoined();
+				std::string AckResult = irc::stringjoiner(Data.ack);
 				user->WriteServ("CAP %s ACK :%s", user->nick.c_str(), AckResult.c_str());
 			}
 
 			if (Data.wanted.size() > 0)
 			{
-				std::string NakResult = irc::stringjoiner(Data.wanted).GetJoined();
+				std::string NakResult = irc::stringjoiner(Data.wanted);
 				user->WriteServ("CAP %s NAK :%s", user->nick.c_str(), NakResult.c_str());
 			}
 		}
@@ -94,7 +94,7 @@ class CommandCAP : public Command
 			reghold.set(user, 1);
 			Data.Send();
 
-			std::string Result = irc::stringjoiner(Data.wanted).GetJoined();
+			std::string Result = irc::stringjoiner(Data.wanted);
 			user->WriteServ("CAP %s %s :%s", user->nick.c_str(), subcommand.c_str(), Result.c_str());
 		}
 		else if (subcommand == "CLEAR")
@@ -104,7 +104,7 @@ class CommandCAP : public Command
 			reghold.set(user, 1);
 			Data.Send();
 
-			std::string Result = irc::stringjoiner(Data.ack).GetJoined();
+			std::string Result = irc::stringjoiner(Data.ack);
 			user->WriteServ("CAP %s ACK :%s", user->nick.c_str(), Result.c_str());
 		}
 		else

--- a/src/modules/m_operlog.cpp
+++ b/src/modules/m_operlog.cpp
@@ -52,8 +52,7 @@ class ModuleOperLog : public Module
 			Command* thiscommand = ServerInstance->Parser->GetHandler(command);
 			if ((thiscommand) && (thiscommand->flags_needed == 'o'))
 			{
-				std::string line = irc::stringjoiner(parameters).GetJoined();
-				std::string msg = "[" + user->GetFullRealHost() + "] " + command + " " + line;
+				std::string msg = "[" + user->GetFullRealHost() + "] " + command + " " + irc::stringjoiner(parameters);
 				ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "OPERLOG: " + msg);
 				if (tosnomask)
 					ServerInstance->SNO->WriteGlobalSno('r', msg);

--- a/src/modules/m_spanningtree/capab.cpp
+++ b/src/modules/m_spanningtree/capab.cpp
@@ -70,8 +70,7 @@ static std::string BuildModeList(ModeType type)
 		}
 	}
 	sort(modes.begin(), modes.end());
-	irc::stringjoiner line(modes);
-	return line.GetJoined();
+	return irc::stringjoiner(modes);
 }
 
 void TreeSocket::SendCapabilities(int phase)

--- a/src/modules/m_spanningtree/treesocket2.cpp
+++ b/src/modules/m_spanningtree/treesocket2.cpp
@@ -313,9 +313,8 @@ void TreeSocket::ProcessConnectedLine(std::string& prefix, std::string& command,
 				return;
 			}
 
-			irc::stringjoiner pmlist(params);
 			ServerInstance->Logs->Log(MODNAME, LOG_SPARSE, "Unrecognised S2S command :%s %s %s",
-				who->uuid.c_str(), command.c_str(), pmlist.GetJoined().c_str());
+				who->uuid.c_str(), command.c_str(), irc::stringjoiner(params).c_str());
 			SendError("Unrecognised command '" + command + "' -- possibly loaded mismatched modules");
 			return;
 		}
@@ -324,9 +323,8 @@ void TreeSocket::ProcessConnectedLine(std::string& prefix, std::string& command,
 
 	if (params.size() < cmdbase->min_params)
 	{
-		irc::stringjoiner pmlist(params);
 		ServerInstance->Logs->Log(MODNAME, LOG_SPARSE, "Insufficient parameters for S2S command :%s %s %s",
-			who->uuid.c_str(), command.c_str(), pmlist.GetJoined().c_str());
+			who->uuid.c_str(), command.c_str(), irc::stringjoiner(params).c_str());
 		SendError("Insufficient parameters for command '" + command + "'");
 		return;
 	}
@@ -347,9 +345,8 @@ void TreeSocket::ProcessConnectedLine(std::string& prefix, std::string& command,
 
 	if (res == CMD_INVALID)
 	{
-		irc::stringjoiner pmlist(params);
 		ServerInstance->Logs->Log(MODNAME, LOG_SPARSE, "Error handling S2S command :%s %s %s",
-			who->uuid.c_str(), command.c_str(), pmlist.GetJoined().c_str());
+			who->uuid.c_str(), command.c_str(), irc::stringjoiner(params).c_str());
 		SendError("Error handling '" + command + "' -- possibly loaded mismatched modules");
 	}
 	else if (res == CMD_SUCCESS)


### PR DESCRIPTION
Why did anyone think that this being a class was a good idea?
