### PR TITLE
Replace deprecated POSIX::tmpnam() by File::Temp::tmpnam()

### DIFF
--- a/make/utilities.pm
+++ b/make/utilities.pm
@@ -33,7 +33,7 @@ use Exporter 'import';
 use Fcntl;
 use File::Path;
 use Getopt::Long;
-use POSIX;
+use File::Temp ();
 
 our @EXPORT = qw(make_rpath pkgconfig_get_include_dirs pkgconfig_get_lib_dirs pkgconfig_check_version translate_functions promptstring);
 
@@ -345,7 +345,7 @@ sub translate_functions($$)
 			my $tmpfile;
 			do
 			{
-				$tmpfile = tmpnam();
+				$tmpfile = File::Temp::tmpnam();
 			} until sysopen(TF, $tmpfile, O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW, 0700);
 			print "(Created and executed \e[1;32m$tmpfile\e[0m)\n";
 			print TF $1;


### PR DESCRIPTION
POSIX::tmpnam() seems to be deprecated since Perl 5.22, i propose to use File::Temp instead.
The only official link i've found about this deprecation is in https://metacpan.org/pod/distribution/perl/ext/POSIX/lib/POSIX.pod#FUNCTIONS.

The Debian reproducible build system catch this problem, see https://reproducible.debian.net/rbuild/unstable/amd64/inspircd_2.0.20-4.rbuild.log.