### PR TITLE
Implement support for callers having multiple handlers.

### DIFF
--- a/include/caller.h
+++ b/include/caller.h
@@ -32,15 +32,26 @@ template<typename ReturnType, typename... Args> class CoreExport Handler : publi
 
 template<typename ReturnType, typename... Args> class CoreExport Caller
 {
- public:
-	Handler<ReturnType, Args...>* target;
+ protected:
+ 	std::vector<Handler<ReturnType, Args...>*> handlers;
 
-	Caller(Handler<ReturnType, Args...>* initial) : target(initial) { }
+ public:
+	Caller(Handler<ReturnType, Args...>* initial) { Add(initial); }
 	virtual ~Caller() { }
+
+	void Add(Handler<ReturnType, Args...>* handler)
+	{
+		handlers.push_back(handler);
+	}
+
+	void Remove(Handler<ReturnType, Args...>* handler)
+	{
+		stdalgo::erase(handlers, handler);
+	}
 
 	virtual ReturnType operator()(const Args&... params)
 	{
-		return this->target->Call(params...);
+		return this->handlers.back()->Call(params...);
 	}
 };
 
@@ -191,12 +202,22 @@ template <typename ReturnType, typename Param1, typename Param2, typename Param3
 
 template <typename HandlerType> class caller
 {
+ protected:
+	std::vector<HandlerType*> handlers;
  public:
-	HandlerType* target;
-
 	caller(HandlerType* initial)
-	: target(initial)
-	{ }
+	{
+		Add(initial);
+	}
+	void Add(HandlerType* handler)
+	{
+		handlers.push_back(handler);
+	}
+
+	void Remove(HandlerType* handler)
+	{
+		stdalgo::erase(handlers, handler);
+	}
 
 	virtual ~caller() { }
 };
@@ -210,7 +231,7 @@ template <typename ReturnType> class caller0 : public caller< HandlerBase0<Retur
 
 	ReturnType operator() ()
 	{
-		return this->target->Call();
+		return this->handlers.back()->Call();
 	}
 };
 
@@ -223,7 +244,7 @@ template <typename ReturnType, typename Param1> class caller1 : public caller< H
 
 	ReturnType operator() (Param1 param1)
 	{
-		return this->target->Call(param1);
+		return this->handlers.back()->Call(param1);
 	}
 };
 
@@ -236,7 +257,7 @@ template <typename ReturnType, typename Param1, typename Param2> class caller2 :
 
 	ReturnType operator() (Param1 param1, Param2 param2)
 	{
-		return this->target->Call(param1, param2);
+		return this->handlers.back()->Call(param1, param2);
 	}
 };
 
@@ -249,7 +270,7 @@ template <typename ReturnType, typename Param1, typename Param2, typename Param3
 
 	ReturnType operator() (Param1 param1, Param2 param2, Param3 param3)
 	{
-		return this->target->Call(param1, param2, param3);
+		return this->handlers.back()->Call(param1, param2, param3);
 	}
 };
 
@@ -262,7 +283,7 @@ template <typename ReturnType, typename Param1, typename Param2, typename Param3
 
 	ReturnType operator() (Param1 param1, Param2 param2, Param3 param3, Param4 param4)
 	{
-		return this->target->Call(param1, param2, param3, param4);
+		return this->handlers.back()->Call(param1, param2, param3, param4);
 	}
 };
 
@@ -275,7 +296,7 @@ template <typename ReturnType, typename Param1, typename Param2, typename Param3
 
 	ReturnType operator() (Param1 param1, Param2 param2, Param3 param3, Param4 param4, Param5 param5)
 	{
-		return this->target->Call(param1, param2, param3, param4, param5);
+		return this->handlers.back()->Call(param1, param2, param3, param4, param5);
 	}
 };
 
@@ -288,7 +309,7 @@ template <typename ReturnType, typename Param1, typename Param2, typename Param3
 
 	ReturnType operator() (Param1 param1, Param2 param2, Param3 param3, Param4 param4, Param5 param5, Param6 param6)
 	{
-		return this->target->Call(param1, param2, param3, param4, param5, param6);
+		return this->handlers.back()->Call(param1, param2, param3, param4, param5, param6);
 	}
 };
 
@@ -301,7 +322,7 @@ template <typename ReturnType, typename Param1, typename Param2, typename Param3
 
 	ReturnType operator() (Param1 param1, Param2 param2, Param3 param3, Param4 param4, Param5 param5, Param6 param6, Param7 param7)
 	{
-		return this->target->Call(param1, param2, param3, param4, param5, param6, param7);
+		return this->handlers.back()->Call(param1, param2, param3, param4, param5, param6, param7);
 	}
 };
 
