### PR TITLE
Fix build problem on Solaris

### DIFF
--- a/make/utilities.pm
+++ b/make/utilities.pm
@@ -86,7 +86,7 @@ sub make_rpath($;$)
 			print "Adding extra library path to \e[1;32m$module\e[0m ... \e[1;32m$libpath\e[0m\n";
 			$already_added{$libpath} = 1;
 		}
-		$output .= "-Wl,--rpath -Wl,$libpath -L$libpath " unless defined $main::opt_disablerpath;
+		$output .= "-Wl,-rpath -Wl,$libpath -L$libpath " unless defined $main::opt_disablerpath;
 		$data =~ s/-L(\S+)//;
 	}
 	return $output;
@@ -432,7 +432,6 @@ sub translate_functions($$)
 		while ($line =~ /rpath\("(.+?)"\)/)
 		{
 			my $replace = make_rpath($1,$module);
-			$replace = "" if ($^O =~ /darwin/i);
 			$line =~ s/rpath\("(.+?)"\)/$replace/;
 		}
 	};


### PR DESCRIPTION
-rpath only takes one dash
Fixes the Solaris build \o/

``````
<fraggeln> SaberUK: http://m.theo.nu/jenkins/job/InspIRCd-2.0/435/label=solaris/console <--
<fraggeln> do you have any clue on why?
<@Shutter> Hmm. Where did that extra - come from.
<fraggeln> Shutter: no idea :)
[...]
<fraggeln> Shutter: sub make_rpath($;$) <-- in make/utilities.pm
<fraggeln> thats where that extra - is```
``````
