### PR TITLE
[2.0] Fix CAP REQ to be atomic like the standard dictates.

### DIFF
--- a/src/modules/m_cap.cpp
+++ b/src/modules/m_cap.cpp
@@ -66,7 +66,12 @@ class CommandCAP : public Command
 
 			while (cap_stream.GetToken(cap_))
 			{
-				Data.wanted.push_back(cap_);
+				// Whilst the handling of extraneous spaces is not currently defined in the CAP specification
+				// every single other implementation ignores extraneous spaces. Lets copy them for
+				// compatibility purposes.
+				trim(cap_);
+				if (!cap_.empty())
+					Data.wanted.push_back(cap_);
 			}
 
 			reghold.set(user, 1);

--- a/src/modules/m_cap.h
+++ b/src/modules/m_cap.h
@@ -21,6 +21,8 @@
 #ifndef M_CAP_H
 #define M_CAP_H
 
+class GenericCap;
+
 class CapEvent : public Event
 {
  public:
@@ -35,6 +37,7 @@ class CapEvent : public Event
 	CapEventType type;
 	std::vector<std::string> wanted;
 	std::vector<std::string> ack;
+	std::vector<std::pair<GenericCap*, int> > changed; // HACK: clean this up before 2.2
 	User* user;
 	CapEvent(Module* sender, User* u, CapEventType capevtype) : Event(sender, "cap_request"), type(capevtype), user(u) {}
 };
@@ -67,7 +70,7 @@ class GenericCap
 					// we can handle this, so ACK it, and remove it from the wanted list
 					data->ack.push_back(*it);
 					data->wanted.erase(it);
-					ext.set(data->user, enablecap ? 1 : 0);
+					data->changed.push_back(std::make_pair(this, ext.set(data->user, enablecap ? 1 : 0)));
 					break;
 				}
 			}


### PR DESCRIPTION
[According to the cap-3.1 specification:](http://ircv3.net/specs/core/capability-negotiation-3.1.html)

>The capability identifier set must be accepted as a whole, or rejected entirely.

Our failure to follow the standard was apparently causing problems with irssi (according to @dequis).

This is a bit of a hack because I didn't want to have to rewrite the entire CAP API.