### PR TITLE
[2.0] Fix a minor crash when a user has no class after OnCheckReady.

### DIFF
--- a/src/userprocess.cpp
+++ b/src/userprocess.cpp
@@ -104,10 +104,15 @@ void InspIRCd::DoBackgroundUserStuff()
 					curr->FullConnect();
 					continue;
 				}
+
+				// If the user has been quit in OnCheckReady then we shouldn't
+				// quit them again for having a registration timeout.
+				if (curr->quitting)
+					continue;
 				break;
 		}
 
-		if (curr->registered != REG_ALL && (Time() > (curr->signon + curr->MyClass->GetRegTimeout())))
+		if (curr->registered != REG_ALL && curr->MyClass && (Time() > (curr->signon + curr->MyClass->GetRegTimeout())))
 		{
 			/*
 			 * registration timeout -- didnt send USER/NICK/HOST


### PR DESCRIPTION
This bug looks serious but it can only be triggered due to a very unusual server configuration problem. If you haven't already had a crash then you probably aren't at any risk.

The way this crash happens is:

1. InspIRCd::DoBackgroundUserStuff is called by the main loop.
2. In the switch statement curr->registered is REG_NICKUSER so InspIRCd::AllModulesReportReady is called.
3. InspIRCd::AllModulesReportReady calls the OnCheckReady event in m_cgiirc.
4. m_cgiirc calls RecheckClass which sets the user's class to NULL and calls LocalUser::SetClass and LocalUser::CheckClass.
5. The user doesn't match any classes in LocalUser::SetClass so LocalUser::CheckClass quits the user with with "Access denied by configuration".
6. Control flow returns to InspIRCd::DoBackgroundUserStuff when InspIRCd::AllModulesReportReady returns false.
7. The if statement at the end of InspIRCd::DoBackgroundUserStuff calls curr->MyClass->GetRegTimeout.
8. ConnectClass::GetRegTimeout tries to access a member of this which is NULL.
9. The server crashes with a SEGFAULT.

I could not replicate this bug locally but @JDowny could and this patch has been confirmed working by him.