### PR TITLE
Fix a blank error message when trying to load a module with a path.

### DIFF
--- a/src/modmanager_dynamic.cpp
+++ b/src/modmanager_dynamic.cpp
@@ -36,7 +36,10 @@ bool ModuleManager::Load(const std::string& filename, bool defer)
 {
 	/* Don't allow people to specify paths for modules, it doesn't work as expected */
 	if (filename.find('/') != std::string::npos)
+	{
+		LastModuleError = "You can't load modules with a path: " + filename;
 		return false;
+	}
 
 	char modfile[MAXBUF];
 	snprintf(modfile,MAXBUF,"%s/%s",ServerInstance->Config->ModPath.c_str(),filename.c_str());


### PR DESCRIPTION
Without this patch when you try to load a module with a path it does this:

     [*] Loading module:	/path/to/module.so

     [*] 