### PR TITLE
Encase the IPv6 address in `STATS p` with square brackets.

### DIFF
--- a/src/coremods/core_stats.cpp
+++ b/src/coremods/core_stats.cpp
@@ -99,6 +99,11 @@ void CommandStats::DoStats(char statschar, User* user, string_list &results)
 				std::string ip = ls->bind_addr;
 				if (ip.empty())
 					ip.assign("*");
+				else if (ip.find_first_of(':') != std::string::npos)
+				{
+					ip.insert(ip.begin(), '[');
+					ip.insert(ip.end(),  ']');
+				}
 				std::string type = ls->bind_tag->getString("type", "clients");
 				std::string hook = ls->bind_tag->getString("ssl", "plaintext");
 


### PR DESCRIPTION
This is a [widely used format](http://en.wikipedia.org/wiki/IPv6_address#Literal_IPv6_addresses_in_network_resource_identifiers) as without it the port is ambiguous.

Before:

    :irc.example.com 249 NickName ::::6667 (clients, plaintext)

After:

    :irc.example.com 249 NickName :[::]:6667 (clients, plaintext)

We also use this format in `irc::sockets::sockaddrs::str()`.