### PR TITLE
Fix a snotice in m_spanningtree incorrectly using an unsigned long.

### DIFF
--- a/src/modules/m_spanningtree/fjoin.cpp
+++ b/src/modules/m_spanningtree/fjoin.cpp
@@ -86,8 +86,8 @@ CmdResult CommandFJoin::Handle(const std::vector<std::string>& params, User *src
 		time_t ourTS = chan->age;
 
 		if (TS != ourTS)
-			ServerInstance->SNO->WriteToSnoMask('d', "Merge FJOIN received for %s, ourTS: %lu, TS: %lu, difference: %lu",
-				chan->name.c_str(), (unsigned long)ourTS, (unsigned long)TS, (unsigned long)(ourTS - TS));
+			ServerInstance->SNO->WriteToSnoMask('d', "Merge FJOIN received for %s, ourTS: %lu, TS: %lu, difference: %ld",
+				chan->name.c_str(), (unsigned long)ourTS, (unsigned long)TS, (long)(ourTS - TS));
 		/* If our TS is less than theirs, we dont accept their modes */
 		if (ourTS < TS)
 		{


### PR DESCRIPTION
This value can be negative so it should be a signed long not an unsigned long.