### PR TITLE
Kill <channels> in favour of (already existing) <connect:maxchans> and (new) <oper:maxchans>.

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -267,8 +267,8 @@
          password="secret"
 
          # maxchans: Maximum number of channels a user in this class
-         # be in at one time. This overrides every other maxchans setting.
-         #maxchans="30"
+         # be in at one time.
+         maxchans="20"
 
          # timeout: How long (in seconds) the server will wait before
          # disconnecting a user if they do not do anything on connect.
@@ -340,8 +340,8 @@
          allow="*"
 
          # maxchans: Maximum number of channels a user in this class
-         # be in at one time. This overrides every other maxchans setting.
-         #maxchans="30"
+         # be in at one time.
+         maxchans="20"
 
          # timeout: How long (in seconds) the server will wait before
          # disconnecting a user if they do not do anything on connect.
@@ -456,16 +456,6 @@
 # Example of an executable file include. Note this will be read on rehash,
 # not when the command is run.
 #<execfiles motd="wget -O - http://www.example.com/motd.txt">
-
-#-#-#-#-#-#-#-#-#-#-#-# MAXIMUM CHANNELS -#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-#                                                                     #
-
-<channels
-          # users: Maximum number of channels a user can be in at once.
-          users="20"
-
-          # opers: Maximum number of channels a oper can be in at once.
-          opers="60">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-# DNS SERVER -#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # If these values are not defined, InspIRCd uses the default DNS resolver

--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -25,13 +25,12 @@
      # ACTIONS:
      #   - users/mass-message: allows opers with this priv to PRIVMSG and NOTICE to a server mask (e.g. NOTICE $*)
      #   - users/samode-usermodes: allows opers with this priv to change the user modes of any other user using /SAMODE
-     #   - channels/high-join-limit: allows opers with this priv to join <channels:opers> total channels instead of <channels:users> total channels.
      # PERMISSIONS:
      #   - users/flood/no-throttle: allows opers with this priv to send commands without being throttled (*NOTE)
      #   - users/flood/increased-buffers: allows opers with this priv to send and receive data without worrying about being disconnected for exceeding limits (*NOTE)
      #
      # *NOTE: These privs are potentially dangerous, as they grant users with them the ability to hammer your server's CPU/RAM as much as they want, essentially.
-     privs="users/auspex channels/auspex servers/auspex users/mass-message channels/high-join-limit users/flood/no-throttle users/flood/increased-buffers"
+     privs="users/auspex channels/auspex servers/auspex users/mass-message users/flood/no-throttle users/flood/increased-buffers"
 
      # usermodes: Oper-only usermodes that opers with this class can use.
      usermodes="*"
@@ -61,6 +60,9 @@
 
     # vhost: host oper gets on oper-up. This is optional.
     vhost="netadmin.omega.org.za"
+
+    # maxchans: Maximum number of channels an oper can be in at once.
+    maxchans="60"
 
     # modes: usermodes besides +o that are set on a oper of this type
     # when they oper up. Used for snomasks and other things.

--- a/include/configreader.h
+++ b/include/configreader.h
@@ -446,14 +446,6 @@ class CoreExport ServerConfig
 	 */
 	OperIndex OperTypes;
 
