### PR TITLE
Update user exempt flag on WEBIRC

### DIFF
--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -144,6 +144,7 @@ class CGIResolver : public Resolver
 			them->host = result;
 			them->dhost = result;
 			them->InvalidateCache();
+			them->exempt = (ServerInstance->XLines->MatchesLine("E",them) != NULL);
 			them->CheckLines(true);
 		}
 	}
@@ -300,6 +301,7 @@ public:
 		if (user->quitting)
 			return MOD_RES_DENY;
 
+		user->exempt = (ServerInstance->XLines->MatchesLine("E",user) != NULL);
 		user->CheckLines(true);
 		if (user->quitting)
 			return MOD_RES_DENY;
@@ -317,6 +319,7 @@ public:
 			if(InspIRCd::Match(user->host, iter->hostmask, ascii_case_insensitive_map) || InspIRCd::MatchCIDR(user->GetIPString(), iter->hostmask, ascii_case_insensitive_map))
 			{
 				// Deal with it...
+				user->exempt = (ServerInstance->XLines->MatchesLine("E",user) != NULL);
 				if(iter->type == PASS)
 				{
 					CheckPass(user); // We do nothing if it fails so...


### PR DESCRIPTION
Solves https://github.com/inspircd/inspircd/issues/989

Simple example: If Mibbit's IP is E-lined, and a user connects through Mibbit (so using WEBIRC), it won't check for bans on the user.