### PR TITLE
[2.0] Fix exposing the opers hostname in KILL when using hidekills.

### DIFF
--- a/src/commands/cmd_kill.cpp
+++ b/src/commands/cmd_kill.cpp
@@ -134,7 +134,7 @@ CmdResult CommandKill::Handle (const std::vector<std::string>& parameters, User 
 				u->Write(":%s KILL %s :%s!%s!%s (%s)", ServerInstance->Config->HideKillsServer.empty() ? user->GetFullHost().c_str() : ServerInstance->Config->HideKillsServer.c_str(),
 						u->nick.c_str(),
 						ServerInstance->Config->ServerName.c_str(),
-						user->dhost.c_str(),
+						ServerInstance->Config->HideKillsServer.empty() ? user->dhost.c_str() : ServerInstance->Config->HideKillsServer.c_str(),
 						ServerInstance->Config->HideKillsServer.empty() ? user->nick.c_str() : ServerInstance->Config->HideKillsServer.c_str(),
 						parameters[1].c_str());
 			}


### PR DESCRIPTION
Suggested by @Adam-. Fixes #1015.