-	/** Max channels per user
-	 */
-	unsigned int MaxChans;
-
-	/** Oper max channels per user
-	 */
-	unsigned int OperMaxChans;
-
 	/** TS6-like server ID.
 	 * NOTE: 000...999 are usable for InspIRCd servers. This
 	 * makes code simpler. 0AA, 1BB etc with letters are reserved

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -38,8 +38,6 @@ ServerConfig::ServerConfig()
 	NetBufferSize = 10240;
 	SoftLimit = SocketEngine::GetMaxFds();
 	MaxConn = SOMAXCONN;
-	MaxChans = 20;
-	OperMaxChans = 30;
 	c_ipv4_range = 32;
 	c_ipv6_range = 128;
 }
@@ -296,7 +294,7 @@ void ServerConfig::CrossCheckConnectBlocks(ServerConfig* current)
 			me->fakelag = tag->getBool("fakelag", me->fakelag);
 			me->maxlocal = tag->getInt("localmax", me->maxlocal);
 			me->maxglobal = tag->getInt("globalmax", me->maxglobal);
-			me->maxchans = tag->getInt("maxchans", me->maxchans);
+			me->maxchans = tag->getInt("maxchans", me->maxchans, 1, UINT_MAX);
 			me->maxconnwarn = tag->getBool("maxconnwarn", me->maxconnwarn);
 			me->limit = tag->getInt("limit", me->limit);
 			me->resolvehostnames = tag->getBool("resolvehostnames", me->resolvehostnames);
@@ -334,6 +332,8 @@ struct DeprecatedConfig
 
 static const DeprecatedConfig ChangedConfig[] = {
 	{ "bind",        "transport",   "",                 "has been moved to <bind:ssl> as of 2.0" },
+	{ "channels",    "opers",       "",                 "has ben moved to <oper:maxchans> as of 2.2" },
+	{ "channels",    "users",       "",                 "has ben moved to <connect:maxchans> as of 2.2" },
 	{ "die",         "value",       "",                 "you need to reread your config" },
 	{ "gnutls",      "starttls",    "",                 "has been replaced with m_starttls as of 2.2" },
 	{ "link",        "autoconnect", "",                 "2.0+ does not use this attribute - define <autoconnect> tags instead" },
@@ -391,8 +391,6 @@ void ServerConfig::Fill()
 	MaxTargets = security->getInt("maxtargets", 20, 1, 31);
 	DefaultModes = options->getString("defaultmodes", "not");
 	PID = ConfValue("pid")->getString("file");
-	MaxChans = ConfValue("channels")->getInt("users", 20);
-	OperMaxChans = ConfValue("channels")->getInt("opers", 60);
 	c_ipv4_range = ConfValue("cidr")->getInt("ipv4clone", 32);
 	c_ipv6_range = ConfValue("cidr")->getInt("ipv6clone", 128);
 	Limits.NickMax = ConfValue("limits")->getInt("maxnick", 32);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -175,7 +175,7 @@ void ISupportManager::Build()
 	tokens["ELIST"] = "MU";
 	tokens["KICKLEN"] = ConvToStr(ServerInstance->Config->Limits.MaxKick);
 	tokens["MAXBANS"] = "64"; // TODO: make this a config setting.
-	tokens["MAXCHANNELS"] = ConvToStr(ServerInstance->Config->MaxChans);
+	tokens["MAXCHANNELS"] = "20"; // TODO: harvest this from the connect class.
 	tokens["MAXTARGETS"] = ConvToStr(ServerInstance->Config->MaxTargets);
 	tokens["MODES"] = ConvToStr(ServerInstance->Config->Limits.MaxModes);
 	tokens["NETWORK"] = ServerInstance->Config->Network;

--- a/src/users.cpp
+++ b/src/users.cpp
@@ -1290,7 +1290,7 @@ const std::string& FakeUser::GetFullRealHost()
 ConnectClass::ConnectClass(ConfigTag* tag, char t, const std::string& mask)
 	: config(tag), type(t), fakelag(true), name("unnamed"), registration_timeout(0), host(mask),
 	pingtime(0), softsendqmax(0), hardsendqmax(0), recvqmax(0),
-	penaltythreshold(0), commandrate(0), maxlocal(0), maxglobal(0), maxconnwarn(true), maxchans(0),
+	penaltythreshold(0), commandrate(0), maxlocal(0), maxglobal(0), maxconnwarn(true), maxchans(20),
 	limit(0), resolvehostnames(true)
 {
 }


### PR DESCRIPTION
This makes the following changes:
- Removes the `<channels:users>` setting in favour of the _already existing_ `<connect:maxchans>` setting.
- Replaces the `<channels:opers>` setting and the `channels/high-join-limit` oper privilege in favour of specifying a higher join limit in the `<type>` or `<oper>` block.

Side note: I think we should implement an override of On005Numeric which takes a `ConnectClass*` so that we can deal with connect class specific tokens like MAXCHANNELS.
