### PR TITLE
Don't load Data::Dumper in the configure script.

### DIFF
--- a/configure
+++ b/configure
@@ -33,12 +33,6 @@ BEGIN {
 use strict;
 use warnings FATAL => qw(all);
 
-use Data::Dumper;
-BEGIN {
-	$Data::Dumper::Sortkeys = 1;
-	$Data::Dumper::Useqq = 1;
-};
-
 use File::Copy ();
 use Socket;
 use Cwd;


### PR DESCRIPTION
This is not used and apparently there are some distros which do not include it as part of the system Perl as seen with this:

```
[04:24] <lalala> [abc@localhost inspircd-2.0.18]$ ./configure
[04:24] <lalala> Can't locate Data/Dumper.pm in @INC (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at ./configure line 36.
[04:24] <lalala> BEGIN failed--compilation aborted at ./configure line 36.
[04:24] <lalala> how to fix it
```