### PR TITLE
[2.0] Optionally do not notify users if their messages are blocked by certain modules.

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -370,7 +370,9 @@
 #
 # If hidemask is set to yes, the user will not be shown the mask when
 # his/her message is blocked.
-#<chanfilter hidemask="yes">
+# If notifyuser is set to no, the user will not be notified when
+# his/her message is blocked.
+#<chanfilter hidemask="yes" notifyuser="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Channel history module: Displays the last 'X' lines of chat to a user
@@ -761,7 +763,9 @@
 # stdlib - stdlib regexps, provided via m_regex_stdlib, see comment   #
 #          at the <module> tag for info on availability.              #
 #                                                                     #
-#<filteropts engine="glob">                                           #
+# If notifyuser is set to no, the user will not be notified when      #
+# his/her message is blocked.                                         #
+#<filteropts engine="glob" notifyuser="yes">
 #                                                                     #
 # Your choice of regex engine must match on all servers network-wide.
 #
@@ -1391,6 +1395,10 @@
 # Muteban: Implements extended ban 'm', which stops anyone matching
 # a mask like +b m:nick!user@host from speaking on channel.
 #<module name="m_muteban.so">
+#
+# If notifyuser is set to no, the user will not be notified when
+# his/her message is blocked.
+#<muteban notifyuser="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Random quote module: Provides a random quote on connect.

--- a/src/modules/m_chanfilter.cpp
+++ b/src/modules/m_chanfilter.cpp
@@ -70,6 +70,7 @@ class ModuleChanFilter : public Module
 {
 	ChanFilter cf;
 	bool hidemask;
+	bool notifyuser;
 
  public:
 
@@ -91,7 +92,9 @@ class ModuleChanFilter : public Module
 
 	virtual void OnRehash(User* user)
 	{
-		hidemask = ServerInstance->Config->ConfValue("chanfilter")->getBool("hidemask");
+		ConfigTag* tag = ServerInstance->Config->ConfValue("chanfilter");
+		hidemask = tag->getBool("hidemask");
+		notifyuser = tag->getBool("notifyuser", true);
 		cf.DoRehash();
 	}
 
@@ -110,6 +113,9 @@ class ModuleChanFilter : public Module
 			{
 				if (InspIRCd::Match(text, i->mask))
 				{
+					if (!notifyuser)
+						return MOD_RES_DENY;
+
 					if (hidemask)
 						user->WriteNumeric(404, "%s %s :Cannot send to channel (your message contained a censored word)",user->nick.c_str(), chan->name.c_str());
 					else

--- a/src/modules/m_muteban.cpp
+++ b/src/modules/m_muteban.cpp
@@ -49,6 +49,10 @@ class ModuleQuietBan : public Module
 		Channel* chan = static_cast<Channel*>(dest);
 		if (chan->GetExtBanStatus(user, 'm') == MOD_RES_DENY && chan->GetPrefixValue(user) < VOICE_VALUE)
 		{
+			bool notifyuser = ServerInstance->Config->ConfValue("muteban")->getBool("notifyuser", true);
+			if (!notifyuser)
+				return MOD_RES_DENY;
+
 			user->WriteNumeric(404, "%s %s :Cannot send to channel (you're muted)", user->nick.c_str(), chan->name.c_str());
 			return MOD_RES_DENY;
 		}


### PR DESCRIPTION
Optionally do not notify users if their messages are blocked by certain modules.

This fixes issue #711, although that issue only mentions m_filter, the m_chanfilter and m_muteban modules also needed this change.