### PR TITLE
[2.0] Force link sqlite3 on OS X when doing Travis builds.

### DIFF
--- a/tools/travis-ci.sh
+++ b/tools/travis-ci.sh
@@ -8,6 +8,7 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]
 then
 	brew update
 	brew install geoip gnutls mysql-connector-c openssl pcre postgresql sqlite3 tre
+	brew link sqlite3 --force
 else
 	>&2 echo "'$TRAVIS_OS_NAME' is an unknown Travis CI environment!"
 	exit 1


### PR DESCRIPTION
The system version of this library does not include support for pkg-config.