@@ -314,7 +335,7 @@ template <typename ReturnType, typename Param1, typename Param2, typename Param3
 
 	ReturnType operator() (Param1 param1, Param2 param2, Param3 param3, Param4 param4, Param5 param5, Param6 param6, Param7 param7, Param8 param8)
 	{
-		return this->target->Call(param1, param2, param3, param4, param5, param6, param7, param8);
+		return this->handlers.back()->Call(param1, param2, param3, param4, param5, param6, param7, param8);
 	}
 };
 

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -1155,7 +1155,7 @@ class ModuleSSLGnuTLS : public Module
 	void init() CXX11_OVERRIDE
 	{
 		ReadProfiles();
-		ServerInstance->GenRandom = &randhandler;
+		ServerInstance->GenRandom.Add(&randhandler);
 	}
 
 	void OnModuleRehash(User* user, const std::string &param) CXX11_OVERRIDE
@@ -1175,7 +1175,7 @@ class ModuleSSLGnuTLS : public Module
 
 	~ModuleSSLGnuTLS()
 	{
-		ServerInstance->GenRandom = &ServerInstance->HandleGenRandom;
+		ServerInstance->GenRandom.Remove(&randhandler);
 	}
 
 	void OnCleanup(int target_type, void* item) CXX11_OVERRIDE

--- a/src/modules/m_channames.cpp
+++ b/src/modules/m_channames.cpp
@@ -45,21 +45,19 @@ bool NewIsChannelHandler::Call(const std::string& channame)
 class ModuleChannelNames : public Module
 {
 	NewIsChannelHandler myhandler;
-	caller1<bool, const std::string&> rememberer;
 	bool badchan;
 	ChanModeReference permchannelmode;
 
  public:
 	ModuleChannelNames()
-		: rememberer(ServerInstance->IsChannel)
-		, badchan(false)
+		: badchan(false)
 		, permchannelmode(this, "permanent")
 	{
 	}
 
 	void init() CXX11_OVERRIDE
 	{
-		ServerInstance->IsChannel = &myhandler;
+		ServerInstance->IsChannel.Add(&myhandler);
 	}
 
 	void ValidateChans()
@@ -142,7 +140,7 @@ class ModuleChannelNames : public Module
 
 	CullResult cull() CXX11_OVERRIDE
 	{
-		ServerInstance->IsChannel = rememberer;
+		ServerInstance->IsChannel.Remove(&myhandler);
 		ValidateChans();
 		return Module::cull();
 	}

--- a/src/modules/m_exemptchanops.cpp
+++ b/src/modules/m_exemptchanops.cpp
@@ -123,12 +123,12 @@ class ModuleExemptChanOps : public Module
 
 	void init() CXX11_OVERRIDE
 	{
-		ServerInstance->OnCheckExemption = &eh;
+		ServerInstance->OnCheckExemption.Add(&eh);
 	}
 
 	~ModuleExemptChanOps()
 	{
-		ServerInstance->OnCheckExemption = &ServerInstance->HandleOnCheckExemption;
+		ServerInstance->OnCheckExemption.Remove(&eh);
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/modules/m_nationalchars.cpp
+++ b/src/modules/m_nationalchars.cpp
@@ -220,7 +220,6 @@ class ModuleNationalChars : public Module
 	lwbNickHandler myhandler;
 	std::string charset, casemapping;
 	unsigned char m_additional[256], m_additionalUp[256], m_lower[256], m_upper[256];
-	caller1<bool, const std::string&> rememberer;
 	bool forcequit;
 	const unsigned char * lowermap_rememberer;
 	unsigned char prev_map[256];
@@ -254,7 +253,7 @@ class ModuleNationalChars : public Module
 
  public:
 	ModuleNationalChars()
-		: rememberer(ServerInstance->IsNick), lowermap_rememberer(national_case_insensitive_map)
+		: lowermap_rememberer(national_case_insensitive_map)
 	{
 		memcpy(prev_map, national_case_insensitive_map, sizeof(prev_map));
 	}
@@ -303,7 +302,7 @@ class ModuleNationalChars : public Module
 
 	~ModuleNationalChars()
 	{
-		ServerInstance->IsNick = rememberer;
+		ServerInstance->IsNick.Remove(&myhandler);
 		national_case_insensitive_map = lowermap_rememberer;
 		CheckForceQuit("National characters module unloaded");
 		CheckRehash();


### PR DESCRIPTION
This fixes the problem of having multiple modules which hook the same event colliding with each other which could potentially cause a crash if a rememberer stores a handler from another module which is unloaded first.

It does not fix the problem of the module which gets the active hook being entirely based on load (or rather `init`) order.