### PR TITLE
Adds classban module providing extban 'n' for connect class ban.

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -467,6 +467,13 @@
 # This module is oper-only.
 # To use, CHGNAME must be in one of your oper class blocks.
 #<module name="chgname">
+#
+#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
+# Connection class ban module: Adds support for extban 'n' which 
+# matches against the class name of the user's connection.
+# This module assumes that connection classes are named in a uniform
+# way on all servers of the network.
+#<module name="classban">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Clear chan module: Allows opers to masskick, masskill or mass-G/ZLine

--- a/src/modules/m_classban.cpp
+++ b/src/modules/m_classban.cpp
@@ -1,0 +1,47 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2016 Johanna Abrahamsson <johanna-a@mjao.org>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+
+class ModuleClassBan : public Module
+{
+ public:
+	ModResult OnCheckBan(User* user, Channel* c, const std::string& mask) CXX11_OVERRIDE
+	{
+		LocalUser* localUser = IS_LOCAL(user);
+		if ((localUser) && (mask.length() > 2) && (mask[0] == 'n') && (mask[1] == ':'))
+		{
+			if (InspIRCd::Match(localUser->GetClass()->name, mask.substr(2)))
+				return MOD_RES_DENY;
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
+	{
+		tokens["EXTBAN"].push_back('n');
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Class 'n' - Connection class ban", VF_VENDOR | VF_OPTCOMMON);
+	}
+};
+
+MODULE_INIT(ModuleClassBan)


### PR DESCRIPTION
This adds a module, connameban, that provides extban token 'n' that matches the mask against the users ->GetClass()->name.
This is not yet tested in production.

The IS_LOCAL() should work in all cases that are contained in master, since in those cases only local users are handled. Changing the signature of OnCheckBan to take a LocalUser* instead of a User* could make sense.

If not, I guess adding some sort of handling of the case where the user is not local would be necessary in this module, I'm not sure how to get that information across server nodes though.