### PR TITLE
modules.conf.example: use full cloaking by default

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -497,7 +497,7 @@
 # An optional prefix may be specified to mark cloaked hosts.          #
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 #
-#<cloak mode="half"
+#<cloak mode="full"
 #       key="secret"
 #       prefix="net-">
 


### PR DESCRIPTION
This was discussed on \#inspircd and \#ircv3 and @SaberUK suggested me to PR about this.