### PR TITLE
Convert build system to Perl 5.10.

### DIFF
--- a/configure
+++ b/configure
@@ -27,9 +27,10 @@
 
 
 BEGIN {
-	require 5.8.0;
+	require 5.10.0;
 }
 
+use feature ':5.10';
 use strict;
 use warnings FATAL => qw(all);
 
@@ -137,7 +138,7 @@ if ($interactive) {
 	}
 }
 
-$config{CXX} = find_compiler($config{CXX} || $ENV{CXX});
+$config{CXX} = find_compiler($config{CXX} // $ENV{CXX});
 unless ($config{CXX}) {
 	print "A suitable C++ compiler could not be detected on your system!\n";
 	print "Set the CXX environment variable to the compiler binary path if this is incorrect.\n";
@@ -149,24 +150,24 @@ $config{HAS_CLOCK_GETTIME} = run_test 'clock_gettime()', test_file($config{CXX},
 $config{HAS_EVENTFD} = run_test 'eventfd()', test_file($config{CXX}, 'eventfd.cpp');
 
 if ($config{HAS_EPOLL} = run_test 'epoll', test_header($config{CXX}, 'sys/epoll.h')) {
-	$config{SOCKETENGINE} ||= 'epoll';
+	$config{SOCKETENGINE} //= 'epoll';
 }
 
 if ($config{HAS_KQUEUE} = run_test 'kqueue', test_file($config{CXX}, 'kqueue.cpp')) {
-	$config{SOCKETENGINE} ||= 'kqueue';
+	$config{SOCKETENGINE} //= 'kqueue';
 }
 
 if ($config{HAS_PORTS} = run_test 'Solaris IOCP', test_header($config{CXX}, 'port.h')) {
-	$config{SOCKETENGINE} ||= 'ports';
+	$config{SOCKETENGINE} //= 'ports';
 }
 
 if ($config{HAS_POLL} = run_test 'poll', test_header($config{CXX}, 'poll.h')) {
-	$config{SOCKETENGINE} ||= 'poll';
+	$config{SOCKETENGINE} //= 'poll';
 }
 
 # Select is available on all platforms
 $config{HAS_SELECT} = 1;
-$config{SOCKETENGINE} ||= 'select';
+$config{SOCKETENGINE} //= 'select';
 
 if (defined $opt_socketengine) {
 	my $cfgkey = 'HAS_' . uc $opt_socketengine;
@@ -191,21 +192,21 @@ if (defined $opt_distribution_label) {
 }
 
 if (defined $opt_system) {
-	$config{BASE_DIR}   = $opt_prefix     || '/var/lib/inspircd';
-	$config{BINARY_DIR} = $opt_binary_dir || '/usr/sbin';
-	$config{CONFIG_DIR} = $opt_config_dir || '/etc/inspircd';
-	$config{DATA_DIR}   = $opt_data_dir   || '/var/inspircd';
-	$config{LOG_DIR}    = $opt_module_dir || '/var/log/inspircd';
-	$config{MANUAL_DIR} = $opt_manual_dir || '/usr/share/man/man1';
-	$config{MODULE_DIR} = $opt_module_dir || '/usr/lib/inspircd';
+	$config{BASE_DIR}   = $opt_prefix     // '/var/lib/inspircd';
+	$config{BINARY_DIR} = $opt_binary_dir // '/usr/sbin';
+	$config{CONFIG_DIR} = $opt_config_dir // '/etc/inspircd';
+	$config{DATA_DIR}   = $opt_data_dir   // '/var/inspircd';
+	$config{LOG_DIR}    = $opt_module_dir // '/var/log/inspircd';
+	$config{MANUAL_DIR} = $opt_manual_dir // '/usr/share/man/man1';
+	$config{MODULE_DIR} = $opt_module_dir // '/usr/lib/inspircd';
 } else {
-	$config{BASE_DIR}   = $opt_prefix     || $config{BASE_DIR}   || rel2abs 'run';
-	$config{BINARY_DIR} = $opt_binary_dir || $config{BINARY_DIR} || rel2abs $config{BASE_DIR} . '/bin';
-	$config{CONFIG_DIR} = $opt_config_dir || $config{CONFIG_DIR} || rel2abs $config{BASE_DIR} . '/conf';
-	$config{DATA_DIR}   = $opt_data_dir   || $config{DATA_DIR}   || rel2abs $config{BASE_DIR} . '/data';
-	$config{LOG_DIR}    = $opt_log_dir    || $config{LOG_DIR}    || rel2abs $config{BASE_DIR} . '/logs';
-	$config{MANUAL_DIR} = $opt_manual_dir || $config{MANUAL_DIR} || rel2abs $config{BASE_DIR} . '/manuals';
-	$config{MODULE_DIR} = $opt_module_dir || $config{MODULE_DIR} || rel2abs $config{BASE_DIR} . '/modules';
+	$config{BASE_DIR}   = $opt_prefix     // $config{BASE_DIR}   // rel2abs 'run';
+	$config{BINARY_DIR} = $opt_binary_dir // $config{BINARY_DIR} // rel2abs $config{BASE_DIR} . '/bin';
+	$config{CONFIG_DIR} = $opt_config_dir // $config{CONFIG_DIR} // rel2abs $config{BASE_DIR} . '/conf';
+	$config{DATA_DIR}   = $opt_data_dir   // $config{DATA_DIR}   // rel2abs $config{BASE_DIR} . '/data';
+	$config{LOG_DIR}    = $opt_log_dir    // $config{LOG_DIR}    // rel2abs $config{BASE_DIR} . '/logs';
+	$config{MANUAL_DIR} = $opt_manual_dir // $config{MANUAL_DIR} // rel2abs $config{BASE_DIR} . '/manuals';
+	$config{MODULE_DIR} = $opt_module_dir // $config{MODULE_DIR} // rel2abs $config{BASE_DIR} . '/modules';
 }
 
 # Parse --gid=123 or --gid=foo and extract the group id.
@@ -214,7 +215,7 @@ if (defined $opt_gid) {
 	@group = $opt_gid =~ /^\d+$/ ? getgrgid($opt_gid) : getgrnam($opt_gid);
 	print_error "there is no '$opt_gid' group on this system!" unless @group;
 } else {
-	@group = $opt_system ? getgrnam('irc') : getgrgid($config{GID} || getgid());
+	@group = $opt_system ? getgrnam('irc') : getgrgid($config{GID} // getgid());
 	print_error "you need to specify a group to run as using '--gid [id|name]'!" unless @group;
 }
 $config{GROUP} = $group[0];
@@ -226,7 +227,7 @@ if (defined $opt_uid) {
 	@user = $opt_uid =~ /^\d+$/ ? getpwuid($opt_uid) : getpwnam($opt_uid);
 	print_error "there is no '$opt_uid' user on this system!" unless @user;
 } else {
-	@user = $opt_system ? getpwnam('irc') : getpwuid($config{UID} || getuid());
+	@user = $opt_system ? getpwnam('irc') : getpwuid($config{UID} // getuid());
 	print_error "you need to specify a user to run as using '--uid [id|name]'!" unless @user;
 }
 $config{USER} = $user[0];
@@ -246,8 +247,8 @@ version instead.
 You can obtain the latest stable version from http://www.inspircd.org/ or by
 running `git checkout insp20` if you are installing from Git.
 EOW
-	if (!prompt_bool $interactive, 'I understand this warning and want to continue anyway.', $opt_development || 0) {
-		print STDERR "If you understand this warning and still want to continue pass the --development flag.\n" unless $interactive;
+	if (!prompt_bool $interactive, 'I understand this warning and want to continue anyway.', $opt_development // 0) {
+		say STDERR 'If you understand this warning and still want to continue pass the --development flag.' unless $interactive;
 		exit 1;
 	}
 }
@@ -322,7 +323,7 @@ EOM
 
 for my $file (<src/modules/m_*>) {
 	my $module = basename $file, '.cpp';
-	print "  * $module\n" if -l $file;
+	say "  * $module" if -l $file;
 }
 
 print_format <<"EOM";

--- a/make/common.pm
+++ b/make/common.pm
@@ -18,11 +18,12 @@
 
 
 BEGIN {
-	require 5.8.0;
+	require 5.10.0;
 }
 
 package make::common;
 
+use feature ':5.10';
 use strict;
 use warnings FATAL => qw(all);
 
@@ -33,9 +34,8 @@ our @EXPORT = qw(get_cpu_count
                  get_version
                  module_installed);
 
-my %version;
-
 sub get_version {
+	state %version;
 	return %version if %version;
 
 	# Attempt to retrieve version information from src/version.sh
@@ -47,22 +47,22 @@ sub get_version {
 	# Attempt to retrieve missing version information from Git
 	chomp(my $gr = `git describe --tags 2>/dev/null`);
 	if ($gr =~ /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\d+-g(\w+))?$/) {
-		$version{MAJOR} = $1 unless defined $version{MAJOR};
-		$version{MINOR} = $2 unless defined $version{MINOR};
-		$version{PATCH} = $3 unless defined $version{PATCH};
+		$version{MAJOR} //= $1;
+		$version{MINOR} //= $2;
+		$version{PATCH} //= $3;
 		$version{LABEL} = $4 if defined $4;
 	}
 
 	# The user is using a stable release which does not have
 	# a label attached.
-	$version{LABEL} = 'release' unless defined $version{LABEL};
+	$version{LABEL} //= 'release';
 
 	# If any of these fields are missing then the user has deleted the
 	# version file and is not running from Git. Fill in the fields with
 	# dummy data so we don't get into trouble with undef values later.
-	$version{MAJOR} = '0' unless defined $version{MAJOR};
-	$version{MINOR} = '0' unless defined $version{MINOR};
-	$version{PATCH} = '0' unless defined $version{PATCH};
+	$version{MAJOR} //= '0';
+	$version{MINOR} //= '0';
+	$version{PATCH} //= '0';
 
 	return %version;
 }

--- a/make/console.pm
+++ b/make/console.pm
@@ -20,9 +20,10 @@
 package make::console;
 
 BEGIN {
-	require 5.8.0;
+	require 5.10.0;
 }
 
+use feature ':5.10';
 use strict;
 use warnings FATAL => qw(all);
 
@@ -55,7 +56,7 @@ sub __console_format($$) {
 
 sub print_format($;$) {
 	my $message = shift;
-	my $stream = shift || *STDOUT;
+	my $stream = shift // *STDOUT;
 	while ($message =~ /(<\|(\S+)\s(.+?)\|>)/) {
 		my $formatted = __console_format $2, $3;
 		$message =~ s/\Q$1\E/$formatted/;
@@ -106,7 +107,7 @@ sub prompt_string($$$) {
 	print_format "$question\n";
 	print_format "[<|GREEN $default|>] => ";
 	chomp(my $answer = <STDIN>);
-	print "\n";
+	say '';
 	return $answer ? $answer : $default;
 }
 

--- a/tools/genssl
+++ b/tools/genssl
@@ -21,9 +21,10 @@
 
 
 BEGIN {
-	require 5.8.0;
+	require 5.10.0;
 }
 
+use feature ':5.10';
 use strict;
 use warnings FATAL => qw(all);
 
@@ -36,15 +37,15 @@ use File::Temp();
 sub prompt($$) {
 	my ($question, $default) = @_;
 	return prompt_string(1, $question, $default) if eval 'use make::console; 1';
-	print "$question\n";
+	say $question;
 	print "[$default] => ";
 	chomp(my $answer = <STDIN>);
-	print "\n";
+	say '';
 	return $answer ? $answer : $default;
 }
 
 if ($#ARGV != 0 || $ARGV[0] !~ /^(?:auto|gnutls|openssl)$/i) {
-	print "Syntax: genssl <auto|gnutls|openssl>\n";
+	say 'Syntax: genssl <auto|gnutls|openssl>';
 	exit 1;
 }
 
@@ -65,14 +66,14 @@ if ($tool eq 'auto') {
 	} elsif ($has_openssl) {
 		$tool = 'openssl';
 	} else {
-		print STDERR "SSL generation failed: could not find $certtool or openssl in the PATH!\n";
+		say STDERR "SSL generation failed: could not find $certtool or openssl in the PATH!";
 		exit 1;
 	}
 } elsif ($tool eq 'gnutls' && !$has_gnutls) {
-	print STDERR "SSL generation failed: could not find '$certtool' in the PATH!\n";
+	say STDERR "SSL generation failed: could not find '$certtool' in the PATH!";
 	exit 1;
 } elsif ($tool eq 'openssl' && !$has_openssl) {
-	print STDERR "SSL generation failed: could not find 'openssl' in the PATH!\n";
+	say STDERR 'SSL generation failed: could not find \'openssl\' in the PATH!';
 	exit 1;
 }
 
@@ -138,13 +139,14 @@ __OPENSSL_END__
 }
 
 if ($status) {
-	print STDERR "SSL generation failed: $tool exited with a non-zero status!\n";
+	say STDERR "SSL generation failed: $tool exited with a non-zero status!";
 	exit 1;
 }
 
 if (defined $dercert && eval 'use Digest::SHA; 1') {
 	my $hash = Digest::SHA->new(256);
 	$hash->add($dercert);
-	print "\nAdd this TLSA record to your domain for DANE support:\n";
-	print "_6697._tcp." . $common_name . " TLSA 3 0 1 " . $hash->hexdigest . "\n";
+	say '';
+	say 'Add this TLSA record to your domain for DANE support:';
+	say "_6697._tcp." . $common_name . " TLSA 3 0 1 " . $hash->hexdigest;
 }

--- a/tools/test-build
+++ b/tools/test-build
@@ -19,13 +19,14 @@
 
 
 BEGIN {
-	require 5.8.0;
+	require 5.10.0;
 	unless (-f 'configure') {
 		print "Error: $0 must be run from the main source directory!\n";
 		exit 1;
 	}
 }
 
+use feature ':5.10';
 use strict;
 use warnings FATAL => qw(all);
 
@@ -39,7 +40,7 @@ system 'git', 'clean', '-dfx';
 my @compilers = $#ARGV >= 0 ? @ARGV : qw(g++ clang++ icpc);
 foreach my $compiler (@compilers) {
 	if (system "$compiler -v > /dev/null 2>&1") {
-		print "Skipping $compiler as it is not installed on this system!\n";
+		say "Skipping $compiler as it is not installed on this system!";
 		next;
 	}
 	$ENV{CXX} = $compiler;
@@ -49,23 +50,23 @@ foreach my $compiler (@compilers) {
 	push @socketengines, 'poll' if test_header $compiler, 'poll.h';
 	push @socketengines, 'ports' if test_header $compiler, 'ports.h';
 	foreach my $socketengine (@socketengines) {
-		print "Attempting to build using the $compiler compiler and the $socketengine socket engine...\n";
+		say "Attempting to build using the $compiler compiler and the $socketengine socket engine...";
 		system './configure', '--enable-extras', $ENV{TEST_BUILD_MODULES} if defined $ENV{TEST_BUILD_MODULES};
 		if (system './configure', '--development', '--socketengine', $socketengine) {
-			print "Failed to configure using the $compiler compiler and the $socketengine socket engine!\n";
+			say "Failed to configure using the $compiler compiler and the $socketengine socket engine!";
 			exit 1;
 		}
 		$ENV{PURE_STATIC} = 1;
 		if (system 'make', '-j'.get_cpu_count, 'install') {
-			print "Failed to compile with static modules using the $compiler compiler and the $socketengine socket engine!\n";
+			say "Failed to compile with static modules using the $compiler compiler and the $socketengine socket engine!";
 			exit 1;
 		}
 		delete $ENV{PURE_STATIC};
 		if (system 'make', '-j'.get_cpu_count, 'install') {
-			print "Failed to compile with dynamic modules using the $compiler compiler and the $socketengine socket engine!\n";
+			say "Failed to compile with dynamic modules using the $compiler compiler and the $socketengine socket engine!";
 			exit 1;
 		}
-		print "Building using the $compiler compiler and the $socketengine socket engine succeeded!\n";
+		say "Building using the $compiler compiler and the $socketengine socket engine succeeded!";
 	}
 
 	system 'git', 'clean', '-dfx';


### PR DESCRIPTION
Now we have dropped support for the old CentOS release we can use Perl 5.10 instead of 5.8. Yay!

**Note:** I'm not going to update `make/utilities.pm` as that file is scheduled to be removed soon anyway. Similarly, `./modulemanager` and the module bits of `./configure` are due to be entirely rewritten so i'm not going to update that either.