### PR TITLE
Update server.cpp

### DIFF
--- a/src/modules/m_spanningtree/server.cpp
+++ b/src/modules/m_spanningtree/server.cpp
@@ -176,7 +176,7 @@ bool TreeSocket::Outbound_Reply_Server(parameterlist &params)
 		return true;
 	}
 
-	this->SendError("Invalid credentials (check the other server's log (or set umode +s +Ll) for details)");
+	this->SendError("Mismatched server name or password (check the other server's snomask output for details - e.g. umode +s +Ll)");
 	ServerInstance->SNO->WriteToSnoMask('l',"Server connection from \2"+sname+"\2 denied, invalid link credentials");
 	return false;
 }


### PR DESCRIPTION
Rewrote "invalid credentials" error message to remove confusion regarding "server snomask", which some users interpreted as "I must make sure the snomask on each server is identical" (which makes no sense), when really the intention is basically "look at the logs on the other server".
