### PR TITLE
Purge code for Windows XP and MSVC pre-2015.

### DIFF
--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -88,7 +88,7 @@ class DNSBLResolver : public DNS::Request
 		bool match = false;
 		in_addr resultip;
 
-		inet_aton(ans_record->rdata.c_str(), &resultip);
+		inet_pton(AF_INET, ans_record->rdata.c_str(), &resultip);
 
 		switch (ConfEntry->type)
 		{

--- a/src/modules/m_spanningtree/main.cpp
+++ b/src/modules/m_spanningtree/main.cpp
@@ -209,7 +209,7 @@ void ModuleSpanningTree::ConnectServer(Link* x, Autoconnect* y)
 	else
 	{
 		in_addr n;
-		if (inet_aton(x->IPAddr.c_str(),&n) < 1)
+		if (inet_pton(AF_INET, x->IPAddr.c_str(),&n) < 1)
 			ipvalid = false;
 	}
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -146,13 +146,13 @@ std::string irc::sockets::sockaddrs::addr() const
 	char addrv[INET6_ADDRSTRLEN+1];
 	if (sa.sa_family == AF_INET)
 	{
-		if (!inet_ntop(AF_INET, &in4.sin_addr, addrv, sizeof(addrv)))
+		if (!inet_ntop(AF_INET, (void*)&in4.sin_addr, addrv, sizeof(addrv)))
 			return "";
 		return addrv;
 	}
 	else if (sa.sa_family == AF_INET6)
 	{
-		if (!inet_ntop(AF_INET6, &in6.sin6_addr, addrv, sizeof(addrv)))
+		if (!inet_ntop(AF_INET6, (void*)&in6.sin6_addr, addrv, sizeof(addrv)))
 			return "";
 		return addrv;
 	}
@@ -171,14 +171,14 @@ std::string irc::sockets::sockaddrs::str() const
 	if (sa.sa_family == AF_INET)
 	{
 		char ipaddr[INET_ADDRSTRLEN];
-		inet_ntop(AF_INET, &in4.sin_addr, ipaddr, sizeof(ipaddr));
+		inet_ntop(AF_INET, (void*)&in4.sin_addr, ipaddr, sizeof(ipaddr));
 		return InspIRCd::Format("%s:%u", ipaddr, ntohs(in4.sin_port));
 	}
 
 	if (sa.sa_family == AF_INET6)
 	{
 		char ipaddr[INET6_ADDRSTRLEN];
-		inet_ntop(AF_INET6, &in6.sin6_addr, ipaddr, sizeof(ipaddr));
+		inet_ntop(AF_INET6, (void*)&in6.sin6_addr, ipaddr, sizeof(ipaddr));
 		return InspIRCd::Format("[%s]:%u", ipaddr, ntohs(in6.sin6_port));
 	}
 

--- a/win/README.txt
+++ b/win/README.txt
@@ -1,7 +1,7 @@
 Building InspIRCd for Windows:
 
 Prerequisites:
-	Visual Studio 2010 or newer (http://www.microsoft.com/visualstudio/eng/products/visual-studio-express-products)
+	Visual Studio 2015 or newer (https://www.visualstudio.com/)
 	CMake 2.8 or newer (http://www.cmake.org/)
 	If building the installer, NSIS http://nsis.sourceforge.net/
 

--- a/win/inspircd_win32wrapper.cpp
+++ b/win/inspircd_win32wrapper.cpp
@@ -30,66 +30,6 @@
 #include <errno.h>
 #include <assert.h>
 
-CoreExport const char *insp_inet_ntop(int af, const void *src, char *dst, socklen_t cnt)
-{
-
-	if (af == AF_INET)
-	{
-		struct sockaddr_in in;
-		memset(&in, 0, sizeof(in));
-		in.sin_family = AF_INET;
-		memcpy(&in.sin_addr, src, sizeof(struct in_addr));
-		if (getnameinfo((struct sockaddr *)&in, sizeof(struct sockaddr_in), dst, cnt, NULL, 0, NI_NUMERICHOST) == 0)
-			return dst;
-	}
-	else if (af == AF_INET6)
-	{
-		struct sockaddr_in6 in;
-		memset(&in, 0, sizeof(in));
-		in.sin6_family = AF_INET6;
-		memcpy(&in.sin6_addr, src, sizeof(struct in_addr6));
-		if (getnameinfo((struct sockaddr *)&in, sizeof(struct sockaddr_in6), dst, cnt, NULL, 0, NI_NUMERICHOST) == 0)
-			return dst;
-	}
-	return NULL;
-}
-
-CoreExport int insp_inet_pton(int af, const char *src, void *dst)
-{
-	int address_length;
-	sockaddr_storage sa;
-	sockaddr_in* sin = reinterpret_cast<sockaddr_in*>(&sa);
-	sockaddr_in6* sin6 = reinterpret_cast<sockaddr_in6*>(&sa);
-
-	switch (af)
-	{
-		case AF_INET:
-			address_length = sizeof(sockaddr_in);
-			break;
-		case AF_INET6:
-			address_length = sizeof(sockaddr_in6);
-			break;
-		default:
-			return -1;
-	}
-
-	if (!WSAStringToAddress(static_cast<LPSTR>(const_cast<char *>(src)), af, NULL, reinterpret_cast<LPSOCKADDR>(&sa), &address_length))
-	{
-		switch (af)
-		{
-			case AF_INET:
-				memcpy(dst, &sin->sin_addr, sizeof(in_addr));
-				break;
-			case AF_INET6:
-				memcpy(dst, &sin6->sin6_addr, sizeof(in6_addr));
-				break;
-		}
-		return 1;
-	}
-
-	return 0;
-}
-
 CoreExport DIR * opendir(const char * path)
 {
 	std::string search_path = std::string(path) + "\\*.*";

--- a/win/inspircd_win32wrapper.h
+++ b/win/inspircd_win32wrapper.h
@@ -87,42 +87,9 @@
 
 typedef int ssize_t;
 
-/* Convert formatted (xxx.xxx.xxx.xxx) string to in_addr struct */
-CoreExport int insp_inet_pton(int af, const char * src, void * dst);
-
-/* Convert struct to formatted (xxx.xxx.xxx.xxx) string */
-CoreExport const char * insp_inet_ntop(int af, const void * src, char * dst, socklen_t cnt);
-
-/* inet_pton/ntop require at least NT 6.0 */
-#define inet_pton insp_inet_pton
-#define inet_ntop insp_inet_ntop
-
-/* Safe printf functions aren't defined in VC++ releases older than v14 */
-#if _MSC_VER <= 1800
-#define snprintf _snprintf
-#define vsnprintf _vsnprintf
-#endif
-
-#ifndef va_copy
-#define va_copy(dest, src) (dest = src)
-#endif
-
-/* Unix-style sleep (argument is in seconds) */
-__inline void sleep(int seconds) { Sleep(seconds * 1000); }
-
 /* _popen, _pclose */
 #define popen _popen
 #define pclose _pclose
-
-/* _access */
-#define access _access
-
-/* IPV4 only convert string to address struct */
-__inline int inet_aton(const char *cp, struct in_addr *addr)
-{
-	addr->s_addr = inet_addr(cp);
-	return (addr->s_addr == INADDR_NONE) ? 0 : 1;
-};
 
 /* getopt() wrapper */
 #define no_argument            0
@@ -151,14 +118,6 @@ struct DIR
 	WIN32_FIND_DATAA find_data;
 	bool first;
 };
-
-#if _MSC_VER <= 1800
-struct timespec
-{
-	time_t tv_sec;
-	long tv_nsec;
-};
-#endif
 
 CoreExport DIR * opendir(const char * path);
 CoreExport dirent * readdir(DIR * handle);
@@ -193,12 +152,6 @@ CoreExport void closedir(DIR * handle);
 
 // warning C4706: assignment within conditional expression
 #pragma warning(disable:4706)
-
-// warning C4355: 'this' : used in base member initializer list
-// This warning is disabled by default since VC2012
-#if _MSC_VER < 1700
-#pragma warning(disable:4355)
-#endif
 
 /* Shared memory allocation functions */
 void * ::operator new(size_t iSize);


### PR DESCRIPTION
I think it is safe to say that nobody should be using XP to host an IRC server, especially now that GnuTLS doesn't support XP anymore.

This pull request also bumps the minimum Visual Studio version to 2015 which removes a massive chunk of code now that Microsoft have decided to follow standards. This should not be a problem as the free community edition can be downloaded at https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx
