### PR TITLE
[2.0] Fix listmodes when the config does not specify a wildcard size entry.

### DIFF
--- a/src/modules/u_listmode.h
+++ b/src/modules/u_listmode.h
@@ -201,13 +201,13 @@ class ListModeBase : public ModeHandler
 			if (limit.mask.size() && limit.limit > 0)
 				chanlimits.push_back(limit);
 		}
-		if (chanlimits.empty())
-		{
-			ListLimit limit;
-			limit.mask = "*";
-			limit.limit = 64;
-			chanlimits.push_back(limit);
-		}
+
+		// Add the default entry. This is inserted last so if the user specifies a
+		// wildcard record in the config it will take precedence over this entry.
+		ListLimit limit;
+		limit.mask = "*";
+		limit.limit = 64;
+		chanlimits.push_back(limit);
 	}
 
 	/** Populate the Implements list with the correct events for a List Mode


### PR DESCRIPTION
Currently, the wildcard entry is only appended if the user does not specify any `<banlist>` tags. This causes the limit to be effectively zero. This is in direct conflict with the documentation in the example configuration file which states:

> If none are specified or no maxbans tag is matched, the banlist size defaults to 64 entries.

This fixes #896 reported by @md-5.
