### PR TITLE
Replace deprecated entry in launchd config with the modern equivalent.

### DIFF
--- a/make/template/org.inspircd.plist
+++ b/make/template/org.inspircd.plist
@@ -4,14 +4,14 @@
 <dict>
 	<key>Iterations</key>
 	<integer>3</integer>
+	<key>KeepAlive</key>
+	<true/>
 	<key>Label</key>
 	<string>org.inspircd</string>
 	<key>LowPriorityIO</key>
 	<true/>
 	<key>Nice</key>
 	<integer>1</integer>
-	<key>OnDemand</key>
-	<false/>
 	<key>Program</key>
 	<string>@BINARY_DIR@/inspircd</string>
 	<key>ProgramArguments</key>


### PR DESCRIPTION
From `man launchd`:

> This key was used in Mac OS X 10.4 to control whether a job was kept alive or not. The default was true.  This key has been deprecated and replaced in Mac OS X 10.5 and later with the more powerful KeepAlive option.

We require OS X 10.6 minimum even on the 2.0 branch so changing this should not be an issue.
