### PR TITLE
Make the maximum hostname length configurable in the config.

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -789,6 +789,9 @@
         # maxident: Maximum length of a ident/username.
         maxident="11"
 
+        # maxhost: Maximum length of a hostname.
+        maxhost="255"
+
         # maxquit: Maximum length of a quit message.
         maxquit="255"
 

--- a/include/configreader.h
+++ b/include/configreader.h
@@ -114,6 +114,8 @@ class ServerLimits
 	size_t MaxAway;
 	/** Maximum line length */
 	size_t MaxLine;
+	/** Maximum hostname length */
+	size_t MaxHost;
 
 	/** Creating the class initialises it to the defaults
 	 * as in 1.1's ./configure script. Reading other values
@@ -121,7 +123,7 @@ class ServerLimits
 	 */
 	ServerLimits() : NickMax(31), ChanMax(64), MaxModes(20), IdentMax(12),
 		MaxQuit(255), MaxTopic(307), MaxKick(255), MaxGecos(128), MaxAway(200),
-		MaxLine(512) { }
+		MaxLine(512), MaxHost(255) { }
 };
 
 struct CommandLineConf

--- a/src/commands/cmd_hostname_lookup.cpp
+++ b/src/commands/cmd_hostname_lookup.cpp
@@ -133,14 +133,14 @@ class UserResolver : public DNS::Request
 					bound_user->WriteNotice("*** There was an internal error resolving your host, using your IP address (" + bound_user->GetIPString() + ") instead.");
 					return;
 				}
-				else if (hostname->length() < 65)
+				else if (hostname->length() <= ServerInstance->Config->Limits.MaxHost)
 				{
 					/* Hostnames starting with : are not a good thing (tm) */
 					if ((*hostname)[0] == ':')
 						hostname->insert(0, "0");
 
 					bound_user->WriteNotice("*** Found your hostname (" + *hostname + (r->cached ? ") -- cached" : ")"));
-					bound_user->host.assign(*hostname, 0, 64);
+					bound_user->host.assign(*hostname, 0, ServerInstance->Config->Limits.MaxHost);
 					bound_user->dhost = bound_user->host;
 
 					/* Invalidate cache */
@@ -148,7 +148,7 @@ class UserResolver : public DNS::Request
 				}
 				else
 				{
-					bound_user->WriteNotice("*** Your hostname is longer than the maximum of 64 characters, using your IP address (" + bound_user->GetIPString() + ") instead.");
+					bound_user->WriteNotice("*** Your hostname is longer than the maximum of " + ConvToStr(ServerInstance->Config->Limits.MaxHost) + " characters, using your IP address (" + bound_user->GetIPString() + ") instead.");
 				}
 
 				ph->unset(bound_user);

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -411,6 +411,7 @@ void ServerConfig::Fill()
 	Limits.ChanMax = ConfValue("limits")->getInt("maxchan", 64);
 	Limits.MaxModes = ConfValue("limits")->getInt("maxmodes", 20);
 	Limits.IdentMax = ConfValue("limits")->getInt("maxident", 11);
+	Limits.MaxHost = ConfValue("limits")->getInt("maxhost", 255);
 	Limits.MaxQuit = ConfValue("limits")->getInt("maxquit", 255);
 	Limits.MaxTopic = ConfValue("limits")->getInt("maxtopic", 307);
 	Limits.MaxKick = ConfValue("limits")->getInt("maxkick", 255);

--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -89,7 +89,7 @@ class CommandWebirc : public Command
 						realhost.set(user, user->host);
 						realip.set(user, user->GetIPString());
 
-						bool host_ok = (parameters[2].length() < 64);
+						bool host_ok = (parameters[2].length() <= ServerInstance->Config->Limits.MaxHost);
 						const std::string& newhost = (host_ok ? parameters[2] : parameters[3]);
 
 						if (notify)
