### PR TITLE
[2.0] Fix sending the wrong numerics on join when a topic is empty.

### DIFF
--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -412,7 +412,7 @@ Channel* Channel::ForceChan(Channel* Ptr, User* user, const std::string &privs, 
 
 	if (IS_LOCAL(user))
 	{
-		if (Ptr->topicset)
+		if (!Ptr->topic.empty())
 		{
 			user->WriteNumeric(RPL_TOPIC, "%s %s :%s", user->nick.c_str(), Ptr->name.c_str(), Ptr->topic.c_str());
 			user->WriteNumeric(RPL_TOPICTIME, "%s %s %s %lu", user->nick.c_str(), Ptr->name.c_str(), Ptr->setby.c_str(), (unsigned long)Ptr->topicset);


### PR DESCRIPTION
The `topicset` variable is the time the topic was changed last not whether there is a topic set.

Fixes #1091.