### PR TITLE
Adds <commandlist> tag with command usage to httpd_stats.

### DIFF
--- a/src/modules/m_httpd_stats.cpp
+++ b/src/modules/m_httpd_stats.cpp
@@ -217,7 +217,15 @@ class ModuleHttpStats : public Module, public HTTPRequestEventListener
 					data << "</server>";
 				}
 
-				data << "</serverlist></inspircdstats>";
+				data << "</serverlist><commandlist>";
+
+				const CommandParser::CommandMap& commands = ServerInstance->Parser.GetCommands();
+				for (CommandParser::CommandMap::const_iterator i = commands.begin(); i != commands.end(); ++i)
+				{
+					data << "<command><name>" << i->second->name << "</name><usecount>" << i->second->use_count << "</usecount></command>";
+				}
+
+				data << "</commandlist></inspircdstats>";
 
 				/* Send the document back to m_httpd */
 				HTTPDocumentResponse response(this, *http, &data, 200);


### PR DESCRIPTION
This patch adds command usage to httpd_stats. It is useful for our network but not tested in production yet. This feels like it should be togglable by configuration though, rather than to be included by default. Or maybe it could be included on a substring match of the URI? (e.g. /stats/?includeCommandList)