### PR TITLE
Minor spelling errors in m_spanningtree.so

### DIFF
--- a/src/modules/m_spanningtree/fjoin.cpp
+++ b/src/modules/m_spanningtree/fjoin.cpp
@@ -201,7 +201,7 @@ CmdResult CommandFJoin::Handle(const std::vector<std::string>& params, User *src
 			}
 			else
 			{
-				ServerInstance->Logs->Log("m_spanningtree",SPARSE, "Ignored nonexistant user %s in fjoin to %s (probably quit?)", usr, channel.c_str());
+				ServerInstance->Logs->Log("m_spanningtree",SPARSE, "Ignored nonexistent user %s in fjoin to %s (probably quit?)", usr, channel.c_str());
 				continue;
 			}
 		}

--- a/src/modules/m_spanningtree/postcommand.cpp
+++ b/src/modules/m_spanningtree/postcommand.cpp
@@ -73,7 +73,7 @@ void SpanningTreeUtilities::RouteCommand(TreeServer* origin, const std::string &
 		TreeServer* sdest = FindServer(routing.serverdest);
 		if (!sdest)
 		{
-			ServerInstance->Logs->Log("m_spanningtree",DEFAULT,"Trying to route ENCAP to nonexistant server %s",
+			ServerInstance->Logs->Log("m_spanningtree",DEFAULT,"Trying to route ENCAP to nonexistent server %s",
 				routing.serverdest.c_str());
 			return;
 		}


### PR DESCRIPTION
[Lintian](https://lintian.debian.org/) Debian packaging helper tool [report](https://lintian.debian.org/full/pkg-irc-maintainers@lists.alioth.debian.org.html#inspircd) some minor spelling error for printed message in module m_spanningtree.so. It's minor, but i'll be glad if included in future 2.0.x to drop this packaging minor patches in future Debian packages. Thanks.