### PR TITLE
Revert "Fix an off-by-one on registration timeout handling."

### DIFF
--- a/src/userprocess.cpp
+++ b/src/userprocess.cpp
@@ -107,7 +107,7 @@ void InspIRCd::DoBackgroundUserStuff()
 				break;
 		}
 
-		if (curr->registered != REG_ALL && (Time() >= (curr->age + curr->MyClass->GetRegTimeout())))
+		if (curr->registered != REG_ALL && (Time() > (curr->age + curr->MyClass->GetRegTimeout())))
 		{
 			/*
 			 * registration timeout -- didnt send USER/NICK/HOST


### PR DESCRIPTION
This seemingly breaks (occasionally timing users out a second early), possibly
due to rounding issues on time (User::age and Time() both return int, but a
whole second is comprised of many ms).

The root cause needs investigation, but we cannot leave a potentially breaking
bug in the tree.

This reverts commit 4414d644a163f3906f90b35186e07ce0383161f4.
