### PR TITLE
[2.0] Fix checking whether kqueue/stdint/strlcpy are available.

### DIFF
--- a/configure
+++ b/configure
@@ -353,14 +353,8 @@ $exec = $config{CC} . " -dumpversion | cut -c 3";
 chomp($config{GCCMINOR}		= `$exec`);
 
 printf "Checking if stdint.h exists... ";
-$config{HAS_STDINT} = "true";
-our $fail = 0;
-open(STDINT, "</usr/include/stdint.h") or $config{HAS_STDINT} = "false";
-if ($config{HAS_STDINT} eq "true") {
-	close(STDINT);
-}
-print "yes\n" if $config{HAS_STDINT} eq "true";
-print "no\n" if $config{HAS_STDINT} eq "false";
+$config{HAS_STDINT} = test_compile('stdint');
+print $config{HAS_STDINT} ? "yes\n" : "no\n";
 
 printf "Checking if strlcpy exists... ";
 $config{HAS_STRLCPY} = test_compile('strlcpy');

--- a/configure
+++ b/configure
@@ -382,22 +382,8 @@ print "yes\n" if $config{HAS_STRLCPY} eq "true";
 print "no\n" if $config{HAS_STRLCPY} eq "false";
 
 printf "Checking if kqueue exists... ";
-$has_kqueue = 0;
-$fail = 0;
-open(KQUEUE, "</usr/include/sys/event.h") or $fail = 1;
-if (!$fail) {
-	while (defined(my $line = <KQUEUE>)) {
-		chomp($line);
-		# try and find the delcaration of:
-		# int kqueue(void);
-		if ($line =~ /int(\0x9|\s)+kqueue/) {
-			$has_kqueue = 1;
-		}
-	}
-	close(KQUEUE);
-}
-print "yes\n" if $has_kqueue == 1;
-print "no\n" if $has_kqueue == 0;
+$has_kqueue = test_compile('kqueue');
+print $has_kqueue ? "yes\n" : "no\n";
 
 printf "Checking for epoll support... ";
 $has_epoll = test_compile('epoll');

--- a/configure
+++ b/configure
@@ -363,23 +363,8 @@ print "yes\n" if $config{HAS_STDINT} eq "true";
 print "no\n" if $config{HAS_STDINT} eq "false";
 
 printf "Checking if strlcpy exists... ";
-# Perform the strlcpy() test..
-$config{HAS_STRLCPY} = "false";
-$fail = 0;
-open(STRLCPY, "</usr/include/string.h") or $fail = 1;
-if (!$fail) {
-	while (defined(my $line = <STRLCPY>)) {
-		chomp($line);
-		# try and find the delcaration of:
-		# size_t strlcpy(...)
-		if ($line =~ /size_t(\0x9|\s)+strlcpy/)	{
-			$config{HAS_STRLCPY} = "true";
-		}
-	}
-	close(STRLCPY);
-}
-print "yes\n" if $config{HAS_STRLCPY} eq "true";
-print "no\n" if $config{HAS_STRLCPY} eq "false";
+$config{HAS_STRLCPY} = test_compile('strlcpy');
+print $config{HAS_STRLCPY} ? "yes\n" : "no\n";
 
 printf "Checking if kqueue exists... ";
 $has_kqueue = test_compile('kqueue');

--- a/make/check_epoll.cpp
+++ b/make/check_epoll.cpp
@@ -1,6 +1,7 @@
 /*
  * InspIRCd -- Internet Relay Chat Daemon
  *
+ *   Copyright (C) 2009 Daniel De Graaf <danieldg@inspircd.org>
  *
  * This file is part of InspIRCd.  InspIRCd is free software: you can
  * redistribute it and/or modify it under the terms of the GNU General Public

--- a/make/check_eventfd.cpp
+++ b/make/check_eventfd.cpp
@@ -1,6 +1,8 @@
 /*
  * InspIRCd -- Internet Relay Chat Daemon
  *
+ *   Copyright (C) 2012 William Pitcock <nenolod@dereferenced.org>
+ *   Copyright (C) 2009-2010 Daniel De Graaf <danieldg@inspircd.org>
  *
  * This file is part of InspIRCd.  InspIRCd is free software: you can
  * redistribute it and/or modify it under the terms of the GNU General Public

--- a/make/check_kqueue.cpp
+++ b/make/check_kqueue.cpp
@@ -1,0 +1,26 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2015 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <sys/types.h>
+#include <sys/event.h>
+
+int main() {
+	int fd = kqueue();
+	return (fd < 0);
+}

--- a/make/check_stdint.cpp
+++ b/make/check_stdint.cpp
@@ -1,0 +1,25 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2015 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <stdint.h>
+
+int main() {
+	uint32_t ret = 0;
+	return ret;
+}

--- a/make/check_strlcpy.cpp
+++ b/make/check_strlcpy.cpp
@@ -1,0 +1,25 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2015 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <string.h>
+
+int main() {
+	char test[5];
+	strlcpy(test, "test", sizeof(test));
+}


### PR DESCRIPTION
Reported by @Adam- who has recently joined the OS X master race.

It seems like the newer OS X versions don't put headers into the system include directories. Switch to using a test file instead.

The test file was backported from 2.2.