### PR TITLE
Differ database error messages for m_permchannels and m_xline_db

### DIFF
--- a/src/modules/m_permchannels.cpp
+++ b/src/modules/m_permchannels.cpp
@@ -66,8 +66,8 @@ static bool WriteDatabase(PermChannel& permchanmode, Module* mod, bool save_list
 	std::ofstream stream(permchannelsnewconf.c_str());
 	if (!stream.is_open())
 	{
-		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Cannot create database! %s (%d)", strerror(errno), errno);
-		ServerInstance->SNO->WriteToSnoMask('a', "database: cannot create new db: %s (%d)", strerror(errno), errno);
+		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Cannot create permchan database \"%s\"! %s (%d)", permchannelsnewconf.c_str(), strerror(errno), errno);
+		ServerInstance->SNO->WriteToSnoMask('a', "database: cannot create new permchan db \"%s\": %s (%d)", permchannelsnewconf.c_str(), strerror(errno), errno);
 		return false;
 	}
 
@@ -137,8 +137,8 @@ static bool WriteDatabase(PermChannel& permchanmode, Module* mod, bool save_list
 
 	if (stream.fail())
 	{
-		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Cannot write to new database! %s (%d)", strerror(errno), errno);
-		ServerInstance->SNO->WriteToSnoMask('a', "database: cannot write to new db: %s (%d)", strerror(errno), errno);
+		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Cannot write to new permchan database \"%s\"! %s (%d)", permchannelsnewconf.c_str(), strerror(errno), errno);
+		ServerInstance->SNO->WriteToSnoMask('a', "database: cannot write to new permchan db \"%s\": %s (%d)", permchannelsnewconf.c_str(), strerror(errno), errno);
 		return false;
 	}
 	stream.close();
@@ -146,16 +146,16 @@ static bool WriteDatabase(PermChannel& permchanmode, Module* mod, bool save_list
 #ifdef _WIN32
 	if (remove(permchannelsconf.c_str()))
 	{
-		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Cannot remove old database! %s (%d)", strerror(errno), errno);
-		ServerInstance->SNO->WriteToSnoMask('a', "database: cannot remove old database: %s (%d)", strerror(errno), errno);
+		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Cannot remove old permchan database \"%s\"! %s (%d)", permchannelsnewconf.c_str(), strerror(errno), errno);
+		ServerInstance->SNO->WriteToSnoMask('a', "database: cannot remove old permchan database \"%s\": %s (%d)", permchannelsnewconf.c_str(), strerror(errno), errno);
 		return false;
 	}
 #endif
 	// Use rename to move temporary to new db - this is guarenteed not to fuck up, even in case of a crash.
 	if (rename(permchannelsnewconf.c_str(), permchannelsconf.c_str()) < 0)
 	{
-		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Cannot move new to old database! %s (%d)", strerror(errno), errno);
-		ServerInstance->SNO->WriteToSnoMask('a', "database: cannot replace old with new db: %s (%d)", strerror(errno), errno);
+		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Cannot move new permchan database to old permchan database \"%s\"! %s (%d)", permchannelsnewconf.c_str(), strerror(errno), errno);
+		ServerInstance->SNO->WriteToSnoMask('a', "database: cannot replace old permchan db with new permchan db \"%s\": %s (%d)", permchannelsnewconf.c_str(), strerror(errno), errno);
 		return false;
 	}
 

--- a/src/modules/m_xline_db.cpp
+++ b/src/modules/m_xline_db.cpp
@@ -91,8 +91,8 @@ class ModuleXLineDB : public Module
 		std::ofstream stream(xlinenewdbpath.c_str());
 		if (!stream.is_open())
 		{
-			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot create database! %s (%d)", strerror(errno), errno);
-			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot create new db: %s (%d)", strerror(errno), errno);
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot create xline database \"%s\"! %s (%d)", xlinenewdbpath.c_str(), strerror(errno), errno);
+			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot create new xline db \"%s\": %s (%d)", xlinenewdbpath.c_str(), strerror(errno), errno);
 			return false;
 		}
 
@@ -128,8 +128,8 @@ class ModuleXLineDB : public Module
 
 		if (stream.fail())
 		{
-			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot write to new database! %s (%d)", strerror(errno), errno);
-			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot write to new db: %s (%d)", strerror(errno), errno);
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot write to new xline database \"%s\"! %s (%d)", xlinenewdbpath.c_str(), strerror(errno), errno);
+			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot write to new xline db \"%s\": %s (%d)", xlinenewdbpath.c_str(), strerror(errno), errno);
 			return false;
 		}
 		stream.close();
@@ -137,16 +137,16 @@ class ModuleXLineDB : public Module
 #ifdef _WIN32
 		if (remove(xlinedbpath.c_str()))
 		{
-			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot remove old database! %s (%d)", strerror(errno), errno);
-			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot remove old database: %s (%d)", strerror(errno), errno);
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot remove old xline database \"%s\"! %s (%d)", xlinenewdbpath.c_str(), strerror(errno), errno);
+			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot remove old xline database \"%s\": %s (%d)", xlinenewdbpath.c_str(), strerror(errno), errno);
 			return false;
 		}
 #endif
 		// Use rename to move temporary to new db - this is guarenteed not to fuck up, even in case of a crash.
 		if (rename(xlinenewdbpath.c_str(), xlinedbpath.c_str()) < 0)
 		{
-			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot move new to old database! %s (%d)", strerror(errno), errno);
-			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot replace old with new db: %s (%d)", strerror(errno), errno);
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot move new xline database to old xline database \"%s\"! %s (%d)", xlinenewdbpath.c_str(), strerror(errno), errno);
+			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot replace old xline db with new xline db \"%s\": %s (%d)", xlinenewdbpath.c_str(), strerror(errno), errno);
 			return false;
 		}
 
@@ -162,8 +162,8 @@ class ModuleXLineDB : public Module
 		std::ifstream stream(xlinedbpath.c_str());
 		if (!stream.is_open())
 		{
-			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot read database! %s (%d)", strerror(errno), errno);
-			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot read db: %s (%d)", strerror(errno), errno);
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Cannot read xline database \"%s\"! %s (%d)", xlinedbpath.c_str(), strerror(errno), errno);
+			ServerInstance->SNO->WriteToSnoMask('a', "database: cannot read xline db \"%s\": %s (%d)", xlinedbpath.c_str(), strerror(errno), errno);
 			return false;
 		}
 


### PR DESCRIPTION
m_permchannels and m_xline_db both have the same error messages as well as not
informing the server operator what file is at fault for the error. This makes it
hard to find which module is causing the error and what file the module is referring
to. The new messages explain which database is trying to be written and the path
used to write the file.

These messages may need editing. Let me know of any changes that need to be done! :D
