### PR TITLE
Fix an off-by-one on registration timeout handling.

### DIFF
--- a/src/userprocess.cpp
+++ b/src/userprocess.cpp
@@ -107,7 +107,7 @@ void InspIRCd::DoBackgroundUserStuff()
 				break;
 		}
 
-		if (curr->registered != REG_ALL && (Time() > (curr->age + curr->MyClass->GetRegTimeout())))
+		if (curr->registered != REG_ALL && (Time() >= (curr->age + curr->MyClass->GetRegTimeout())))
 		{
 			/*
 			 * registration timeout -- didnt send USER/NICK/HOST


### PR DESCRIPTION
The use of > instead of >= here added a second onto the configured timeout.

We won't be breaking any existing configuration, because users.h explicitly
increases the limit if it's 0.
