### PR TITLE
[2.0] Generate a 2048-bit dhparams unless explicitly specified.

### DIFF
--- a/make/opensslcert.pm
+++ b/make/opensslcert.pm
@@ -46,6 +46,7 @@ sub make_openssl_cert()
 	my $state = promptstring_s('What state are you located in?', 'Example State');
 	my $country = promptstring_s('What is the ISO 3166-1 code for the country you are located in?', 'XZ');
 	my $time = promptstring_s('How many days do you want your certificate to be valid for?', '365');
+	my $use_1024 = promptstring_s('Do you want to generate less secure dhparams which are compatible with old versions of Java?', 'n');
 	print FH <<__END__;
 $country
 $state
@@ -56,8 +57,9 @@ $commonname
 $email
 __END__
 close(FH);
-system("cat openssl.template | openssl req -x509 -nodes -newkey rsa:1024 -keyout key.pem -out cert.pem -days $time 2>/dev/null");
-system("openssl dhparam -out dhparams.pem 1024");
+my $dhbits = $use_1024 =~ /^(1|on|true|yes|y)$/ ? 1024 : 2048;
+system("cat openssl.template | openssl req -x509 -nodes -newkey rsa:2048 -keyout key.pem -out cert.pem -days $time 2>/dev/null");
+system("openssl dhparam -out dhparams.pem $dhbits");
 unlink("openssl.template");
 }
 


### PR DESCRIPTION
The reason for this change is because a 1024-bit prime is feasibly factorable in a year by attackers with a large enough budget to do so.

This is a change in build system behaviour but it should not cause any problems although I have added a backwards compatibility switch just in case. In my opinion the aforementioned risk is big enough to justify this.

GnuTLS is not affected as it defaults to 2048-bit certificates by default.

References:
- https://freedom-to-tinker.com/blog/haldermanheninger/how-is-nsa-breaking-so-much-crypto/
- https://weakdh.org/imperfect-forward-secrecy-ccs15.pdf