### PR TITLE
Add support for generating DANE TLSA records to genssl.

### DIFF
--- a/tools/genssl
+++ b/tools/genssl
@@ -85,6 +85,9 @@ my $state = prompt('What state are you located in?', 'Example State');
 my $country = prompt('What is the ISO 3166-1 code for the country you are located in?', 'XZ');
 my $days = prompt('How many days do you want your certificate to be valid for?', '365');
 
+# Contains the SSL certificate in DER form.
+my $dercert;
+
 # Contains the exit code of openssl/gnutls-certtool.
 my $status = 0;
 
@@ -113,6 +116,7 @@ __GNUTLS_END__
 	$status ||= system "$certtool --generate-privkey --outfile key.pem";
 	$status ||= system "$certtool --generate-self-signed --load-privkey key.pem --outfile cert.pem --template $tmp";
 	$status ||= system "$certtool --generate-dh-params --bits 2048 --outfile dhparams.pem";
+	$dercert = `$certtool --certificate-info --infile cert.pem --outder` unless $status;
 } elsif ($tool eq 'openssl') {
 	my $tmp = new File::Temp();
 	print $tmp <<__OPENSSL_END__;
@@ -127,9 +131,17 @@ __OPENSSL_END__
 	close($tmp);
 	$status ||= system "cat $tmp | openssl req -x509 -nodes -newkey rsa:2048 -keyout key.pem -out cert.pem -days $days 2>/dev/null";
 	$status ||= system 'openssl dhparam -out dhparams.pem 2048';
+	$dercert = `openssl x509 -in cert.pem -outform DER` unless $status;
 }
 
 if ($status) {
 	print STDERR "SSL generation failed: $tool exited with a non-zero status!\n";
 	exit 1;
+}
+
+if (defined $dercert && eval 'use Digest::SHA; 1') {
+	my $hash = Digest::SHA->new(256);
+	$hash->add($dercert);
+	print "Add this TLSA record to your domain for DANE support:\n";
+	print "_6697._tcp." . $common_name . " TLSA 3 0 1 " . $hash->hexdigest . "\n";
 }


### PR DESCRIPTION
This is based on the information provided at http://ahf.me/articles/2013/09/14/enhancing-ssl-security-for-irc-dane-support/. I can sadly not test this due to my domain registrar not supporting DNSSEC/TLSA but it should be correct according to this post. If anyone else has a domain registrar who can test this it would be appreciated if you could.
