### PR TITLE
Remove various broken/useless features from the build system.

### DIFF
--- a/configure
+++ b/configure
@@ -101,13 +101,12 @@ our $interactive = !(
 	(defined $opt_use_gnutls)
 );
 
-our $topdir = getcwd();
 our %config = read_configure_cache();
 
 print "Checking for cache from previous configure... ";
 print %config ? "found\n" : "not found\n";
 
-$config{BASE_DIR} = $topdir."/run";
+$config{BASE_DIR} = getcwd()."/run";
 
 if (defined $opt_base_dir) {
 	$config{BASE_DIR} = $opt_base_dir;
@@ -120,7 +119,6 @@ if (defined $opt_system) {
 	$config{CONFIG_DIR} = '/etc/inspircd';
 	$config{MODULE_DIR} = '/usr/lib/inspircd';
 	$config{BINARY_DIR} = '/usr/sbin/';
-	$config{BUILD_DIR} = $topdir."/build";
 	$config{DATA_DIR} = '/var/inspircd';
 	$config{LOG_DIR} = '/var/log/inspircd';
 } else {
@@ -128,7 +126,6 @@ if (defined $opt_system) {
 	$config{CONFIG_DIR} = rel2abs($config{BASE_DIR}."/conf");
 	$config{MODULE_DIR} = rel2abs($config{BASE_DIR}."/modules");
 	$config{BINARY_DIR} = rel2abs($config{BASE_DIR}."/bin");
-	$config{BUILD_DIR} = rel2abs($topdir."/build");
 	$config{DATA_DIR} = rel2abs($config{BASE_DIR}."/data");
 	$config{LOG_DIR} = rel2abs($config{BASE_DIR}."/logs");
 }
@@ -163,8 +160,6 @@ if (defined $opt_use_openssl)
 {
 	$config{USE_OPENSSL} = "y";
 }
-
-$config{STARTSCRIPT} = $^O eq 'darwin' ? 'org.inspircd.plist' : 'inspircd';
 
 $config{CXX} = defined $ENV{CXX} && !system("$ENV{CXX} -v > /dev/null 2>&1") ? $ENV{CXX} : find_compiler();
 if ($config{CXX} eq "") {
@@ -312,7 +307,6 @@ EOW
 	$config{DATA_DIR} = prompt_dir(1, 'In what directory are variable data files to be stored?', $config{DATA_DIR});
 	$config{LOG_DIR} = prompt_dir(1, 'In what directory are log files to be stored?', $config{LOG_DIR});
 	$config{MODULE_DIR} = prompt_dir(1, 'In what directory are the modules to be placed?', $config{MODULE_DIR});
-	$config{BUILD_DIR} = prompt_dir(1, 'In what directory do you want the build to take place?', $config{BUILD_DIR});
 
 	my $chose_hiperf = 0;
 	if ($config{HAS_KQUEUE}) {
@@ -489,13 +483,11 @@ EOF
 		$_ = join '', <FILEHANDLE>;
 		close(FILEHANDLE);
 
-		$config{BUILD_DIR} ||= rel2abs($topdir."/build");
 		$config{COMPILER} = lc $cxx{NAME};
 		$config{SYSTEM} = lc $^O;
 
 		for my $var (qw(
-			CXX COMPILER SYSTEM BASE_DIR CONFIG_DIR MODULE_DIR BINARY_DIR BUILD_DIR DATA_DIR UID
-			STARTSCRIPT SOCKETENGINE
+			CXX COMPILER SYSTEM BASE_DIR CONFIG_DIR MODULE_DIR BINARY_DIR DATA_DIR UID SOCKETENGINE
 		)) {
 			s/\@$var\@/$config{$var}/g;
 		}

--- a/make/calcdep.pl
+++ b/make/calcdep.pl
@@ -239,15 +239,8 @@ sub dep_cpp($$$) {
 sub dep_so($) {
 	my($file) = @_;
 	my $out = find_output $file;
-	my $split = find_output $file, 1;
 
-	if ($ENV{SPLIT_CC}) {
-		dep_cpp $file, $split, 'gen-o';
-		print MAKE "$out: $split\n";
-		print MAKE "\t@\$(SOURCEPATH)/make/unit-cc.pl link-so\$(VERBOSE) \$\@ \$(SOURCEPATH)/src/$file \$>\n";
-	} else {
-		dep_cpp $file, $out, 'gen-so';
-	}
+	dep_cpp $file, $out, 'gen-so';
 	return $out;
 }
 

--- a/make/configure.pm
+++ b/make/configure.pm
@@ -131,7 +131,6 @@ sub cmd_update {
 	print "Updating...\n";
 	%main::config = read_configure_cache();
 	%main::cxx = get_compiler_info($main::config{CXX});
-	$main::topdir = getcwd();
 	main::writefiles();
 	print "Update complete!\n";
 	exit 0;

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -33,7 +33,7 @@
 CXX = @CXX@
 COMPILER = @COMPILER@
 SYSTEM = @SYSTEM@
-BUILDPATH = @BUILD_DIR@
+BUILDPATH ?= $(PWD)/build
 SOCKETENGINE = @SOCKETENGINE@
 CORECXXFLAGS = -fPIC -fvisibility-inlines-hidden -pipe -Iinclude -Wall -Wextra -Wfatal-errors -Wno-unused-parameter -Wshadow
 LDLIBS = -lstdc++
@@ -131,7 +131,7 @@ FOOTER = finishmessage
 CORECXXFLAGS += $(CXXFLAGS)
 
 @DO_EXPORT RUNCC RUNLD CORECXXFLAGS LDLIBS PICLDFLAGS VERBOSE SOCKETENGINE CORELDFLAGS
-@DO_EXPORT SOURCEPATH BUILDPATH PURE_STATIC SPLIT_CC
+@DO_EXPORT SOURCEPATH BUILDPATH PURE_STATIC
 
 # Default target
 TARGET = all
@@ -228,7 +228,10 @@ install: target
 @IFNDEF PURE_STATIC
 	[ $(BUILDPATH)/modules/ -ef $(MODPATH) ] || $(INSTALL) -m $(INSTMODE_LIB) $(BUILDPATH)/modules/*.so $(MODPATH)
 @ENDIF
-	-$(INSTALL) -m $(INSTMODE_BIN) @STARTSCRIPT@ $(BASE) 2>/dev/null
+	-$(INSTALL) -m $(INSTMODE_BIN) inspircd $(BASE) 2>/dev/null
+@IFEQ $(SYSTEM) darwin
+	-$(INSTALL) -m $(INSTMODE_BIN) org.inspircd.plist $(BASE) 2>/dev/null
+@ENDIF
 	-$(INSTALL) -m $(INSTMODE_BIN) tools/genssl $(BINPATH)/inspircd-genssl 2>/dev/null
 	-$(INSTALL) -m $(INSTMODE_LIB) tools/gdbargs $(BASE)/.gdbargs 2>/dev/null
 	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/*.example $(CONPATH)/examples


### PR DESCRIPTION
- Removed support for changing the build directory using configure.
   This can still be set using make BUILDPATH=foo.
- Removed support for SPLIT_CC builds. This is not documented
   anywhere and is quite useless as it doesn't work.
- Remove STARTSCRIPT from configure; always install the perl
   helper.
