### PR TITLE
Clean up a bunch of legacy code in the Poll socketengine.

### DIFF
--- a/src/socketengines/socketengine_poll.cpp
+++ b/src/socketengines/socketengine_poll.cpp
@@ -29,17 +29,8 @@
 #include "inspircd.h"
 #include "socketengine.h"
 
-#ifndef _WIN32
-# ifndef __USE_XOPEN
-#  define __USE_XOPEN /* fuck every fucking OS ever made. needed by poll.h to work.*/
-# endif
-# include <poll.h>
-# include <sys/poll.h>
-# include <sys/resource.h>
-#else
-# define struct pollfd WSAPOLLFD
-# define poll WSAPoll
-#endif
+#include <sys/poll.h>
+#include <sys/resource.h>
 
 /** A specialisation of the SocketEngine class, designed to use poll().
  */


### PR DESCRIPTION
This removes some legacy code which should no longer be needed to use poll. It also removes Windows support as we don't use it and it is probably broken anyway.

I have confirmed that this works on OS X (and therefore FreeBSD) and Linux. It should also work on other Unices.
