### PR TITLE
[2.0] Fix extraneous quotes in makefile template.

### DIFF
--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -226,7 +226,7 @@ install: target
 	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(BINPATH)
 	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(CONPATH)/examples/aliases
 	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(CONPATH)/examples/modules
-	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(MODPATH)"
+	@-$(INSTALL) -d -m $(INSTMODE_DIR) $(MODPATH)
 	[ "$(BUILDPATH)/bin/" -ef $(BINPATH) ] || $(INSTALL) -m $(INSTMODE_BIN) "$(BUILDPATH)/bin/inspircd" $(BINPATH)
 @IFNDEF PURE_STATIC
 	[ "$(BUILDPATH)/modules/" -ef $(MODPATH) ] || $(INSTALL) -m $(INSTMODE_LIB) "$(BUILDPATH)/modules/"*.so $(MODPATH)


### PR DESCRIPTION
I have no idea how this happened considering that everything was green when I pushed it to Jenkins. I guess that Jenkins is just doing `make` instead of `make install`? Blah.

Thanks to @Robby- for reporting this.