### PR TITLE
Remove the STARTTLS token from ISUPPORT.

### DIFF
--- a/src/modules/m_starttls.cpp
+++ b/src/modules/m_starttls.cpp
@@ -102,11 +102,6 @@ class ModuleStartTLS : public Module
 			ssl.SetProvider("ssl/" + newprovider);
 	}
 
-	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
-	{
-		tokens["STARTTLS"];
-	}
-
 	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for the STARTTLS command", VF_VENDOR);


### PR DESCRIPTION
This is an InspIRCd-specific token which is pointless because:

1. You can't STARTTLS after registration is complete.
2. You can already discover STARTTLS support via cap `tls`.