### PR TITLE
Fix requireaccount

### DIFF
--- a/src/modules/m_services_account.cpp
+++ b/src/modules/m_services_account.cpp
@@ -325,7 +325,7 @@ class ModuleServicesAccount : public Module
 
 	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass)
 	{
-		if (myclass->config->getBool("requireaccount") && !accountname.get(user))
+		if (user->registered & REG_NICKUSER && myclass->config->getBool("requireaccount") && !accountname.get(user))
 			return MOD_RES_DENY;
 		return MOD_RES_PASSTHRU;
 	}


### PR DESCRIPTION
Prevent the user from being booted before he has had a chance to authenticate using SASL.
