### PR TITLE
Fix modules not being versioned on Windows.

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -1717,7 +1717,8 @@ struct AllModuleList {
 				break; \
 		} \
 		return TRUE; \
-	}
+	} \
+	extern "C" DllExport const char inspircd_src_version[] = VERSION " r" REVISION;
 
 #else
 


### PR DESCRIPTION
Also, deduplicate MODULE_INIT (we are using a default implementation of DllMain).