### PR TITLE
[2.0] Fix "make -jX debug install" causing linker errors.

### DIFF
--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -314,4 +314,6 @@ help:
 	@echo ' deinstall Removes the files created by "make install"'
 	@echo
 
+.NOTPARALLEL:
+
 .PHONY: all target debug debug-header mod-header mod-footer std-header finishmessage install clean deinstall squeakyclean configureclean help


### PR DESCRIPTION
The main makefile tries to parallelise things and does a debug and normal build at the same time which causes the linker to explode when it tries to link files from a debug and non debug build together. This patch makes it do one at a time which causes one of the builds to be a no-op.

This target is not propagated to the sub-makefile so it does not affect the parallelisation of the build. ~~The only thing it might slow down is the install target but thats so fast anyway it isn't a problem even on something ridiculously underpowered like a Raspberry Pi.~~ Edit: No it won't. I'm not sure why I thought it would.

This is a 2.0 fix only. I am working on something better than this for master.

Tested and working on both BSD Make 24 and GNU Make 3.81.