### PR TITLE
Optionally do not notify users if their messages are blocked by certain modules.

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -402,7 +402,10 @@
 # his/her message is blocked.
 #
 # If maxlen is set then it defines the maximum length of a filter entry.
-#<chanfilter hidemask="yes" maxlen="50">
+#
+# If notifyuser is set to no, the user will not be notified when
+# his/her message is blocked.
+#<chanfilter hidemask="yes" maxlen="50" notifyuser="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Channel history module: Displays the last 'X' lines of chat to a user
@@ -785,14 +788,16 @@
 # stdlib - stdlib regexps, provided via regex_stdlib, see comment     #
 #          at the <module> tag for info on availability.              #
 #                                                                     #
-#<filteropts engine="glob">                                           #
+# If notifyuser is set to no, the user will not be notified when      #
+# his/her message is blocked.                                         #
+#<filteropts engine="glob" notifyuser="yes">
 #                                                                     #
-# Your choice of regex engine must match on all servers network-wide.
-#
+# Your choice of regex engine must match on all servers network-wide. #
+#                                                                     #
 # To learn more about the configuration of this module, read          #
 # examples/filter.conf.example, which covers the various types of     #
 # filters and shows how to add exemptions.                            #
-#
+#                                                                     #
 #-#-#-#-#-#-#-#-#-#-#-  FILTER  CONFIGURATION  -#-#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #
 # Optional - If you specify to use the filter module, then            #
@@ -1536,6 +1541,10 @@
 # Muteban: Implements extended ban 'm', which stops anyone matching
 # a mask like +b m:nick!user@host from speaking on channel.
 #<module name="muteban">
+#
+# If notifyuser is set to no, the user will not be notified when
+# his/her message is blocked.
+#<muteban notifyuser="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Random quote module: Provides a random quote on connect.

--- a/src/modules/m_chanfilter.cpp
+++ b/src/modules/m_chanfilter.cpp
@@ -46,7 +46,7 @@ class ChanFilter : public ListModeBase
 
 	bool ValidateParam(User* user, Channel* chan, std::string& word) CXX11_OVERRIDE
 	{
-		if (word.length() > maxlen)	
+		if (word.length() > maxlen)
 		{
 			user->WriteNumeric(Numerics::InvalidModeParameter(chan, this, word, "Word is too long for the spamfilter list"));
 			return false;
@@ -76,6 +76,7 @@ class ModuleChanFilter : public Module
 	CheckExemption::EventProvider exemptionprov;
 	ChanFilter cf;
 	bool hidemask;
+	bool notifyuser;
 
  public:
 
@@ -90,6 +91,7 @@ class ModuleChanFilter : public Module
 		ConfigTag* tag = ServerInstance->Config->ConfValue("chanfilter");
 		hidemask = tag->getBool("hidemask");
 		cf.maxlen = tag->getUInt("maxlen", 35, 10, 100);
+		notifyuser = tag->getBool("notifyuser", true);
 		cf.DoRehash();
 	}
 
@@ -112,6 +114,12 @@ class ModuleChanFilter : public Module
 			{
 				if (InspIRCd::Match(details.text, i->mask))
 				{
+					if (!notifyuser)
+					{
+						details.echooriginal = true;
+						return MOD_RES_DENY;
+					}
+
 					if (hidemask)
 						user->WriteNumeric(ERR_CANNOTSENDTOCHAN, chan->name, "Cannot send to channel (your message contained a censored word)");
 					else

--- a/src/modules/m_muteban.cpp
+++ b/src/modules/m_muteban.cpp
@@ -36,6 +36,13 @@ class ModuleQuietBan : public Module
 		Channel* chan = target.Get<Channel>();
 		if (chan->GetExtBanStatus(user, 'm') == MOD_RES_DENY && chan->GetPrefixValue(user) < VOICE_VALUE)
 		{
+			bool notifyuser = ServerInstance->Config->ConfValue("muteban")->getBool("notifyuser", true);
+			if (!notifyuser)
+			{
+				details.echooriginal = true;
+				return MOD_RES_DENY;
+			}
+
 			user->WriteNumeric(ERR_CANNOTSENDTOCHAN, chan->name, "Cannot send to channel (you're muted)");
 			return MOD_RES_DENY;
 		}


### PR DESCRIPTION
Optionally do not notify users if their messages are blocked by certain modules.

This fixes issue #711, although that issue only mentions `filter`, the `chanfilter` and `muteban` modules also needed this change.

Ported to master as requested in #1096.
