### PR TITLE
Replace snprintf usage with InspIRCd::Format.

### DIFF
--- a/src/coremods/core_stats.cpp
+++ b/src/coremods/core_stats.cpp
@@ -232,17 +232,11 @@ void CommandStats::DoStats(Stats::Context& stats)
 			stats.AddRow(249, "Commands: "+ConvToStr(ServerInstance->Parser.GetCommands().size()));
 
 			float kbitpersec_in, kbitpersec_out, kbitpersec_total;
-			char kbitpersec_in_s[30], kbitpersec_out_s[30], kbitpersec_total_s[30];
-
 			SocketEngine::GetStats().GetBandwidth(kbitpersec_in, kbitpersec_out, kbitpersec_total);
 
-			snprintf(kbitpersec_total_s, 30, "%03.5f", kbitpersec_total);
-			snprintf(kbitpersec_out_s, 30, "%03.5f", kbitpersec_out);
-			snprintf(kbitpersec_in_s, 30, "%03.5f", kbitpersec_in);
-
-			stats.AddRow(249, "Bandwidth total:  "+ConvToStr(kbitpersec_total_s)+" kilobits/sec");
-			stats.AddRow(249, "Bandwidth out:    "+ConvToStr(kbitpersec_out_s)+" kilobits/sec");
-			stats.AddRow(249, "Bandwidth in:     "+ConvToStr(kbitpersec_in_s)+" kilobits/sec");
+			stats.AddRow(249, InspIRCd::Format("Bandwidth total:  %03.5f kilobits/sec", kbitpersec_total));
+			stats.AddRow(249, InspIRCd::Format("Bandwidth out:    %03.5f kilobits/sec", kbitpersec_out));
+			stats.AddRow(249, InspIRCd::Format("Bandwidth in:     %03.5f kilobits/sec", kbitpersec_in));
 
 #ifndef _WIN32
 			/* Moved this down here so all the not-windows stuff (look w00tie, I didn't say win32!) is in one ifndef.
@@ -259,21 +253,18 @@ void CommandStats::DoStats(Stats::Context& stats)
 				stats.AddRow(249, "Swaps:            "+ConvToStr(R.ru_nswap));
 				stats.AddRow(249, "Context Switches: Voluntary; "+ConvToStr(R.ru_nvcsw)+" Involuntary; "+ConvToStr(R.ru_nivcsw));
 
-				char percent[30];
-
 				float n_elapsed = (ServerInstance->Time() - ServerInstance->stats.LastSampled.tv_sec) * 1000000
 					+ (ServerInstance->Time_ns() - ServerInstance->stats.LastSampled.tv_nsec) / 1000;
 				float n_eaten = ((R.ru_utime.tv_sec - ServerInstance->stats.LastCPU.tv_sec) * 1000000 + R.ru_utime.tv_usec - ServerInstance->stats.LastCPU.tv_usec);
 				float per = (n_eaten / n_elapsed) * 100;
 
-				snprintf(percent, 30, "%03.5f%%", per);
-				stats.AddRow(249, std::string("CPU Use (now):    ")+percent);
+				stats.AddRow(249, InspIRCd::Format("CPU Use (now):    %03.5f%%", per));
 
 				n_elapsed = ServerInstance->Time() - ServerInstance->startup_time;
 				n_eaten = (float)R.ru_utime.tv_sec + R.ru_utime.tv_usec / 100000.0;
 				per = (n_eaten / n_elapsed) * 100;
-				snprintf(percent, 30, "%03.5f%%", per);
-				stats.AddRow(249, std::string("CPU Use (total):  ")+percent);
+
+				stats.AddRow(249, InspIRCd::Format("CPU Use (total):  %03.5f%%", per));
 			}
 #else
 			PROCESS_MEMORY_COUNTERS MemCounters;
@@ -298,16 +289,13 @@ void CommandStats::DoStats(Stats::Context& stats)
 				double n_elapsed = (double)(ThisSample.QuadPart - ServerInstance->stats.LastSampled.QuadPart) / ServerInstance->stats.QPFrequency.QuadPart;
 				double per = (n_eaten/n_elapsed);
 
-				char percent[30];
-
-				snprintf(percent, 30, "%03.5f%%", per);
-				stats.AddRow(249, std::string("CPU Use (now):    ")+percent);
+				stats.AddRow(249, InspIRCd::Format("CPU Use (now):    %03.5f%%", per));
 
 				n_elapsed = ServerInstance->Time() - ServerInstance->startup_time;
 				n_eaten = (double)(( (uint64_t)(KernelTime.dwHighDateTime) << 32 ) + (uint64_t)(KernelTime.dwLowDateTime))/100000;
 				per = (n_eaten / n_elapsed);
-				snprintf(percent, 30, "%03.5f%%", per);
-				stats.AddRow(249, std::string("CPU Use (total):  ")+percent);
+
+				stats.AddRow(249, InspIRCd::Format("CPU Use (total):  %03.5f%%", per));
 			}
 #endif
 		}

--- a/src/modules/m_cloaking.cpp
+++ b/src/modules/m_cloaking.cpp
@@ -253,19 +253,17 @@ class ModuleCloaking : public Module
 		}
 		else
 		{
-			char buf[50];
 			if (ip.sa.sa_family == AF_INET6)
 			{
-				snprintf(buf, 50, ".%02x%02x.%02x%02x%s",
+				rv.append(InspIRCd::Format(".%02x%02x.%02x%02x%s",
 					ip.in6.sin6_addr.s6_addr[2], ip.in6.sin6_addr.s6_addr[3],
-					ip.in6.sin6_addr.s6_addr[0], ip.in6.sin6_addr.s6_addr[1], suffix.c_str());
+					ip.in6.sin6_addr.s6_addr[0], ip.in6.sin6_addr.s6_addr[1], suffix.c_str()));
 			}
 			else
 			{
 				const unsigned char* ip4 = (const unsigned char*)&ip.in4.sin_addr;
-				snprintf(buf, 50, ".%d.%d%s", ip4[1], ip4[0], suffix.c_str());
+				rv.append(InspIRCd::Format(".%d.%d%s", ip4[1], ip4[0], suffix.c_str()));
 			}
-			rv.append(buf);
 		}
 		return rv;
 	}

--- a/src/modules/m_spanningtree/override_map.cpp
+++ b/src/modules/m_spanningtree/override_map.cpp
@@ -82,9 +82,7 @@ static std::vector<std::string> GetMap(User* user, TreeServer* current, unsigned
 	// Pad with spaces until its at max len, max_len must always be >= my names length
 	buffer.append(max_len - current->GetName().length(), ' ');
 
-	char buf[16];
-	snprintf(buf, sizeof(buf), "%5d [%5.2f%%]", current->UserCount, percent);
-	buffer += buf;
+	buffer += InspIRCd::Format("%5d [%5.2f%%]", current->UserCount, percent);
 
 	if (user->IsOper())
 	{


### PR DESCRIPTION
Now all formatting code goes through InspIRCd::Format and doesn't mess around with C arrays.