### PR TITLE
Add configuration for building with Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+compiler:
+  - "clang"
+  - "gcc"
+language: "cpp"
+notifications:
+  email: false
+os:
+  - "linux"
+  - "osx"
+script:
+  - "sh ./tools/travis-ci.sh"
+sudo: required

--- a/tools/travis-ci.sh
+++ b/tools/travis-ci.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -v
+if [ "$TRAVIS_OS_NAME" = "linux" ]
+then
+	sudo apt-get update --assume-yes
+	sudo apt-get install --assume-yes libgeoip-dev libgnutls-dev libldap2-dev libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtre-dev
+elif [ "$TRAVIS_OS_NAME" = "osx" ]
+then
+	brew update
+	brew install geoip gnutls mysql-connector-c openssl pcre postgresql sqlite3 tre
+else
+	>&2 echo "'$TRAVIS_OS_NAME' is an unknown Travis CI environment!"
+	exit 1
+fi
+set -e
+./configure --enable-extras=m_geoip.cpp,m_ldapauth.cpp,m_ldapoper.cpp,m_mysql.cpp,m_pgsql.cpp,m_regex_pcre.cpp,m_regex_posix.cpp,m_regex_tre.cpp,m_sqlite3.cpp,m_ssl_gnutls.cpp,m_ssl_openssl.cpp
+./configure --with-cc=$CXX
+make -j4 install
+./run/bin/inspircd --version


### PR DESCRIPTION
`travis-ci.sh` is only needed for insp20. On master the script can just use "./tools/test-build $CXX".