### PR TITLE
Use ERR_YOUREBANNEDCREEP instead of NOTICE when a user is banned.

### DIFF
--- a/include/numerics.h
+++ b/include/numerics.h
@@ -144,6 +144,7 @@ enum Numerics
 	ERR_NOTREGISTERED               = 451,
 	ERR_NEEDMOREPARAMS              = 461,
 	ERR_ALREADYREGISTERED           = 462,
+	ERR_YOUREBANNEDCREEP            = 465,
 	ERR_UNKNOWNMODE                 = 472,
 
 	/*

--- a/src/usermanager.cpp
+++ b/src/usermanager.cpp
@@ -112,7 +112,7 @@ void UserManager::AddUser(int socket, ListenSocket* via, irc::sockets::sockaddrs
 			/* user banned */
 			ServerInstance->Logs->Log("BANCACHE", LOG_DEBUG, "BanCache: Positive hit for " + New->GetIPString());
 			if (!ServerInstance->Config->XLineMessage.empty())
-				New->WriteNotice("*** " +  ServerInstance->Config->XLineMessage);
+				New->WriteNumeric(ERR_YOUREBANNEDCREEP, ":" + ServerInstance->Config->XLineMessage);
 			this->QuitUser(New, b->Reason);
 			return;
 		}

--- a/src/xline.cpp
+++ b/src/xline.cpp
@@ -531,7 +531,7 @@ void XLine::DefaultApply(User* u, const std::string &line, bool bancache)
 	const std::string banReason = line + "-Lined: " + reason;
 
 	if (!ServerInstance->Config->XLineMessage.empty())
-		u->WriteNotice("*** " + ServerInstance->Config->XLineMessage);
+		u->WriteNumeric(ERR_YOUREBANNEDCREEP, ":" + ServerInstance->Config->XLineMessage);
 
 	if (ServerInstance->Config->HideBans)
 		ServerInstance->Users->QuitUser(u, line + "-Lined", &banReason);


### PR DESCRIPTION
This behaviour is specified in RFC 1459 and is used by Charybdis and other IRC server implementations so we should probably also use it.