### PR TITLE
[2.0] Show a better warning when certtool/openssl are missing.

### DIFF
--- a/make/opensslcert.pm
+++ b/make/opensslcert.pm
@@ -32,6 +32,11 @@ our @EXPORT = qw(make_openssl_cert);
 
 sub make_openssl_cert()
 {
+	if (system 'openssl version >/dev/null 2>&1')
+	{
+		print "\e[1;31mCertificate generation failed:\e[0m unable to find 'openssl' in the PATH!\n";
+		return;
+	}
 	open (FH, ">openssl.template");
 	my $commonname = promptstring_s('What is the hostname of your server?', 'irc.example.com');
 	my $email = promptstring_s('What email address can you be contacted at?', 'example@example.com');


### PR DESCRIPTION
This converts this:

```
$ ./configure --generate-gnutls-cert
What is the hostname of your server?
[irc.example.com] -> 

What email address can you be contacted at?
[example@example.com] -> 

What is the name of your unit?
[Server Admins] -> 

What is the name of your organization?
[Example IRC Network] -> 

What city are you located in?
[Example City] -> 

What state are you located in?
[Example State] -> 

What is the ISO 3166-1 code for the country you are located in?
[XZ] -> 

How many days do you want your certificate to be valid for?
[365] -> 

Can't exec "certtool": No such file or directory at make/gnutlscert.pm line 142, <STDIN> line 8.

[CONFIGURE NOW CONTINUES INTO NORMAL INTERACTIVE MODE OBSCURING THE ERROR MESSAGE]
```

Into this:

```
$ ./configure --generate-gnutls-cert
Error: unable to find 'certtool' in the PATH!
```

This is needed because if you are missing the binary packages for your SSL library then it will fail to generate certificates but because `./configure` in 2.0 is awful it will continue running after encountering the error which obscures the error message from certtool/openssl. In my experience this is probably one of the most common SSL module-related problems encountered in \#inspircd.