### PR TITLE
Move some time duration code to helperfuncs.

### DIFF
--- a/include/command_parse.h
+++ b/include/command_parse.h
@@ -146,30 +146,3 @@ class CoreExport CommandParser
 	 */
 	static std::string TranslateUIDs(const std::vector<TranslateType>& to, const std::vector<std::string>& source, bool prefix_final = false, CommandBase* custom_translator = NULL);
 };
-
-/** A lookup table of values for multiplier characters used by
- * InspIRCd::Duration(). In this lookup table, the indexes for
- * the ascii values 'm' and 'M' have the value '60', the indexes
- * for the ascii values 'D' and 'd' have a value of '86400', etc.
- */
-const int duration_multi[] =
-{
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 86400, 1, 1, 1, 3600,
-	1, 1, 1, 1, 60, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	604800, 1, 31557600, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 86400, 1, 1, 1, 3600, 1, 1, 1, 1, 60,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 604800, 1, 31557600,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-};

--- a/include/inspircd.h
+++ b/include/inspircd.h
@@ -573,6 +573,12 @@ class CoreExport InspIRCd
 	 */
 	static unsigned long Duration(const std::string& str);
 
+	/** Determines whether a std::string contains a valid time duration.
+	 * @param duration The std::string to validate.
+	 * @return True if the std::string is a valid duration; otherwise, false.
+	 */
+	static bool IsValidDuration(const std::string& duration);
+
 	/** Attempt to compare a password to a string from the config file.
 	 * This will be passed to handling modules which will compare the data
 	 * against possible hashed equivalents in the input string.

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -451,7 +451,7 @@ void ConfigTag::CheckRange(const std::string& key, long& res, long def, long min
 long ConfigTag::getDuration(const std::string& key, long def, long min, long max)
 {
 	std::string duration;
-	if (!readString(key, duration))
+	if (!readString(key, duration) || !InspIRCd::IsValidDuration(duration))
 		return def;
 
 	long ret = InspIRCd::Duration(duration);

--- a/src/helperfuncs.cpp
+++ b/src/helperfuncs.cpp
@@ -331,6 +331,33 @@ void InspIRCd::SendWhoisLine(User* user, User* dest, int numeric, const char* fo
 	this->SendWhoisLine(user, dest, numeric, textbuffer);
 }
 
+/** A lookup table of values for multiplier characters used by
+ * InspIRCd::Duration(). In this lookup table, the indexes for
+ * the ascii values 'm' and 'M' have the value '60', the indexes
+ * for the ascii values 'D' and 'd' have a value of '86400', etc.
+ */
+static const int duration_multi[] =
+{
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 86400, 1, 1, 1, 3600,
+	1, 1, 1, 1, 60, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	604800, 1, 31557600, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 86400, 1, 1, 1, 3600, 1, 1, 1, 1, 60,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 604800, 1, 31557600,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+};
+
 /** Refactored by Brain, Jun 2009. Much faster with some clever O(1) array
  * lookups and pointer maths.
  */
@@ -372,6 +399,20 @@ unsigned long InspIRCd::Duration(const std::string &str)
 	}
 	/* Any trailing values built up are treated as raw seconds */
 	return total + subtotal;
+}
+
+bool InspIRCd::IsValidDuration(const std::string& duration)
+{
+	for (std::string::const_iterator i = duration.begin(); i != duration.end(); ++i)
+	{
+		unsigned char c = *i;
+		if (((c >= '0') && (c <= '9')) || (c == 's') || (c == 'S'))
+			continue;
+
+		if (duration_multi[c] == 1)
+			return false;
+	}
+	return true;
 }
 
 const char* InspIRCd::Format(va_list &vaList, const char* formatString)

--- a/src/modules/m_chanhistory.cpp
+++ b/src/modules/m_chanhistory.cpp
@@ -38,20 +38,6 @@ struct HistoryList
 
 class HistoryMode : public ParamMode<HistoryMode, SimpleExtItem<HistoryList> >
 {
-	bool IsValidDuration(const std::string& duration)
-	{
-		for (std::string::const_iterator i = duration.begin(); i != duration.end(); ++i)
-		{
-			unsigned char c = *i;
-			if (((c >= '0') && (c <= '9')) || (c == 's') || (c == 'S'))
-				continue;
-
-			if (duration_multi[c] == 1)
-				return false;
-		}
-		return true;
-	}
-
  public:
 	unsigned int maxlines;
 	HistoryMode(Module* Creator)
@@ -66,7 +52,7 @@ class HistoryMode : public ParamMode<HistoryMode, SimpleExtItem<HistoryList> >
 			return MODEACTION_DENY;
 
 		std::string duration(parameter, colon+1);
-		if ((IS_LOCAL(source)) && ((duration.length() > 10) || (!IsValidDuration(duration))))
+		if ((IS_LOCAL(source)) && ((duration.length() > 10) || (!InspIRCd::IsValidDuration(duration))))
 			return MODEACTION_DENY;
 
 		unsigned int len = ConvToInt(parameter.substr(0, colon));


### PR DESCRIPTION
- Move IsValidDuration from m_chanhistory to helperfuncs.
- Move duration_multi to be a static variable in helperfuncs.
- Check whether the duration is valid in ConfigTag::getDuration.