### PR TITLE
Fix modulemanager not being able to download modules (again!).

### DIFF
--- a/modulemanager
+++ b/modulemanager
@@ -348,11 +348,16 @@ for my $mod (sort keys %todo) {
 	}
 	$mod_versions{$mod} = $ver;
 
-	my $stat = getstore($url, "src/modules/$mod.cpp");
-	if ($stat == 200) {
+	my $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0 });
+	my $response = $ua->get($url);
+
+	if ($response->is_success) {
+		open(MF, ">src/modules/$mod.cpp") or die "\nFilesystem not writable: $!";
+		print MF $response->decoded_content;
+		close(MF);
 		print " - done\n";
 	} else {
-		print " - HTTP $stat\n";
+		printf "\nHTTP %s: %s\n", $response->code, $response->message;
 	}
 }
 


### PR DESCRIPTION
I already fixed this for the module list (almost a year ago now) but apparently I missed one place.

This fix is non-ideal but for now it's the best we can do what with distros and their broken LWP's. I'll see if I can find something better for 2.2.
