### PR TITLE
Give m_connectban a configurable ban message

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -562,7 +562,11 @@
 # IP addresses (32 and 128 bits) into CIDR masks, to allow for throttling
 # over whole ISPs/blocks of IPs, which may be needed to prevent attacks.
 #
-#<connectban threshold="10" duration="10m" ipv4cidr="32" ipv6cidr="128">
+# A custom ban message may optionally be specified.
+#
+# <connectban threshold="10" duration="10m" ipv4cidr="32" ipv6cidr="128"
+#  banmessage="Your IP range has been attempting to connect too many times in too short a duration. Wait a while, and you will be able to connect.">
+#
 # This allows for 10 connections in an hour with a 10 minute ban if that is exceeded.
 #
 #<module name="m_connectban.so">

--- a/src/modules/m_connectban.cpp
+++ b/src/modules/m_connectban.cpp
@@ -27,6 +27,7 @@ class ModuleConnectBan : public Module
 	unsigned int banduration;
 	unsigned int ipv4_cidr;
 	unsigned int ipv6_cidr;
+	std::string banmessage;
 
  public:
 	Version GetVersion() CXX11_OVERRIDE
@@ -42,6 +43,7 @@ class ModuleConnectBan : public Module
 		ipv6_cidr = tag->getInt("ipv6cidr", 128, 1, 128);
 		threshold = tag->getInt("threshold", 10, 1);
 		banduration = tag->getDuration("duration", 10*60, 1);
+		banmessage = tag->getString("banmessage","Your IP range has been attempting to connect too many times in too short a duration. Wait a while, and you will be able to connect.");
 	}
 
 	void OnSetUserIP(LocalUser* u) CXX11_OVERRIDE
@@ -72,7 +74,7 @@ class ModuleConnectBan : public Module
 			if (i->second >= threshold)
 			{
 				// Create zline for set duration.
-				ZLine* zl = new ZLine(ServerInstance->Time(), banduration, ServerInstance->Config->ServerName, "Your IP range has been attempting to connect too many times in too short a duration. Wait a while, and you will be able to connect.", mask.str());
+				ZLine* zl = new ZLine(ServerInstance->Time(), banduration, ServerInstance->Config->ServerName,banmessage, mask.str());
 				if (!ServerInstance->XLines->AddLine(zl, NULL))
 				{
 					delete zl;


### PR DESCRIPTION
m_connectban's default ban message accounts for at least 90% of Canternet's support queries.
Being able to customize it so that people don't immediately freak when they see "Z-line" would be helpful.
