### PR TITLE
Rename vague build environment variables to prevent collisions.

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -1235,7 +1235,7 @@ class CoreExport ModuleManager : public fakederef<ModuleManager>
 #define MODULE_INIT_SYM_FN_2(x,y) MODULE_INIT_SYM_FN_1(x,y)
 #define MODULE_INIT_SYM_FN_1(x,y) inspircd_module_ ## x ## _ ## y
 
-#ifdef PURE_STATIC
+#ifdef INSPIRCD_STATIC
 
 struct AllCommandList {
 	typedef Command* (*fn)(Module*);

--- a/make/calcdep.pl
+++ b/make/calcdep.pl
@@ -57,7 +57,7 @@ sub run() {
 	open MAKE, '>real.mk' or die "Could not write real.mk: $!";
 	chdir "${\SOURCEPATH}/src";
 
-	if ($ENV{PURE_STATIC}) {
+	if ($ENV{INSPIRCD_STATIC}) {
 		run_static();
 	} else {
 		run_dynamic();

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -143,10 +143,10 @@ TARGET = all
     @TARGET GNU_MAKE TARGET = modules/$(M:.so=).so
 @ENDIF
 
-@IFDEF T
+@IFDEF INSPIRCD_TARGET
     HEADER =
     FOOTER = target
-    TARGET = $(T)
+    TARGET = $(INSPIRCD_TARGET)
 @ENDIF
 
 @IFEQ $(DBGOK) 0
@@ -314,9 +314,9 @@ help:
 	@echo ' debug     Compile a debug build. Equivalent to "make D=1 all"'
 	@echo ''
 	@echo ' M=m_foo   Builds a single module (cmd_foo also works here)'
-	@echo ' T=target  Builds a user-specified target, such as "inspircd" or "modules"'
-	@echo '           Other targets are specified by their path in the build directory'
-	@echo '           Multiple targets may be separated by a space'
+	@echo ' INSPIRCD_TARGET=target  Builds a user-specified target, such as "inspircd" or "modules"'
+	@echo '                         Other targets are specified by their path in the build directory'
+	@echo '                         Multiple targets may be separated by a space'
 	@echo ''
 	@echo ' clean     Cleans object files produced by the compile'
 	@echo ' distclean Cleans all generated files (build, configure, run, etc)'

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -114,7 +114,7 @@ FOOTER = finishmessage
 @TARGET GNU_MAKE SOURCEPATH = $(shell /bin/pwd)
 @TARGET BSD_MAKE SOURCEPATH != /bin/pwd
 
-@IFDEF V
+@IFDEF INSPIRCD_VERBOSE
   VERBOSE = -v
 @ELSE
   @TARGET GNU_MAKE MAKEFLAGS += --silent
@@ -301,11 +301,11 @@ help:
 	@echo 'Use: ${MAKE} [flags] [targets]'
 	@echo ''
 	@echo 'Flags:'
-	@echo ' V=1       Show the full command being executed instead of "BUILD: dns.cpp"'
+	@echo ' INSPIRCD_VERBOSE=1  Show the full command being executed instead of "BUILD: dns.cpp"'
 	@echo ' D=1       Enable debug build, for module development or crash tracing'
 	@echo ' D=2       Enable debug build with optimizations, for detailed backtraces'
-	@echo ' DESTDIR=  Specify a destination root directory (for tarball creation)'
-	@echo ' -j <N>    Run a parallel build using N jobs'
+	@echo ' DESTDIR=            Specify a destination root directory (for tarball creation)'
+	@echo ' -j <N>              Run a parallel build using N jobs'
 	@echo ''
 	@echo 'Targets:'
 	@echo ' all       Complete build of InspIRCd, without installing (default)'

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -84,12 +84,12 @@ INSTMODE_LIB = 0640
   PICLDFLAGS = -fPIC -shared -twolevel_namespace -undefined dynamic_lookup $(LDFLAGS)
 @ENDIF
 
-@IFNDEF D
-  D=0
+@IFNDEF INSPIRCD_DEBUG
+  INSPIRCD_DEBUG=0
 @ENDIF
 
 DBGOK=0
-@IFEQ $(D) 0
+@IFEQ $(INSPIRCD_DEBUG) 0
   CORECXXFLAGS += -fno-rtti -O2
 @IFEQ $(COMPILER) GCC
     CORECXXFLAGS += -g1
@@ -97,12 +97,12 @@ DBGOK=0
   HEADER = std-header
   DBGOK=1
 @ENDIF
-@IFEQ $(D) 1
+@IFEQ $(INSPIRCD_DEBUG) 1
   CORECXXFLAGS += -O0 -g3 -Werror -DINSPIRCD_ENABLE_RTTI
   HEADER = debug-header
   DBGOK=1
 @ENDIF
-@IFEQ $(D) 2
+@IFEQ $(INSPIRCD_DEBUG) 2
   CORECXXFLAGS += -fno-rtti -O2 -g3
   HEADER = debug-header
   DBGOK=1
@@ -160,7 +160,7 @@ target: $(HEADER)
 	cd $(BUILDPATH); $(MAKEENV) $(MAKE) -f real.mk $(TARGET)
 
 debug:
-	@${MAKE} D=1 all
+	@${MAKE} INSPIRCD_DEBUG=1 all
 
 debug-header:
 	@echo "*************************************"
@@ -302,8 +302,8 @@ help:
 	@echo ''
 	@echo 'Flags:'
 	@echo ' INSPIRCD_VERBOSE=1  Show the full command being executed instead of "BUILD: dns.cpp"'
-	@echo ' D=1       Enable debug build, for module development or crash tracing'
-	@echo ' D=2       Enable debug build with optimizations, for detailed backtraces'
+	@echo ' INSPIRCD_DEBUG=1    Enable debug build, for module development or crash tracing'
+	@echo ' INSPIRCD_DEBUG=2    Enable debug build with optimizations, for detailed backtraces'
 	@echo ' DESTDIR=            Specify a destination root directory (for tarball creation)'
 	@echo ' -j <N>              Run a parallel build using N jobs'
 	@echo ''

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -136,11 +136,11 @@ CORECXXFLAGS += $(CXXFLAGS)
 # Default target
 TARGET = all
 
-@IFDEF M
+@IFDEF INSPIRCD_MODULE
     HEADER = mod-header
     FOOTER = mod-footer
-    @TARGET BSD_MAKE TARGET = modules/${M:S/.so$//}.so
-    @TARGET GNU_MAKE TARGET = modules/$(M:.so=).so
+    @TARGET BSD_MAKE TARGET = modules/${INSPIRCD_MODULE:S/.so$//}.so
+    @TARGET GNU_MAKE TARGET = modules/$(INSPIRCD_MODULE:.so=).so
 @ENDIF
 
 @IFDEF INSPIRCD_TARGET
@@ -313,7 +313,7 @@ help:
 	@echo '           Currently installs to ${BASE}'
 	@echo ' debug     Compile a debug build. Equivalent to "make D=1 all"'
 	@echo ''
-	@echo ' M=m_foo   Builds a single module (cmd_foo also works here)'
+	@echo ' INSPIRCD_MODULE=m_foo   Builds a single module (core_foo also works here)'
 	@echo ' INSPIRCD_TARGET=target  Builds a user-specified target, such as "inspircd" or "modules"'
 	@echo '                         Other targets are specified by their path in the build directory'
 	@echo '                         Multiple targets may be separated by a space'

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -122,8 +122,8 @@ FOOTER = finishmessage
   VERBOSE =
 @ENDIF
 
-@IFDEF PURE_STATIC
-  CORECXXFLAGS += -DPURE_STATIC
+@IFDEF INSPIRCD_STATIC
+  CORECXXFLAGS += -DINSPIRCD_STATIC
 @ENDIF
 
 # Add the users CXXFLAGS to the base ones to allow them to override
@@ -131,7 +131,7 @@ FOOTER = finishmessage
 CORECXXFLAGS += $(CXXFLAGS)
 
 @DO_EXPORT CXX CORECXXFLAGS LDLIBS PICLDFLAGS VERBOSE SOCKETENGINE CORELDFLAGS
-@DO_EXPORT SOURCEPATH BUILDPATH PURE_STATIC
+@DO_EXPORT SOURCEPATH BUILDPATH INSPIRCD_STATIC
 
 # Default target
 TARGET = all
@@ -177,7 +177,7 @@ debug-header:
 	@echo "*************************************"
 
 mod-header:
-@IFDEF PURE_STATIC
+@IFDEF INSPIRCD_STATIC
 	@echo 'Cannot build single modules in pure-static build'
 	@exit 1
 @ENDIF
@@ -226,7 +226,7 @@ install: target
 	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(MANPATH)
 	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(MODPATH)
 	[ $(BUILDPATH)/bin/ -ef $(BINPATH) ] || $(INSTALL) -m $(INSTMODE_BIN) $(BUILDPATH)/bin/inspircd $(BINPATH)
-@IFNDEF PURE_STATIC
+@IFNDEF INSPIRCD_STATIC
 	[ $(BUILDPATH)/modules/ -ef $(MODPATH) ] || $(INSTALL) -m $(INSTMODE_LIB) $(BUILDPATH)/modules/*.so $(MODPATH)
 @ENDIF
 	-$(INSTALL) -m $(INSTMODE_BIN) @CONFIGURE_DIRECTORY@/inspircd $(BASE) 2>/dev/null

--- a/src/coremods/core_info/cmd_modules.cpp
+++ b/src/coremods/core_info/cmd_modules.cpp
@@ -64,7 +64,7 @@ CmdResult CommandModules::Handle (const std::vector<std::string>& parameters, Us
 				if (!(V.Flags & mult))
 					flags[pos] = '-';
 
-#ifdef PURE_STATIC
+#ifdef INSPIRCD_STATIC
 			user->WriteRemoteNumeric(702, InspIRCd::Format("%s %s :%s", m->ModuleSourceFile.c_str(), flags.c_str(), V.description.c_str()));
 #else
 			std::string srcrev = m->ModuleDLLManager->GetVersion();

--- a/src/modmanager_dynamic.cpp
+++ b/src/modmanager_dynamic.cpp
@@ -25,7 +25,7 @@
 #include <dirent.h>
 #endif
 
-#ifndef PURE_STATIC
+#ifndef INSPIRCD_STATIC
 
 bool ModuleManager::Load(const std::string& modname, bool defer)
 {

--- a/src/modmanager_static.cpp
+++ b/src/modmanager_static.cpp
@@ -23,7 +23,7 @@
 #include "exitcodes.h"
 #include <iostream>
 
-#ifdef PURE_STATIC
+#ifdef INSPIRCD_STATIC
 
 typedef std::map<std::string, AllModuleList*> modmap;
 static std::vector<AllCommandList::fn>* cmdlist = NULL;

--- a/tools/test-build
+++ b/tools/test-build
@@ -33,7 +33,7 @@ use warnings FATAL => qw(all);
 use make::common;
 use make::configure;
 
-$ENV{D} = $ENV{V} = 1;
+$ENV{D} = $ENV{INSPIRCD_VERBOSE} = 1;
 
 system 'git', 'clean', '-dfx';
 

--- a/tools/test-build
+++ b/tools/test-build
@@ -33,7 +33,7 @@ use warnings FATAL => qw(all);
 use make::common;
 use make::configure;
 
-$ENV{D} = $ENV{INSPIRCD_VERBOSE} = 1;
+$ENV{INSPIRCD_DEBUG} = $ENV{INSPIRCD_VERBOSE} = 1;
 
 system 'git', 'clean', '-dfx';
 

--- a/tools/test-build
+++ b/tools/test-build
@@ -56,12 +56,12 @@ foreach my $compiler (@compilers) {
 			say "Failed to configure using the $compiler compiler and the $socketengine socket engine!";
 			exit 1;
 		}
-		$ENV{PURE_STATIC} = 1;
+		$ENV{INSPIRCD_STATIC} = 1;
 		if (system 'make', '-j'.get_cpu_count, 'install') {
 			say "Failed to compile with static modules using the $compiler compiler and the $socketengine socket engine!";
 			exit 1;
 		}
-		delete $ENV{PURE_STATIC};
+		delete $ENV{INSPIRCD_STATIC};
 		if (system 'make', '-j'.get_cpu_count, 'install') {
 			say "Failed to compile with dynamic modules using the $compiler compiler and the $socketengine socket engine!";
 			exit 1;


### PR DESCRIPTION
This implements the idea I said I would implement in #1009 for the user facing variables. The rest will be changed at a later date.

Jenkins might need some updates after this, cc @tobgen.