### PR TITLE
* Add characterset option to MySQL database connection

### DIFF
--- a/src/modules/extra/m_mysql.cpp
+++ b/src/modules/extra/m_mysql.cpp
@@ -259,10 +259,10 @@ class SQLConnection : public SQLProvider
 		std::string characterset;
 		if (config->readString("characterset", characterset))
 		{
-		  if (!mysql_set_character_set(connection,characterset.c_str()))
-		  {
-		    ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "WARNING: Could not change character-set to " + characterset);
-		  }
+			if (!mysql_set_character_set(connection, characterset.c_str()))
+			{
+				ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "WARNING: Could not change character-set to " + characterset);
+			}
 		}
 		std::string initquery;
 		if (config->readString("initialquery", initquery))

--- a/src/modules/extra/m_mysql.cpp
+++ b/src/modules/extra/m_mysql.cpp
@@ -255,6 +255,15 @@ class SQLConnection : public SQLProvider
 		bool rv = mysql_real_connect(connection, host.c_str(), user.c_str(), pass.c_str(), dbname.c_str(), port, NULL, 0);
 		if (!rv)
 			return rv;
+		// enable character-set settings
+		std::string characterset;
+		if (config->readString("characterset", characterset))
+		{
+		  if (!mysql_set_character_set(connection,characterset.c_str()))
+		  {
+		    ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "WARNING: Could not change character-set to " + characterset);
+		  }
+		}
 		std::string initquery;
 		if (config->readString("initialquery", initquery))
 		{

--- a/src/modules/extra/m_mysql.cpp
+++ b/src/modules/extra/m_mysql.cpp
@@ -257,9 +257,10 @@ class SQLConnection : public SQLProvider
 			return rv;
 		// enable character-set settings
 		std::string characterset;
-		if (config->readString("characterset", characterset))
+		characterset=config->getString("characterset");
+		if (!characterset.empty())
 		{
-			if (!mysql_set_character_set(connection, characterset.c_str()))
+			if (mysql_set_character_set(connection, characterset.c_str()))
 			{
 				ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "WARNING: Could not change character-set to " + characterset);
 			}


### PR DESCRIPTION
Hi,

I loaded the nationalchar for utf-8 and utf-8 sqlauth isn't working since the MySQL connection wasn't configured for utf-8

Here the patch to add an option for character-set.
It may be interessant to put it for others SQL drivers

Best