### PR TITLE
[2.0] Fix various issues with the nationalchars module.

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1148,10 +1148,13 @@
 # 2) Allows using custom (national) casemapping over the network.
 #<module name="m_nationalchars.so">
 #
-# file - filename of existing file in "locales" directory
-# casemapping - custom value for 005 numeric (if you want it to be
-#               different from the filename). Set this to the name of
-#               the locale if you are specifying an absolute path.
+# file - Location of the file which contains casemapping rules. If this
+#        is a relative path then it is relative to "<PWD>/../locales"
+#        on UNIX and "<PWD>/locales" on Windows.
+# casemapping - The name of the casemapping sent to clients in the 005
+#               numeric. If this is not set then it defaults to the name
+#               of the casemapping file unless the file name contains a
+#               space in which case you will have to specify it manually.
 #<nationalchars file="bynets/russian-w1251-charlink" casemapping="ru_RU.cp1251-charlink">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#

--- a/win/CMakeLists.txt
+++ b/win/CMakeLists.txt
@@ -74,6 +74,10 @@ install(FILES ${EXTRA_DLLS} DESTINATION .)
 file(GLOB_RECURSE EXAMPLE_CONFIGS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${INSPIRCD_BASE}/docs/conf/*.example")
 install(FILES ${EXAMPLE_CONFIGS} DESTINATION conf)
 
+# Install nationalchars files
+file(GLOB_RECURSE EXAMPLE_LOCALES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${INSPIRCD_BASE}/locales/*")
+install(FILES ${EXAMPLE_LOCALES} DESTINATION locales)
+
 # Create an empty data and logs directory and install them
 file(MAKE_DIRECTORY ${DATA_PATH})
 install(DIRECTORY ${DATA_PATH} DESTINATION .)


### PR DESCRIPTION
This fixes some of the more serious problems with the nationalchars module:

- Strip the directory name in the default casemapping value. This prevents the entire path from being shown in ISUPPORT.
- Error out if the casemapping value contains a space. This prevents invalid entries in ISUPPORT.
- Error out if the locale file failed to load. This fixes the case where errors could be silently ignored which is the cause of some confusion.
- Fix relative file path when building on Windows. The executable is not in the bin directory on Windows.
- Install nationalchars files on Windows. 