### PR TITLE
Fix some oversights from #895.

### DIFF
--- a/configure
+++ b/configure
@@ -300,7 +300,7 @@ if (<src/modules/m_ssl_*.cpp> && prompt_bool $interactive, 'Would you like to ge
 	system './tools/genssl', 'auto';
 }
 
-write_configure_cache %config if $interactive;
+write_configure_cache %config;
 parse_templates \%config, \%compiler, \%version;
 
 print_format <<"EOM";
@@ -312,10 +312,15 @@ Configuration is complete! You have chosen to build with the following settings:
   <|GREEN Name:|>    $compiler{NAME}
   <|GREEN Version:|> $compiler{VERSION}
 
-<|GREEN Extra Modules:|> <<TODO>>
-  * m_foo
-  * m_bar
-  * m_baz
+<|GREEN Extra Modules:|>
+EOM
+
+for my $file (<src/modules/m_*>) {
+	my $module = basename $file, '.cpp';
+	print "  * $module\n" if -l $file;
+}
+
+print_format <<"EOM";
 
 <|GREEN Paths:|>
   <|GREEN Base:|>   $config{BASE_DIR}

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -247,7 +247,7 @@ install: target
 	-$(INSTALL) -m $(INSTMODE_LIB) inspircd-genssl.1 $(MANPATH) 2>/dev/null
 	-$(INSTALL) -m $(INSTMODE_BIN) tools/genssl $(BINPATH)/inspircd-genssl 2>/dev/null
 	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/*.example $(CONPATH)/examples
-	-$(INSTALL) -m $(INSTMODE_LIB) *.pem $(CONPATH)
+	-$(INSTALL) -m $(INSTMODE_LIB) *.pem $(CONPATH) 2>/dev/null
 	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/aliases/*.example $(CONPATH)/examples/aliases
 	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/modules/*.example $(CONPATH)/examples/modules
 	@echo ""
@@ -264,11 +264,8 @@ install: target
 	@echo 'Remember to create your config file:' $(CONPATH)/inspircd.conf
 	@echo 'Examples are available at:' $(CONPATH)/examples/
 
-@TARGET BSD_MAKE CONFIGURE_CACHE_FILE = @CONFIGURE_CACHE_FILE@
-@TARGET GNU_MAKE CONFIGURE_CACHE_FILE = $(wildcard @CONFIGURE_CACHE_FILE@)
-
-GNUmakefile BSDmakefile: make/template/main.mk src/version.sh configure $(CONFIGURE_CACHE_FILE)
-	./configure -update
+GNUmakefile BSDmakefile: make/template/main.mk src/version.sh configure @CONFIGURE_CACHE_FILE@
+	./configure --update
 @TARGET BSD_MAKE .MAKEFILEDEPS: BSDmakefile
 
 clean:


### PR DESCRIPTION
- Always write the configure cache file as it is needed for updating
  the makefile when --update is called.
- List the modules which have been enabled in the "configuration
  complete" message.
- Silence some harmless warnings about installing PEM files which
  don't exist.
