### PR TITLE
Improvements to ./configure file generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,17 +5,12 @@
 .*
 !.git*
 
+/.configure
 /BSDmakefile
 /GNUmakefile
 /build
 /docs/doxygen
-/inspircd
-/inspircd.1
-/inspircd-genssl.1
-/inspircd.service
-/org.inspircd.plist
 /run
-/bin
 
 /include/config.h
 

--- a/make/common.pm
+++ b/make/common.pm
@@ -28,11 +28,21 @@ use strict;
 use warnings FATAL => qw(all);
 
 use Exporter              qw(import);
+use File::Path            qw(mkpath);
 use File::Spec::Functions qw(rel2abs);
 
-our @EXPORT = qw(get_cpu_count
+our @EXPORT = qw(create_directory
+                 get_cpu_count
                  get_version
                  module_installed);
+
+sub create_directory($$) {
+	my ($location, $permissions) = @_;
+	return eval {
+		mkpath($location, 0, $permissions);
+		return 1;
+	} // 0;
+}
 
 sub get_version {
 	state %version;

--- a/make/configure.pm
+++ b/make/configure.pm
@@ -419,7 +419,7 @@ sub parse_templates($$$) {
 
 				# Write the template file.
 				print_format "Writing <|GREEN $target|> ...\n";
-				open(TARGET, '>', $target) or print_error "unable to write $_: $!";
+				open(TARGET, '>', $target) or print_error "unable to write $target: $!";
 				foreach (@final_lines) {
 					say TARGET $_;
 				}

--- a/make/configure.pm
+++ b/make/configure.pm
@@ -220,7 +220,7 @@ sub read_configure_cache {
 	open(CACHE, CONFIGURE_CACHE_FILE) or return %config;
 	while (my $line = <CACHE>) {
 		next if $line =~ /^\s*($|\#)/;
-		my ($key, $value) = ($line =~ /^(\S+)="(.*)"$/);
+		my ($key, $value) = ($line =~ /^(\S+)(?:\s(.+))?$/);
 		$config{$key} = $value;
 	}
 	close(CACHE);
@@ -238,7 +238,7 @@ sub write_configure_cache(%) {
 	open(CACHE, '>', CONFIGURE_CACHE_FILE) or print_error "unable to write ${\CONFIGURE_CACHE_FILE}: $!";
 	while (my ($key, $value) = each %config) {
 		$value //= '';
-		say CACHE "$key=\"$value\"";
+		say CACHE "$key $value";
 	}
 	close(CACHE);
 }

--- a/make/configure.pm
+++ b/make/configure.pm
@@ -41,7 +41,7 @@ use make::console;
 use make::utilities;
 
 use constant CONFIGURE_DIRECTORY     => '.configure';
-use constant CONFIGURE_CACHE_FILE    => '.configure.cache';
+use constant CONFIGURE_CACHE_FILE    => catfile(CONFIGURE_DIRECTORY, 'cache.cfg');
 use constant CONFIGURE_CACHE_VERSION => '1';
 
 our @EXPORT = qw(CONFIGURE_CACHE_FILE
@@ -228,6 +228,11 @@ sub read_configure_cache {
 }
 
 sub write_configure_cache(%) {
+	unless (-e CONFIGURE_DIRECTORY) {
+		print_format "Creating <|GREEN ${\CONFIGURE_DIRECTORY}|> ...\n";
+		create_directory CONFIGURE_DIRECTORY, 0750 or print_error "unable to create ${\CONFIGURE_DIRECTORY}: $!";
+	}
+
 	print_format "Writing <|GREEN ${\CONFIGURE_CACHE_FILE}|> ...\n";
 	my %config = @_;
 	open(CACHE, '>', CONFIGURE_CACHE_FILE) or print_error "unable to write ${\CONFIGURE_CACHE_FILE}: $!";

--- a/make/console.pm
+++ b/make/console.pm
@@ -88,12 +88,8 @@ sub prompt_dir($$$;$) {
 		$answer = rel2abs(prompt_string($interactive, $question, $default));
 		$create = prompt_bool($interactive && !-d $answer, "$answer does not exist. Create it?", 'y');
 		if ($create && $create_now) {
-			my $mkpath = eval {
-				mkpath($answer, 0, 0750);
-				return 1;
-			};
-			unless (defined $mkpath) {
-				print_warning "unable to create $answer!\n";
+			unless (create_directory $answer, 0750) {
+				print_warning "unable to create $answer: $!\n";
 				$create = 0;
 			}
 		}

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -229,16 +229,16 @@ install: target
 @IFNDEF PURE_STATIC
 	[ $(BUILDPATH)/modules/ -ef $(MODPATH) ] || $(INSTALL) -m $(INSTMODE_LIB) $(BUILDPATH)/modules/*.so $(MODPATH)
 @ENDIF
-	-$(INSTALL) -m $(INSTMODE_BIN) inspircd $(BASE) 2>/dev/null
+	-$(INSTALL) -m $(INSTMODE_BIN) @CONFIGURE_DIRECTORY@/inspircd $(BASE) 2>/dev/null
 	-$(INSTALL) -m $(INSTMODE_LIB) .gdbargs $(BASE)/.gdbargs 2>/dev/null
 @IFEQ $(SYSTEM) darwin
-	-$(INSTALL) -m $(INSTMODE_BIN) org.inspircd.plist $(BASE) 2>/dev/null
+	-$(INSTALL) -m $(INSTMODE_BIN) @CONFIGURE_DIRECTORY@/org.inspircd.plist $(BASE) 2>/dev/null
 @ENDIF
 @IFEQ $(SYSTEM) linux
-	-$(INSTALL) -m $(INSTMODE_LIB) inspircd.service $(BASE) 2>/dev/null
+	-$(INSTALL) -m $(INSTMODE_LIB) @CONFIGURE_DIRECTORY@/inspircd.service $(BASE) 2>/dev/null
 @ENDIF
-	-$(INSTALL) -m $(INSTMODE_LIB) inspircd.1 $(MANPATH) 2>/dev/null
-	-$(INSTALL) -m $(INSTMODE_LIB) inspircd-genssl.1 $(MANPATH) 2>/dev/null
+	-$(INSTALL) -m $(INSTMODE_LIB) @CONFIGURE_DIRECTORY@/inspircd.1 $(MANPATH) 2>/dev/null
+	-$(INSTALL) -m $(INSTMODE_LIB) @CONFIGURE_DIRECTORY@/inspircd-genssl.1 $(MANPATH) 2>/dev/null
 	-$(INSTALL) -m $(INSTMODE_BIN) tools/genssl $(BINPATH)/inspircd-genssl 2>/dev/null
 	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/*.example $(CONPATH)/examples
 	-$(INSTALL) -m $(INSTMODE_LIB) *.pem $(CONPATH) 2>/dev/null


### PR DESCRIPTION
## Extract directory creation code to its own subroutine.

This is needed in a later commit so I extracted it to a helper method to reduce duplication.

## Fix a typo in parse_templates.

An error message was using the context variable rather than the target file variable.

## Write generated templates to the .configure directory.

Instead of polluting the root directory generated files that do not have a specific location to go in are now put in the .configure directory.

## Move the configure cache to the .configure directory too.

Same as the previous but for the configure cache file.

## Simplify the configure cache file format.

Previously the configuration file parser would break if a value contained a double quote symbol.  The format has been simplified to just `<name> [value...]` to avoid needing to escape these. 