### PR TITLE
Fix various small problems with configure.

### DIFF
--- a/make/configure.pm
+++ b/make/configure.pm
@@ -276,7 +276,6 @@ InspIRCd 1.0.x, are also allowed.
                                to select() [not set]
   --disable-kqueue             Do not enable kqueue(), fall back
                                to select() [not set]
-  --disable-ipv6               Do not build IPv6 native InspIRCd [not set]
   --with-cc=[filename]         Use an alternative compiler to
                                build InspIRCd [g++]
   --with-maxbuf=[n]            Change the per message buffer size [512]
@@ -287,17 +286,16 @@ InspIRCd 1.0.x, are also allowed.
                                and library dirs as subdirectories of prefix)
                                [$PWD]
   --config-dir=[directory]     Config file directory for config and SSL certs
-                               [$PWD/conf]
+                               [$PWD/run/conf]
   --log-dir=[directory]	       Log file directory for logs
-			       [$PWD/logs]
-  --data-dir=[directory]       Data directory for variable data, such as the permchannel configuration and the XLine database
-			       [$PWD/data]
+                               [$PWD/run/logs]
+  --data-dir=[directory]       Data directory for variable data, such as the
+                               permchannel configuration and the XLine database
+                               [$PWD/run/data]
   --module-dir=[directory]     Modules directory for loadable modules
-                               [$PWD/modules]
+                               [$PWD/run/modules]
   --binary-dir=[directory]     Binaries directory for core binary
-                               [$PWD/bin]
-  --library-dir=[directory]    Library directory for core libraries
-                               [$PWD/lib]
+                               [$PWD/run/bin]
   --list-extras                Show current status of extra modules
   --enable-extras=[extras]     Enable the specified list of extras
   --disable-extras=[extras]    Disable the specified list of extras

--- a/make/utilities.pm
+++ b/make/utilities.pm
@@ -76,6 +76,7 @@ sub promptstring($$$$$)
 sub make_rpath($;$)
 {
 	my ($executable, $module) = @_;
+	return "" if defined $ENV{DISABLE_RPATH};
 	chomp(my $data = `$executable`);
 	my $output = "";
 	while ($data =~ /-L(\S+)/)
@@ -83,10 +84,10 @@ sub make_rpath($;$)
 		my $libpath = $1;
 		if (!exists $already_added{$libpath})
 		{
-			print "Adding extra library path to \e[1;32m$module\e[0m ... \e[1;32m$libpath\e[0m\n";
+			print "Adding runtime library path to \e[1;32m$module\e[0m ... \e[1;32m$libpath\e[0m\n";
 			$already_added{$libpath} = 1;
 		}
-		$output .= "-Wl,-rpath -Wl,$libpath -L$libpath " unless defined $main::opt_disablerpath;
+		$output .= "-Wl,-rpath -Wl,$libpath -L$libpath ";
 		$data =~ s/-L(\S+)//;
 	}
 	return $output;
@@ -400,6 +401,7 @@ sub translate_functions($$)
 			close TF;
 			my $replace = `perl $tmpfile`;
 			chomp($replace);
+			unlink($tmpfile);
 			$line =~ s/eval\("(.+?)"\)/$replace/;
 		}
 		while ($line =~ /pkgconflibs\("(.+?)","(.+?)","(.+?)"\)/)
@@ -445,7 +447,7 @@ sub translate_functions($$)
 		print "\nMake sure you have pkg-config installed\n";
 		print "\nIn the case of gnutls configuration errors on debian,\n";
 		print "Ubuntu, etc, you should ensure that you have installed\n";
-		print "gnutls-bin as well as gnutls-dev and gnutls.\n";
+		print "gnutls-bin as well as libgnutls-dev and libgnutls.\n";
 		exit;
 	}
 	else


### PR DESCRIPTION
- Fix temporary files not being deleted after use (requested by @attilamolnar).
- Fix the option for disabling rpath.
- Fix the help message:
  - Fix indentation of some help options.
  - Fix default paths not containing 'run'.
  - Remove documentation for --disable-ipv6 (exists but does nothing).
  - Remove documentation for --library-dir (does not exist).
- Fix some minor errors in messages.
