### PR TITLE
[2.0] Fix building when VERBOSE is already set in the environment.

### DIFF
--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -125,6 +125,7 @@ CXXFLAGS += -Iinclude
   @BSD_ONLY MAKE += -s
   RUNCC = perl $(SOURCEPATH)/make/run-cc.pl $(CC)
   RUNLD = perl $(SOURCEPATH)/make/run-cc.pl $(CC)
+  VERBOSE =
 @ENDIF
 
 @IFDEF PURE_STATIC


### PR DESCRIPTION
This is a workaround for now. In 2.2 we should prefix all of the environment variables with INSPIRCD_ to avoid collisions.