### PR TITLE
[2.0] Fix IPv6 nameservers not being detected by the resolv.conf parser.

### DIFF
--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -199,7 +199,7 @@ static void FindDNS(std::string& server)
 		if (server == "nameserver")
 		{
 			resolv >> server;
-			if (server.find_first_not_of("0123456789.") == std::string::npos)
+			if (server.find_first_not_of("0123456789.") == std::string::npos || server.find_first_not_of("0123456789ABCDEFabcdef:") == std::string::npos)
 			{
 				ServerInstance->Logs->Log("CONFIG",DEFAULT,"<dns:server> set to '%s' as first resolver in /etc/resolv.conf.",server.c_str());
 				return;


### PR DESCRIPTION
This fixes #973. Tested by @Robby-.