### PR TITLE
Replace deprecated tmpnam() call

### DIFF
--- a/make/utilities.pm
+++ b/make/utilities.pm
@@ -29,6 +29,7 @@ use warnings FATAL => qw(all);
 
 use Exporter 'import';
 use POSIX;
+use File::Temp;
 use Getopt::Long;
 use Fcntl;
 our @EXPORT = qw(make_rpath pkgconfig_get_include_dirs pkgconfig_get_lib_dirs pkgconfig_check_version translate_functions promptstring);
@@ -404,7 +405,7 @@ sub translate_functions($$)
 			my $tmpfile;
 			do
 			{
-				$tmpfile = tmpnam();
+				$tmpfile = File::Temp::tmpnam();
 			} until sysopen(TF, $tmpfile, O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW, 0700);
 			print "(Created and executed \e[1;32m$tmpfile\e[0m)\n";
 			print TF $1;


### PR DESCRIPTION
From Perl 5.22 onwards, POSIX::tmpnam() has been deprecated (without the
usual 2 year deprecation cycle), using the File::Temp module instead
preserves compatibility while allowing compilation on 5.22 and later.

As it stands, Fedora Rawhide is failing like so:

Configuration failed. The following error occured:

Calling POSIX::tmpnam() is deprecated at make/utilities.pm line 407, line 32.