### PR TITLE
m_spanningtree: Add an optional KEY param to SVSJOIN

### DIFF
--- a/src/modules/m_spanningtree/svsjoin.cpp
+++ b/src/modules/m_spanningtree/svsjoin.cpp
@@ -36,7 +36,11 @@ CmdResult CommandSVSJoin::Handle(User* user, std::vector<std::string>& parameter
 	/* only join if it's local, otherwise just pass it on! */
 	LocalUser* localuser = IS_LOCAL(u);
 	if (localuser)
-		Channel::JoinUser(localuser, parameters[1]);
+	{
+		const std::string& key = parameters.size() == 3 ? parameters[2] : "";
+		const bool override = key.empty() && parameters.size() == 3;
+		Channel::JoinUser(localuser, parameters[1], override, key);
+	}
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
So ajoin on services can join users to keyed channels with SVSJOIN without issuing an invite first.
