### PR TITLE
[2.0] Move RFC-compliant behaviour behind a config option.

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -614,7 +614,12 @@
          # welcomenotice: When turned on, this sends a NOTICE to connecting users
          # with the text Welcome to <networkname>! after successful registration.
          # Defaults to yes.
-         welcomenotice="yes">
+         welcomenotice="yes"
+
+         # emptytopiconjoin: This sends an empty topic to users on joining the
+         # channel when the topic has been unset. This is RFC-incompliant behaviour
+         # but exists for compatibility with previous 2.0 releases.
+         emptytopiconjoin="yes">
 
 
 #-#-#-#-#-#-#-#-#-#-#-# PERFORMANCE CONFIGURATION #-#-#-#-#-#-#-#-#-#-#

--- a/include/configreader.h
+++ b/include/configreader.h
@@ -587,6 +587,11 @@ class CoreExport ServerConfig
 	 * connecting users
 	 */
 	bool WelcomeNotice;
+
+	/** If true, send an empty topic when a topic has been unset when a user
+	 * joins the channel.
+	 */
+	bool EmptyTopicOnJoin;
 };
 
 /** The background thread for config reading, so that reading from executable includes

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -412,7 +412,8 @@ Channel* Channel::ForceChan(Channel* Ptr, User* user, const std::string &privs, 
 
 	if (IS_LOCAL(user))
 	{
-		if (!Ptr->topic.empty())
+		bool hasTopic = ServerInstance->Config->EmptyTopicOnJoin ? Ptr->topicset : !Ptr->topic.empty();
+		if (hasTopic)
 		{
 			user->WriteNumeric(RPL_TOPIC, "%s %s :%s", user->nick.c_str(), Ptr->name.c_str(), Ptr->topic.c_str());
 			user->WriteNumeric(RPL_TOPICTIME, "%s %s %s %lu", user->nick.c_str(), Ptr->name.c_str(), Ptr->setby.c_str(), (unsigned long)Ptr->topicset);

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -561,6 +561,7 @@ void ServerConfig::Fill()
 	InvBypassModes = options->getBool("invitebypassmodes", true);
 	NoSnoticeStack = options->getBool("nosnoticestack", false);
 	WelcomeNotice = options->getBool("welcomenotice", true);
+	EmptyTopicOnJoin = options->getBool("emptytopiconjoin", true);
 
 	range(SoftLimit, 10, ServerInstance->SE->GetMaxFds(), ServerInstance->SE->GetMaxFds(), "<performance:softlimit>");
 	if (ConfValue("performance")->getBool("limitsomaxconn", true))


### PR DESCRIPTION
Fixes the compatibility issue mentioned by @attilamolnar in #1092.