### PR TITLE
Fix sending the wrong numeric when an empty new nick is received.

### DIFF
--- a/include/numerics.h
+++ b/include/numerics.h
@@ -137,6 +137,7 @@ enum
 	ERR_NOTEXTTOSEND                = 412,
 	ERR_UNKNOWNCOMMAND              = 421,
 	ERR_NOMOTD                      = 422,
+	ERR_NONICKNAMEGIVEN             = 431,
 	ERR_ERRONEUSNICKNAME            = 432,
 	ERR_NICKNAMEINUSE               = 433,
 	ERR_NORULES                     = 434, // unrealircd

--- a/src/coremods/core_user/cmd_nick.cpp
+++ b/src/coremods/core_user/cmd_nick.cpp
@@ -47,7 +47,7 @@ CmdResult CommandNick::HandleLocal(const std::vector<std::string>& parameters, L
 
 	if (newnick.empty())
 	{
-		user->WriteNumeric(ERR_ERRONEUSNICKNAME, '*', "Erroneous Nickname");
+		user->WriteNumeric(ERR_NONICKNAMEGIVEN, '*', "No nickname given");
 		return CMD_FAILURE;
 	}
 


### PR DESCRIPTION
This fixes InspIRCd to work like section 4.1.2 of RFC 1459 dictates.

Filed against master so we don't break anything relying on the old behaviour..