### PR TITLE
[WIP] Rewrite parsing logic in m_httpd.

### DIFF
--- a/include/modules/httpd.h
+++ b/include/modules/httpd.h
@@ -42,6 +42,7 @@ class HTTPHeaders
 	 */
 	void SetHeader(const std::string &name, const std::string &data)
 	{
+		ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "SetHeader: set %s to %s", name.c_str(), data.c_str());
 		headers[name] = data;
 	}
 
@@ -58,6 +59,7 @@ class HTTPHeaders
 	 */
 	void RemoveHeader(const std::string &name)
 	{
+		ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "RemoveHeader: removed %s", name.c_str());
 		headers.erase(name);
 	}
 

--- a/src/modules/m_httpd_config.cpp
+++ b/src/modules/m_httpd_config.cpp
@@ -67,15 +67,13 @@ class ModuleHttpConfig : public Module
 
 	void OnEvent(Event& event) CXX11_OVERRIDE
 	{
-		std::stringstream data("");
-
 		if (event.id == "httpd_url")
 		{
-			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Handling httpd event");
 			HTTPRequest* http = (HTTPRequest*)&event;
-
-			if ((http->GetURI() == "/config") || (http->GetURI() == "/config/"))
+			if (http->GetURI() == "/config")
 			{
+				ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Handling httpd event");
+				std::stringstream data;
 				data << "<html><head><title>InspIRCd Configuration</title></head><body>";
 				data << "<h1>InspIRCd Configuration</h1><p>";
 

--- a/src/modules/m_httpd_stats.cpp
+++ b/src/modules/m_httpd_stats.cpp
@@ -89,15 +89,13 @@ class ModuleHttpStats : public Module
 
 	void OnEvent(Event& event) CXX11_OVERRIDE
 	{
-		std::stringstream data("");
-
 		if (event.id == "httpd_url")
 		{
-			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Handling httpd event");
 			HTTPRequest* http = (HTTPRequest*)&event;
-
-			if ((http->GetURI() == "/stats") || (http->GetURI() == "/stats/"))
+			if (http->GetURI() == "/stats")
 			{
+				ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Handling httpd event");
+				std::stringstream data;
 				data << "<inspircdstats><server><name>" << ServerInstance->Config->ServerName << "</name><gecos>"
 					<< Sanitize(ServerInstance->Config->ServerDesc) << "</gecos><version>"
 					<< Sanitize(ServerInstance->GetVersionString()) << "</version></server>";


### PR DESCRIPTION
Also, various minor improvements:
- Fix SendHeaders when the value of http_version is unusual.
- Strip trailing path seperators before calling module events.
- Only write debug logs in handlers in events they care about.
- Close HTTP sockets when an error happens.
- Use InspIRCd::TimeString instead of the C time functions.
