### PR TITLE
[2.0] Log STDOUT and STDERR in the launchd script.

### DIFF
--- a/make/template/org.inspircd.plist
+++ b/make/template/org.inspircd.plist
@@ -21,6 +21,10 @@
 	</array>
 	<key>ServiceIPC</key>
 	<false/>
+	<key>StandardOutPath</key>
+	<string>@LOG_DIR@/launchd-stdout.log</string>
+	<key>StandardErrorPath</key>
+	<string>@LOG_DIR@/launchd-stderr.log</string>
 	<key>UserName</key>
 	<string>ircdaemon</string>
 </dict>


### PR DESCRIPTION
This makes resolving configuration errors *so* much easier.