@@ -140,7 +140,7 @@ class CGIResolver : public DNS::Request
 				return;
 
 			const DNS::ResourceRecord &ans_record = r->answers[0];
-			if (ans_record.rdata.empty() || ans_record.rdata.length() > 64)
+			if (ans_record.rdata.empty() || ans_record.rdata.length() > ServerInstance->Config->Limits.MaxHost)
 				return;
 
 			if (notify)
@@ -394,7 +394,7 @@ public:
 
 	bool IsValidHost(const std::string &host)
 	{
-		if(!host.size() || host.size() > 64)
+		if(!host.size() || host.size() > ServerInstance->Config->Limits.MaxHost)
 			return false;
 
 		for(unsigned int i = 0; i < host.size(); i++)

--- a/src/modules/m_chghost.cpp
+++ b/src/modules/m_chghost.cpp
@@ -39,7 +39,7 @@ class CommandChghost : public Command
 	{
 		const char* x = parameters[1].c_str();
 
-		if (parameters[1].length() > 63)
+		if (parameters[1].length() > ServerInstance->Config->Limits.MaxHost)
 		{
 			user->WriteNotice("*** CHGHOST: Host too long");
 			return CMD_FAILURE;

--- a/src/modules/m_sethost.cpp
+++ b/src/modules/m_sethost.cpp
@@ -46,7 +46,7 @@ class CommandSethost : public Command
 			}
 		}
 
-		if (len > 64)
+		if (len > ServerInstance->Config->Limits.MaxHost)
 		{
 			user->WriteNotice("*** SETHOST: Host too long");
 			return CMD_FAILURE;

--- a/src/modules/m_spanningtree/capab.cpp
+++ b/src/modules/m_spanningtree/capab.cpp
@@ -149,6 +149,7 @@ void TreeSocket::SendCapabilities(int phase)
 			" MAXKICK="+ConvToStr(ServerInstance->Config->Limits.MaxKick)+
 			" MAXGECOS="+ConvToStr(ServerInstance->Config->Limits.MaxGecos)+
 			" MAXAWAY="+ConvToStr(ServerInstance->Config->Limits.MaxAway)+
+			" MAXHOST="+ConvToStr(ServerInstance->Config->Limits.MaxHost)+
 			extra+
 			" PREFIX="+ServerInstance->Modes->BuildPrefixes()+
 			" CHANMODES="+ServerInstance->Modes->GiveModeList(MODETYPE_CHANNEL)+

--- a/src/modules/m_spanningtree/utils.cpp
+++ b/src/modules/m_spanningtree/utils.cpp
@@ -301,8 +301,8 @@ void SpanningTreeUtilities::ReadConfiguration()
 		if (L->Name.find('.') == std::string::npos)
 			throw ModuleException("The link name '"+assign(L->Name)+"' is invalid as it must contain at least one '.' character");
 
-		if (L->Name.length() > 64)
-			throw ModuleException("The link name '"+assign(L->Name)+"' is invalid as it is longer than 64 characters");
+		if (L->Name.length() > ServerInstance->Config->Limits.MaxHost)
+			throw ModuleException("The link name '"+assign(L->Name)+"' is invalid as it is longer than " + ConvToStr(ServerInstance->Config->Limits.MaxHost) + " characters");
 
 		if (L->RecvPass.empty())
 			throw ModuleException("Invalid configuration for server '"+assign(L->Name)+"', recvpass not defined");

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -1121,7 +1121,7 @@ bool User::ChangeDisplayedHost(const std::string& shost)
 
 	FOREACH_MOD(OnChangeHost, (this,shost));
 
-	this->dhost.assign(shost, 0, 64);
+	this->dhost.assign(shost, 0, ServerInstance->Config->Limits.MaxHost);
 	this->InvalidateCache();
 
 	if (IS_LOCAL(this))


### PR DESCRIPTION
This replaces an offensive amount of inconsistent magic numbers.
