### PR TITLE
Modify m_helpop to be compatible with other server implementations.

### DIFF
--- a/docs/conf/helpop-full.conf.example
+++ b/docs/conf/helpop-full.conf.example
@@ -17,8 +17,7 @@ parameter for this command.
 /HELPOP SNOMASKS -      To see a list of oper snotice masks
 /HELPOP EXTBANS  -      To see a list of extended bans">
 
-<helpop key="nohelp" value="There is no help for the topic
-you searched for. Please try again.">
+<helpop key="nohelp" value="There is no help for the topic you searched for. Please try again.">
 
 #####################
 #   User Commands   #

--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -24,8 +24,7 @@ parameter for this command.
 /HELPOP SNOMASKS -      To see a list of oper snotice masks
 /HELPOP EXTBANS  -      To see a list of extended bans">
 
-<helpop key="nohelp" value="There is no help for the topic
-you searched for. Please try again.">
+<helpop key="nohelp" value="There is no help for the topic you searched for. Please try again.">
 
 <helpop key="cuser" value="User Commands
 -------------


### PR DESCRIPTION
We now use the same numerics as the IRCD-Hybrid family for help instead of incorrectly using the numerics used by UnrealIRCd.
