### PR TITLE
fix m_customprefix modes deleting RFC-defined chanmodes from 005 PREFIX

### DIFF
--- a/src/modules/m_customprefix.cpp
+++ b/src/modules/m_customprefix.cpp
@@ -17,6 +17,7 @@
  */
 
 
+#include "mode.h"
 #include "inspircd.h"
 
 /* $ModDesc: Allows custom prefix modes to be created. */
@@ -112,6 +113,8 @@ class ModuleCustomPrefix : public Module
 			modes.push_back(mh);
 			if (mh->rank <= 0)
 				throw ModuleException("Rank must be specified for prefix at " + tag->getTagLocation());
+			if (mh->rank == VOICE_VALUE || mh->rank == OP_VALUE) //fix customprefix modes removing RFC-defined chanmodes from 005 PREFIX
+				throw ModuleException("Rank must not be equal to VOICE_VALUE (10000) or OP_VALUE (30000) at " + tag->getTagLocation());
 			if (!isalpha(mh->GetModeChar()))
 				throw ModuleException("Mode must be a letter for prefix at " + tag->getTagLocation());
 			try

--- a/src/modules/m_customprefix.cpp
+++ b/src/modules/m_customprefix.cpp
@@ -17,8 +17,8 @@
  */
 
 
-#include "mode.h"
 #include "inspircd.h"
+#include "mode.h"
 
 /* $ModDesc: Allows custom prefix modes to be created. */
 


### PR DESCRIPTION
This pull request will help to idiot-proof (I fell victim to this) the configuration for m_customprefix a little bit, as defining a custom mode with a rank equal to VOICE_VALUE or OP_VALUE results in +v or +o's respective entry in the 005 PREFIX response being removed altogether, which causes various bugs in some clients, ie minor annoyances.