### PR TITLE
Fix various problems detected by Clang 3.4.

### DIFF
--- a/src/cidr.cpp
+++ b/src/cidr.cpp
@@ -23,25 +23,7 @@
 
 #include "inspircd.h"
 
-/* Used when comparing CIDR masks for the modulus bits left over.
- * A lot of ircd's seem to do this:
- * ((-1) << (8 - (mask % 8)))
- * But imho, it sucks in comparison to a nice neat lookup table.
- */
-const unsigned char inverted_bits[8] = {	0x00, /* 00000000 - 0 bits - never actually used */
-				0x80, /* 10000000 - 1 bits */
-				0xC0, /* 11000000 - 2 bits */
-				0xE0, /* 11100000 - 3 bits */
-				0xF0, /* 11110000 - 4 bits */
-				0xF8, /* 11111000 - 5 bits */
-				0xFC, /* 11111100 - 6 bits */
-				0xFE  /* 11111110 - 7 bits */
-};
-
-
 /* Match CIDR strings, e.g. 127.0.0.1 to 127.0.0.0/8 or 3ffe:1:5:6::8 to 3ffe:1::0/32
- * If you have a lot of hosts to match, youre probably better off building your mask once
- * and then using the lower level MatchCIDRBits directly.
  *
  * This will also attempt to match any leading usernames or nicknames on the mask, using
  * match(), when match_with_username is true.

--- a/src/commands/cmd_stats.cpp
+++ b/src/commands/cmd_stats.cpp
@@ -217,7 +217,7 @@ void CommandStats::DoStats(char statschar, User* user, string_list &results)
 			results.push_back(sn+" 249 "+user->nick+" :Channels: "+ConvToStr(ServerInstance->chanlist->size()));
 			results.push_back(sn+" 249 "+user->nick+" :Commands: "+ConvToStr(ServerInstance->Parser->cmdlist.size()));
 
-			if (!ServerInstance->Config->WhoWasGroupSize == 0 && !ServerInstance->Config->WhoWasMaxGroups == 0)
+			if (ServerInstance->Config->WhoWasGroupSize && ServerInstance->Config->WhoWasMaxGroups)
 			{
 				Module* whowas = ServerInstance->Modules->Find("cmd_whowas.so");
 				if (whowas)

--- a/src/inspircd.cpp
+++ b/src/inspircd.cpp
@@ -476,7 +476,7 @@ InspIRCd::InspIRCd(int argc, char** argv) :
 	/* Set the finished argument values */
 	Config->cmdline.nofork = (do_nofork != 0);
 	Config->cmdline.forcedebug = (do_debug != 0);
-	Config->cmdline.writelog = (!do_nolog != 0);
+	Config->cmdline.writelog = !do_nolog;
 	Config->cmdline.TestSuite = (do_testsuite != 0);
 
 	if (do_debug)

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -217,8 +217,6 @@ bool irc::sockets::satoap(const irc::sockets::sockaddrs& sa, std::string& addr, 
 	return !addr.empty();
 }
 
-static const char all_zero[16] = {0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0 };
-
 std::string irc::sockets::sockaddrs::str() const
 {
 	char buffer[MAXBUF];


### PR DESCRIPTION
- cidr.cpp: remove inverted_bits; unused since 9fad3ecb9215a0034bf407f192926b04cb5efaed.
- cmd_stats.cpp: remove needless inversion and comparison to 0.
- inspircd.cpp: remove needless comparison to 0.
- socket.cpp: remove all_zero; unused since 03a1bf15b1da7643b237c22db1a478916a976ccf.
