### PR TITLE
Fix xline reasons being truncated in m_xline_db.

### DIFF
--- a/src/modules/m_xline_db.cpp
+++ b/src/modules/m_xline_db.cpp
@@ -120,7 +120,7 @@ class ModuleXLineDB : public Module
 				XLine* line = i->second;
 				stream << "LINE " << line->type << " " << line->Displayable() << " "
 					<< ServerInstance->Config->ServerName << " " << line->set_time << " "
-					<< line->duration << " " << line->reason << std::endl;
+					<< line->duration << " :" << line->reason << std::endl;
 			}
 		}
 


### PR DESCRIPTION
This error was introduced in bbeb5ea3.