### PR TITLE
Backport questions from master's genssl tool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.pem
 *.swp
 
 /.config.cache

--- a/make/gnutlscert.pm
+++ b/make/gnutlscert.pm
@@ -34,12 +34,14 @@ sub make_gnutls_cert()
 {
 	open (FH, ">certtool.template");
 	my $timestr = time();
-	my $org = promptstring_s("Please enter the organization name", "My IRC Network");
-	my $unit = promptstring_s("Please enter the unit Name", "Server Admins");
-	my $state = promptstring_s("Please enter your state (two letter code)", "CA");
-	my $country = promptstring_s("Please enter your country", "Oompa Loompa Land");
-	my $commonname = promptstring_s("Please enter the certificate common name (hostname)", "irc.mynetwork.com");
-	my $email = promptstring_s("Please enter a contact email address", "oompa\@loompa.com");
+	my $commonname = promptstring_s('What is the hostname of your server?', 'irc.example.com');
+	my $email = promptstring_s('What email address can you be contacted at?', 'example@example.com');
+	my $unit = promptstring_s('What is the name of your unit?', 'Server Admins');
+	my $org = promptstring_s('What is the name of your organization?', 'Example IRC Network');
+	my $city = promptstring_s('What city are you located in?', 'Example City');
+	my $state = promptstring_s('What state are you located in?', 'Example State');
+	my $country = promptstring_s('What is the ISO 3166-1 code for the country you are located in?', 'XZ');
+	my $days = promptstring_s('How many days do you want your certificate to be valid for?', '365');
 	print FH <<__END__;
 # X.509 Certificate options
 #
@@ -52,13 +54,13 @@ organization = "$org"
 unit = "$unit"
 
 # The locality of the subject.
-# locality =
+locality = "$city"
 
 # The state of the certificate owner.
 state = "$state"
 
 # The country of the subject. Two letter code.
-country = $country
+country = "$country"
 
 # The common name of the certificate owner.
 cn = "$commonname"
@@ -80,7 +82,7 @@ cn = "$commonname"
 serial = $timestr
 
 # In how many days, counting from today, this certificate will expire.
-expiration_days = 700
+expiration_days = $days
 
 # X.509 v3 extensions
 

--- a/make/opensslcert.pm
+++ b/make/opensslcert.pm
@@ -33,13 +33,14 @@ our @EXPORT = qw(make_openssl_cert);
 sub make_openssl_cert()
 {
 	open (FH, ">openssl.template");
-	my $org = promptstring_s("Please enter the organization name", "My IRC Network");
-	my $unit = promptstring_s("Please enter the unit Name", "Server Admins");
-	my $country = promptstring_s("Please enter your country (two letter code)", "US");
-	my $state = promptstring_s("Please enter your state or locality name", "Alaska");
-	my $city = promptstring_s("Please enter your city", "Factory Town");
-	my $email = promptstring_s("Please enter a contact email address", "oompa\@loompa.com");
-	my $commonname = promptstring_s("Please enter the common name (domain name) of the irc server", "example.inspircd.org");
+	my $commonname = promptstring_s('What is the hostname of your server?', 'irc.example.com');
+	my $email = promptstring_s('What email address can you be contacted at?', 'example@example.com');
+	my $unit = promptstring_s('What is the name of your unit?', 'Server Admins');
+	my $org = promptstring_s('What is the name of your organization?', 'Example IRC Network');
+	my $city = promptstring_s('What city are you located in?', 'Example City');
+	my $state = promptstring_s('What state are you located in?', 'Example State');
+	my $country = promptstring_s('What is the ISO 3166-1 code for the country you are located in?', 'XZ');
+	my $time = promptstring_s('How many days do you want your certificate to be valid for?', '365');
 	print FH <<__END__;
 $country
 $state
@@ -50,9 +51,6 @@ $commonname
 $email
 __END__
 close(FH);
-
-my $time = promptstring_s("Please enter the number of days that this certificate is valid for","365");
-
 system("cat openssl.template | openssl req -x509 -nodes -newkey rsa:1024 -keyout key.pem -out cert.pem -days $time 2>/dev/null");
 system("openssl dhparam -out dhparams.pem 1024");
 unlink("openssl.template");


### PR DESCRIPTION
The previous questions were problematic because:
1. It was apparently not clear enough to some users that they should be inputting their own values.
2. The locality and time questions were only asked on OpenSSL.
3. The questions incorrectly asked for the state as a two letter code rather than the country. According to @TheTechman this caused problems for the Erlang SSL libraries which are used by IRCCloud.
