### PR TITLE
Set SSL options to sane default and enfore server cipher preferences

### DIFF
--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -107,6 +107,9 @@ namespace OpenSSL
 		Context(SSL_CTX* context)
 			: ctx(context)
 		{
+			/** sane default options for OpenSSL see https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
+			* and when choosing a cipher, use the server's preferences instead of the client preferences. */
+			SSL_CTX_set_options(ctx, SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_COMPRESSION | SSL_OP_SINGLE_DH_USE | SSL_OP_SINGLE_ECDH_USE | SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION | SSL_OP_CIPHER_SERVER_PREFERENCE);
 			SSL_CTX_set_mode(ctx, SSL_MODE_ENABLE_PARTIAL_WRITE | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 			SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, OnVerify);
 


### PR DESCRIPTION
This patch adds sane options to the SSL context when using OpenSSL. Most notably, it enforces the selection of cipher server-side, which is necessary to properly use a ciphersuite defined by an administrator.

My understanding is that some options may fail with OpenSSL < 0.9.7, which was published in 2004.

I tested that the build passes, and got the following warning:

```
Checking version of package openssl is >= 0.9.7... Yes (version 1.0.1e)
Locating include directory for package openssl for module m_ssl_openssl.cpp... -DVERSION_OPENSSL="1.0.1e" (version 1.0.1e)
Locating library directory for package openssl for module m_ssl_openssl.cpp... -lssl -lcrypto  (version 1.0.1e)
```
