### PR TITLE
Replace deprecated tmpnam() call

### DIFF
--- a/make/utilities.pm
+++ b/make/utilities.pm
@@ -32,6 +32,7 @@ use warnings FATAL => qw(all);
 use Exporter 'import';
 use Fcntl;
 use File::Path;
+use File::Temp;
 use Getopt::Long;
 use POSIX;
 
@@ -363,7 +364,7 @@ sub translate_functions($$)
 			my $tmpfile;
 			do
 			{
-				$tmpfile = tmpnam();
+				$tmpfile = File::Temp::tmpnam();
 			} until sysopen(TF, $tmpfile, O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW, 0700);
 			print "(Created and executed \e[1;32m$tmpfile\e[0m)\n";
 			print TF $1;


### PR DESCRIPTION
From Perl 5.22 onwards, POSIX::tmpnam() has been deprecated (without the
usual 2 year deprecation cycle), using the File::Temp module instead
preserves compatibility while allowing compilation on 5.22 and later.