### PR TITLE
Allow U-lined services to bypass m_silence (configurable)

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1841,7 +1841,10 @@
 #<module name="m_silence.so">
 #
 # Set the maximum number of entries allowed on a user's silence list.
-#<silence maxentries="32">
+#<silence maxentries="32"
+#
+# Whether messages from U-lined servers will bypass silence masks.
+#exemptuline="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # SQLite3 module: Allows other SQL modules to access SQLite3          #


### PR DESCRIPTION
Currently, it is possible for users to "mute" U-lined services through the use of m_silence. This should rarely, if ever, be desired behaviour.

Adds config options to m_silence to specify whether U-lined services should bypass silence mask(s).