### PR TITLE
[2.0] Delete modules cautiously when doing a deinstall.

### DIFF
--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -267,7 +267,8 @@ clean:
 deinstall:
 	-rm -f $(BINPATH)/inspircd
 	-rm -rf $(CONPATH)/examples
-	-rm -f $(MODPATH)/*.so
+	-rm -f $(MODPATH)/cmd_*.so
+	-rm -f $(MODPATH)/m_*.so
 	-rm -f $(BASE)/.gdbargs
 	-rm -f $(BASE)/org.inspircd.plist
 

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -220,22 +220,22 @@ install: target
 		echo ""; \
 		exit 1; \
 	fi
-	@-$(INSTALL) -d -o $(INSTUID) -m $(INSTMODE_DIR) "$(BASE)"
-	@-$(INSTALL) -d -o $(INSTUID) -m $(INSTMODE_DIR) "$(DATPATH)"
-	@-$(INSTALL) -d -o $(INSTUID) -m $(INSTMODE_DIR) "$(LOGPATH)"
-	@-$(INSTALL) -d -m $(INSTMODE_DIR) "$(BINPATH)"
-	@-$(INSTALL) -d -m $(INSTMODE_DIR) "$(CONPATH)/examples/aliases"
-	@-$(INSTALL) -d -m $(INSTMODE_DIR) "$(CONPATH)/examples/modules"
-	@-$(INSTALL) -d -m $(INSTMODE_DIR) "$(MODPATH)"
-	[ "$(BUILDPATH)/bin/" -ef "$(BINPATH)" ] || $(INSTALL) -m $(INSTMODE_BIN) "$(BUILDPATH)/bin/inspircd" "$(BINPATH)"
+	@-$(INSTALL) -d -o $(INSTUID) -m $(INSTMODE_DIR) $(BASE)
+	@-$(INSTALL) -d -o $(INSTUID) -m $(INSTMODE_DIR) $(DATPATH)
+	@-$(INSTALL) -d -o $(INSTUID) -m $(INSTMODE_DIR) $(LOGPATH)
+	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(BINPATH)
+	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(CONPATH)/examples/aliases
+	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(CONPATH)/examples/modules
+	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(MODPATH)"
+	[ "$(BUILDPATH)/bin/" -ef $(BINPATH) ] || $(INSTALL) -m $(INSTMODE_BIN) "$(BUILDPATH)/bin/inspircd" $(BINPATH)
 @IFNDEF PURE_STATIC
-	[ "$(BUILDPATH)/modules/" -ef "$(MODPATH)" ] || $(INSTALL) -m $(INSTMODE_LIB) "$(BUILDPATH)/modules/"*.so "$(MODPATH)"
+	[ "$(BUILDPATH)/modules/" -ef $(MODPATH) ] || $(INSTALL) -m $(INSTMODE_LIB) "$(BUILDPATH)/modules/"*.so $(MODPATH)
 @ENDIF
-	-$(INSTALL) -m $(INSTMODE_BIN) @STARTSCRIPT@ "$(BASE)" 2>/dev/null
-	-$(INSTALL) -m $(INSTMODE_LIB) tools/gdbargs "$(BASE)/.gdbargs" 2>/dev/null
-	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/*.example "$(CONPATH)/examples"
-	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/aliases/*.example "$(CONPATH)/examples/aliases"
-	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/modules/*.example "$(CONPATH)/examples/modules"
+	-$(INSTALL) -m $(INSTMODE_BIN) @STARTSCRIPT@ $(BASE) 2>/dev/null
+	-$(INSTALL) -m $(INSTMODE_LIB) tools/gdbargs $(BASE)/.gdbargs 2>/dev/null
+	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/*.example $(CONPATH)/examples
+	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/aliases/*.example $(CONPATH)/examples/aliases
+	-$(INSTALL) -m $(INSTMODE_LIB) docs/conf/modules/*.example $(CONPATH)/examples/modules
 	@echo ""
 	@echo "*************************************"
 	@echo "*        INSTALL COMPLETE!          *"
@@ -265,11 +265,11 @@ clean:
 	@echo Completed.
 
 deinstall:
-	-rm -f "$(BINPATH)/inspircd"
-	-rm -rf "$(CONPATH)/examples"
-	-rm -f "$(MODPATH)/*.so"
-	-rm -f "$(BASE)/.gdbargs"
-	-rm -f "$(BASE)/org.inspircd.plist"
+	-rm -f $(BINPATH)/inspircd
+	-rm -rf $(CONPATH)/examples
+	-rm -f $(MODPATH)/*.so
+	-rm -f $(BASE)/.gdbargs
+	-rm -f $(BASE)/org.inspircd.plist
 
 squeakyclean: distclean
 


### PR DESCRIPTION
This will not affect 99% of users but its good to be sure just in case the user tries to dump module files into a global library directory.