### PR TITLE
Move WriteNeighboursWithExt from m_ircv3 to the User class.

### DIFF
--- a/include/users.h
+++ b/include/users.h
@@ -567,6 +567,12 @@ class CoreExport User : public Extensible
 	 */
 	void WriteCommonQuit(const std::string &normal_text, const std::string &oper_text);
 
+	/** Write a line to the neighbours of this user who have a specific extension set.
+	 * @param line The line of text to send to the user.
+	 * @param ext The extension to check neighbours of this user for.
+	 */
+	void WriteNeighboursWithExt(const std::string& line, const LocalIntExt& ext);
+
 	/** Dump text to a user target, splitting it appropriately to fit
 	 * @param linePrefix text to prefix each complete line with
 	 * @param textStream the text to send to the user


### PR DESCRIPTION
As discussed in #687 this moves WriteNeighboursWithExt to the User class so it can be used by other modules.
