### PR TITLE
Add CXX11_OVERRIDE to overridden members that lack it.

### DIFF
--- a/include/builtinmodes.h
+++ b/include/builtinmodes.h
@@ -97,8 +97,8 @@ class ModeUserServerNoticeMask : public ModeHandler
 
  public:
 	ModeUserServerNoticeMask();
-	ModeAction OnModeChange(User* source, User* dest, Channel* channel, std::string &parameter, bool adding);
-	void OnParameterMissing(User* user, User* dest, Channel* channel);
+	ModeAction OnModeChange(User* source, User* dest, Channel* channel, std::string &parameter, bool adding) CXX11_OVERRIDE;
+	void OnParameterMissing(User* user, User* dest, Channel* channel) CXX11_OVERRIDE;
 
 	/** Create a displayable mode string of the snomasks set on a given user
 	 * @param user The user whose notice masks to format

--- a/include/extensible.h
+++ b/include/extensible.h
@@ -111,7 +111,7 @@ class CoreExport Extensible : public classbase
 	inline const ExtensibleStore& GetExtList() const { return extensions; }
 
 	Extensible();
-	virtual CullResult cull();
+	virtual CullResult cull() CXX11_OVERRIDE;
 	virtual ~Extensible();
 	void doUnhookExtensions(const std::vector<reference<ExtensionItem> >& toRemove);
 

--- a/include/inspsocket.h
+++ b/include/inspsocket.h
@@ -312,7 +312,7 @@ class CoreExport StreamSocket : public EventHandler
 	 */
 	virtual void Close();
 	/** This ensures that close is called prior to destructor */
-	virtual CullResult cull();
+	virtual CullResult cull() CXX11_OVERRIDE;
 
 	/** Get the IOHook of a module attached to this socket
 	 * @param mod Module whose IOHook to return
@@ -372,7 +372,7 @@ class CoreExport BufferedSocket : public StreamSocket
 	/** When there is data waiting to be read on a socket, the OnDataReady()
 	 * method is called.
 	 */
-	virtual void OnDataReady() = 0;
+	virtual void OnDataReady() CXX11_OVERRIDE = 0;
 
 	/**
 	 * When an outbound connection fails, and the attempt times out, you

--- a/include/mode.h
+++ b/include/mode.h
@@ -166,7 +166,7 @@ class CoreExport ModeHandler : public ServiceProvider
 	 * @param mclass The object type of this mode handler, one of ModeHandler::Class
 	 */
 	ModeHandler(Module* me, const std::string& name, char modeletter, ParamSpec params, ModeType type, Class mclass = MC_OTHER);
-	virtual CullResult cull();
+	virtual CullResult cull() CXX11_OVERRIDE;
 	virtual ~ModeHandler();
 
 	/** Register this object in the ModeParser

--- a/include/modules.h
+++ b/include/modules.h
@@ -276,7 +276,7 @@ class CoreExport Module : public classbase, public usecountbase
 	/** Clean up prior to destruction
 	 * If you override, you must call this AFTER your module's cleanup
 	 */
-	virtual CullResult cull();
+	virtual CullResult cull() CXX11_OVERRIDE;
 
 	/** Default destructor.
 	 * destroys a module class

--- a/include/users.h
+++ b/include/users.h
@@ -717,7 +717,7 @@ class CoreExport User : public Extensible
 	/** Default destructor
 	 */
 	virtual ~User();
-	virtual CullResult cull();
+	virtual CullResult cull() CXX11_OVERRIDE;
 };
 
 class CoreExport UserIOHandler : public StreamSocket
@@ -742,7 +742,7 @@ class CoreExport LocalUser : public User, public insp::intrusive_list_node<Local
 {
  public:
 	LocalUser(int fd, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server);
-	CullResult cull();
+	CullResult cull() CXX11_OVERRIDE;
 
 	UserIOHandler eh;
 
@@ -836,12 +836,12 @@ class CoreExport LocalUser : public User, public insp::intrusive_list_node<Local
 	 */
 	void SetClass(const std::string &explicit_name = "");
 
-	bool SetClientIP(const char* sip, bool recheck_eline = true);
+	bool SetClientIP(const char* sip, bool recheck_eline = true) CXX11_OVERRIDE;
 
-	void SetClientIP(const irc::sockets::sockaddrs& sa, bool recheck_eline = true);
+	void SetClientIP(const irc::sockets::sockaddrs& sa, bool recheck_eline = true) CXX11_OVERRIDE;
 
-	void Write(const std::string& text);
-	void Write(const char*, ...) CUSTOM_PRINTF(2, 3);
+	void Write(const std::string& text) CXX11_OVERRIDE;
+	void Write(const char*, ...) CXX11_OVERRIDE CUSTOM_PRINTF(2, 3);
 
 	/** Send a NOTICE message from the local server to the user.
 	 * The message will be sent even if the user is connected to a remote server.
@@ -855,7 +855,7 @@ class CoreExport LocalUser : public User, public insp::intrusive_list_node<Local
 	 * @param command A command (should be all CAPS)
 	 * @return True if this user can execute the command
 	 */
-	bool HasPermission(const std::string &command);
+	bool HasPermission(const std::string &command) CXX11_OVERRIDE;
 
 	/** Returns true if a user has a given permission.
 	 * This is used to check whether or not users may perform certain actions which admins may not wish to give to
@@ -865,7 +865,7 @@ class CoreExport LocalUser : public User, public insp::intrusive_list_node<Local
 	 * @param noisy If set to true, the user is notified that they do not have the specified permission where applicable. If false, no notification is sent.
 	 * @return True if this user has the permission in question.
 	 */
-	bool HasPrivPermission(const std::string &privstr, bool noisy = false);
+	bool HasPrivPermission(const std::string &privstr, bool noisy = false) CXX11_OVERRIDE;
 
 	/** Returns true or false if a user can set a privileged user or channel mode.
 	 * This is done by looking up their oper type from User::oper, then referencing
@@ -873,7 +873,7 @@ class CoreExport LocalUser : public User, public insp::intrusive_list_node<Local
 	 * @param mh Mode to check
 	 * @return True if the user can set or unset this mode.
 	 */
-	bool HasModePermission(const ModeHandler* mh) const;
+	bool HasModePermission(const ModeHandler* mh) const CXX11_OVERRIDE;
 
 	/** Change nick to uuid, unset REG_NICK and send a nickname overruled numeric.
 	 * This is called when another user (either local or remote) needs the nick of this user and this user
@@ -904,9 +904,9 @@ class CoreExport FakeUser : public User
 		nick = sname;
 	}
 
-	virtual CullResult cull();
-	virtual const std::string& GetFullHost();
-	virtual const std::string& GetFullRealHost();
+	virtual CullResult cull() CXX11_OVERRIDE;
+	virtual const std::string& GetFullHost() CXX11_OVERRIDE;
+	virtual const std::string& GetFullRealHost() CXX11_OVERRIDE;
 };
 
 /* Faster than dynamic_cast */

--- a/src/coremods/core_dns.cpp
+++ b/src/coremods/core_dns.cpp
@@ -442,7 +442,7 @@ class MyManager : public Manager, public Timer, public EventHandler
 		}
 	}
 
-	void Process(DNS::Request* req)
+	void Process(DNS::Request* req) CXX11_OVERRIDE
 	{
 		if ((unloading) || (req->creator->dying))
 			throw Exception("Module is being unloaded");
@@ -509,13 +509,13 @@ class MyManager : public Manager, public Timer, public EventHandler
 		ServerInstance->Timers.AddTimer(req);
 	}
 
-	void RemoveRequest(DNS::Request* req)
+	void RemoveRequest(DNS::Request* req) CXX11_OVERRIDE
 	{
 		if (requests[req->id] == req)
 			requests[req->id] = NULL;
 	}
 
-	std::string GetErrorStr(Error e)
+	std::string GetErrorStr(Error e) CXX11_OVERRIDE
 	{
 		switch (e)
 		{
@@ -664,7 +664,7 @@ class MyManager : public Manager, public Timer, public EventHandler
 		delete request;
 	}
 
-	bool Tick(time_t now)
+	bool Tick(time_t now) CXX11_OVERRIDE
 	{
 		ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "cache: purging DNS cache");
 
@@ -826,7 +826,7 @@ class ModuleDNS : public Module
 			this->manager.Rehash(DNSServer, SourceIP, SourcePort);
 	}
 
-	void OnUnloadModule(Module* mod)
+	void OnUnloadModule(Module* mod) CXX11_OVERRIDE
 	{
 		for (unsigned int i = 0; i <= MAX_REQUEST_ID; ++i)
 		{
@@ -845,7 +845,7 @@ class ModuleDNS : public Module
 		}
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("DNS support", VF_CORE|VF_VENDOR);
 	}

--- a/src/coremods/core_hostname_lookup.cpp
+++ b/src/coremods/core_hostname_lookup.cpp
@@ -195,7 +195,7 @@ class ModuleHostnameLookup : public Module
 		ph = &ptrHosts;
 	}
 
-	void OnUserInit(LocalUser *user)
+	void OnUserInit(LocalUser *user) CXX11_OVERRIDE
 	{
 		if (!DNS || !user->MyClass->resolvehostnames)
 		{
@@ -222,12 +222,12 @@ class ModuleHostnameLookup : public Module
 		}
 	}
 
-	ModResult OnCheckReady(LocalUser* user)
+	ModResult OnCheckReady(LocalUser* user) CXX11_OVERRIDE
 	{
 		return this->dnsLookup.get(user) ? MOD_RES_DENY : MOD_RES_PASSTHRU;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides support for DNS lookups on connecting clients", VF_CORE|VF_VENDOR);
 	}

--- a/src/coremods/core_loadmodule.cpp
+++ b/src/coremods/core_loadmodule.cpp
@@ -116,7 +116,7 @@ class CoreModLoadModule : public Module
 	{
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the LOADMODULE and UNLOADMODULE commands", VF_VENDOR|VF_CORE);
 	}

--- a/src/coremods/core_lusers.cpp
+++ b/src/coremods/core_lusers.cpp
@@ -151,20 +151,20 @@ class ModuleLusers : public Module
 	{
 	}
 
-	void OnPostConnect(User* user)
+	void OnPostConnect(User* user) CXX11_OVERRIDE
 	{
 		counters.UpdateMaxUsers();
 		if (user->IsModeSet(invisiblemode))
 			counters.invisible++;
 	}
 
-	void OnUserQuit(User* user, const std::string& message, const std::string& oper_message)
+	void OnUserQuit(User* user, const std::string& message, const std::string& oper_message) CXX11_OVERRIDE
 	{
 		if (user->IsModeSet(invisiblemode))
 			counters.invisible--;
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("LUSERS", VF_VENDOR | VF_CORE);
 	}

--- a/src/coremods/core_privmsg.cpp
+++ b/src/coremods/core_privmsg.cpp
@@ -280,7 +280,7 @@ class ModuleCoreMessage : public Module
 	{
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("PRIVMSG, NOTICE", VF_CORE|VF_VENDOR);
 	}

--- a/src/coremods/core_stub.cpp
+++ b/src/coremods/core_stub.cpp
@@ -147,7 +147,7 @@ class CoreModStub : public Module
 	{
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the stub commands CONNECT, LINKS, SERVER and SQUIT", VF_VENDOR|VF_CORE);
 	}

--- a/src/coremods/core_whowas.cpp
+++ b/src/coremods/core_whowas.cpp
@@ -259,13 +259,13 @@ class ModuleWhoWas : public Module
 	{
 	}
 
-	void OnGarbageCollect()
+	void OnGarbageCollect() CXX11_OVERRIDE
 	{
 		// Remove all entries older than MaxKeep
 		cmd.manager.Maintain();
 	}
 
-	void OnUserQuit(User* user, const std::string& message, const std::string& oper_message)
+	void OnUserQuit(User* user, const std::string& message, const std::string& oper_message) CXX11_OVERRIDE
 	{
 		cmd.manager.Add(user);
 	}
@@ -288,7 +288,7 @@ class ModuleWhoWas : public Module
 		cmd.manager.UpdateConfig(NewGroupSize, NewMaxGroups, NewMaxKeep);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("WHOWAS", VF_VENDOR);
 	}

--- a/src/modmanager_static.cpp
+++ b/src/modmanager_static.cpp
@@ -72,7 +72,7 @@ class AllModule : public Module
 		stdalgo::delete_all(cmds);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("All commands", VF_VENDOR|VF_CORE);
 	}

--- a/src/modules/extra/m_pgsql.cpp
+++ b/src/modules/extra/m_pgsql.cpp
@@ -159,7 +159,7 @@ class SQLConn : public SQLProvider, public EventHandler
 		}
 	}
 
-	CullResult cull()
+	CullResult cull() CXX11_OVERRIDE
 	{
 		this->SQLProvider::cull();
 		ServerInstance->Modules->DelService(*this);
@@ -389,7 +389,7 @@ restart:
 		}
 	}
 
-	void submit(SQLQuery *req, const std::string& q)
+	void submit(SQLQuery *req, const std::string& q) CXX11_OVERRIDE
 	{
 		if (qinprog.q.empty())
 		{
@@ -402,7 +402,7 @@ restart:
 		}
 	}
 
-	void submit(SQLQuery *req, const std::string& q, const ParamL& p)
+	void submit(SQLQuery *req, const std::string& q, const ParamL& p) CXX11_OVERRIDE
 	{
 		std::string res;
 		unsigned int param = 0;
@@ -427,7 +427,7 @@ restart:
 		submit(req, res);
 	}
 
-	void submit(SQLQuery *req, const std::string& q, const ParamM& p)
+	void submit(SQLQuery *req, const std::string& q, const ParamM& p) CXX11_OVERRIDE
 	{
 		std::string res;
 		for(std::string::size_type i = 0; i < q.length(); i++)

--- a/src/modules/m_abbreviation.cpp
+++ b/src/modules/m_abbreviation.cpp
@@ -22,7 +22,7 @@
 class ModuleAbbreviation : public Module
 {
  public:
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->SetPriority(this, I_OnPreCommand, PRIORITY_FIRST);
 	}

--- a/src/modules/m_alias.cpp
+++ b/src/modules/m_alias.cpp
@@ -352,7 +352,7 @@ class ModuleAlias : public Module
 		ServerInstance->Parser.CallHandler(command, pars, user);
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		// Prioritise after spanningtree so that channel aliases show the alias before the effects.
 		Module* linkmod = ServerInstance->Modules->Find("m_spanningtree.so");

--- a/src/modules/m_bcrypt.cpp
+++ b/src/modules/m_bcrypt.cpp
@@ -978,7 +978,7 @@ class ModuleBCrypt : public Module
 		bcrypt.rounds = conf->getInt("rounds", 10, 1);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements bcrypt hashing", VF_VENDOR);
 	}

--- a/src/modules/m_clearchan.cpp
+++ b/src/modules/m_clearchan.cpp
@@ -150,7 +150,7 @@ class ModuleClearChan : public Module
 	{
 	}
 
-	void init()
+	void init() CXX11_OVERRIDE
 	{
 		// Only attached while we are working; don't react to events otherwise
 		ServerInstance->Modules->DetachAll(this);

--- a/src/modules/m_cloaking.cpp
+++ b/src/modules/m_cloaking.cpp
@@ -290,7 +290,7 @@ class ModuleCloaking : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		/* Needs to be after m_banexception etc. */
 		ServerInstance->Modules->SetPriority(this, I_OnCheckBan, PRIORITY_LAST);

--- a/src/modules/m_conn_join.cpp
+++ b/src/modules/m_conn_join.cpp
@@ -78,7 +78,7 @@ class ModuleConnJoin : public Module
 		defdelay = tag->getInt("delay", 0, 0, 60);
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->SetPriority(this, I_OnPostConnect, PRIORITY_LAST);
 	}

--- a/src/modules/m_conn_umodes.cpp
+++ b/src/modules/m_conn_umodes.cpp
@@ -25,7 +25,7 @@
 class ModuleModesOnConnect : public Module
 {
  public:
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		// for things like +x on connect, important, otherwise we have to resort to config order (bleh) -- w00t
 		ServerInstance->Modules->SetPriority(this, I_OnUserConnect, PRIORITY_FIRST);

--- a/src/modules/m_connectban.cpp
+++ b/src/modules/m_connectban.cpp
@@ -95,7 +95,7 @@ class ModuleConnectBan : public Module
 		}
 	}
 
-	void OnGarbageCollect()
+	void OnGarbageCollect() CXX11_OVERRIDE
 	{
 		ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Clearing map.");
 		connects.clear();

--- a/src/modules/m_filter.cpp
+++ b/src/modules/m_filter.cpp
@@ -176,7 +176,7 @@ class ModuleFilter : public Module
 	ExemptTargetSet exemptednicks;
 
 	ModuleFilter();
-	CullResult cull();
+	CullResult cull() CXX11_OVERRIDE;
 	ModResult OnUserPreMessage(User* user, void* dest, int target_type, std::string& text, char status, CUList& exempt_list, MessageType msgtype) CXX11_OVERRIDE;
 	FilterResult* FilterMatch(User* user, const std::string &text, int flags);
 	bool DeleteFilter(const std::string &freeform);

--- a/src/modules/m_flashpolicyd.cpp
+++ b/src/modules/m_flashpolicyd.cpp
@@ -146,7 +146,7 @@ class ModuleFlashPD : public Module
 </cross-domain-policy>";
 	}
 
-	CullResult cull()
+	CullResult cull() CXX11_OVERRIDE
 	{
 		for (insp::intrusive_list<FlashPDSocket>::const_iterator i = sockets.begin(); i != sockets.end(); ++i)
 		{

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -224,7 +224,7 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 		WriteData("\r\n");
 	}
 
-	void OnDataReady()
+	void OnDataReady() CXX11_OVERRIDE
 	{
 		if (InternalState == HTTP_SERVE_RECV_POSTDATA)
 		{
@@ -415,7 +415,7 @@ class ModuleHttpServer : public Module
 		return MOD_RES_ALLOW;
 	}
 
-	void OnUnloadModule(Module* mod)
+	void OnUnloadModule(Module* mod) CXX11_OVERRIDE
 	{
 		for (insp::intrusive_list<HttpServerSocket>::const_iterator i = sockets.begin(); i != sockets.end(); )
 		{

--- a/src/modules/m_ircv3.cpp
+++ b/src/modules/m_ircv3.cpp
@@ -169,7 +169,7 @@ class ModuleIRCv3 : public Module, public AccountEventListener
 		last_excepts.clear();
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->SetPriority(this, I_OnUserJoin, PRIORITY_LAST);
 	}

--- a/src/modules/m_messageflood.cpp
+++ b/src/modules/m_messageflood.cpp
@@ -150,7 +150,7 @@ class ModuleMsgFlood : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		// we want to be after all modules that might deny the message (e.g. m_muteban, m_noctcp, m_blockcolor, etc.)
 		ServerInstance->Modules->SetPriority(this, I_OnUserPreMessage, PRIORITY_LAST);

--- a/src/modules/m_mlock.cpp
+++ b/src/modules/m_mlock.cpp
@@ -34,7 +34,7 @@ class ModuleMLock : public Module
 		return Version("Implements the ability to have server-side MLOCK enforcement.", VF_VENDOR);
 	}
 
-	ModResult OnRawMode(User* source, Channel* channel, ModeHandler* mh, const std::string& parameter, bool adding)
+	ModResult OnRawMode(User* source, Channel* channel, ModeHandler* mh, const std::string& parameter, bool adding) CXX11_OVERRIDE
 	{
 		if (!channel)
 			return MOD_RES_PASSTHRU;

--- a/src/modules/m_namedmodes.cpp
+++ b/src/modules/m_namedmodes.cpp
@@ -124,7 +124,7 @@ class ModuleNamedModes : public Module
 		return Version("Provides the ability to manipulate modes via long names.",VF_VENDOR);
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->SetPriority(this, I_OnPreMode, PRIORITY_FIRST);
 	}

--- a/src/modules/m_nicklock.cpp
+++ b/src/modules/m_nicklock.cpp
@@ -157,7 +157,7 @@ class ModuleNickLock : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		Module *nflood = ServerInstance->Modules->Find("m_nickflood.so");
 		ServerInstance->Modules->SetPriority(this, I_OnUserPreNick, PRIORITY_BEFORE, nflood);

--- a/src/modules/m_ojoin.cpp
+++ b/src/modules/m_ojoin.cpp
@@ -150,7 +150,7 @@ class ModuleOjoin : public Module
 		return MOD_RES_DENY;
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules->SetPriority(this, I_OnUserPreJoin, PRIORITY_FIRST);
 	}

--- a/src/modules/m_operprefix.cpp
+++ b/src/modules/m_operprefix.cpp
@@ -72,7 +72,7 @@ class ModuleOperPrefixMode : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void OnPostJoin(Membership* memb)
+	void OnPostJoin(Membership* memb) CXX11_OVERRIDE
 	{
 		if ((!IS_LOCAL(memb->user)) || (!memb->user->IsOper()) || (memb->user->IsModeSet(hideopermode)))
 			return;
@@ -105,7 +105,7 @@ class ModuleOperPrefixMode : public Module
 		return Version("Gives opers cmode +y which provides a staff prefix.", VF_VENDOR);
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		// m_opermodes may set +H on the oper to hide him, we don't want to set the oper prefix in that case
 		Module* opermodes = ServerInstance->Modules->Find("m_opermodes.so");

--- a/src/modules/m_permchannels.cpp
+++ b/src/modules/m_permchannels.cpp
@@ -273,7 +273,7 @@ public:
 		dirty = false;
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		// XXX: Load the DB here because the order in which modules are init()ed at boot is
 		// alphabetical, this means we must wait until all modules have done their init()

--- a/src/modules/m_rline.cpp
+++ b/src/modules/m_rline.cpp
@@ -333,7 +333,7 @@ class ModuleRLine : public Module
 		}
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		Module* mod = ServerInstance->Modules->Find("m_cgiirc.so");
 		ServerInstance->Modules->SetPriority(this, I_OnUserRegister, PRIORITY_AFTER, mod);

--- a/src/modules/m_samode.cpp
+++ b/src/modules/m_samode.cpp
@@ -96,7 +96,7 @@ class ModuleSaMode : public Module
 		return MOD_RES_PASSTHRU;
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		Module *override = ServerInstance->Modules->Find("m_override.so");
 		ServerInstance->Modules->SetPriority(this, I_OnPreMode, PRIORITY_BEFORE, override);

--- a/src/modules/m_sha1.cpp
+++ b/src/modules/m_sha1.cpp
@@ -190,7 +190,7 @@ class ModuleSHA1 : public Module
 		big_endian = (htonl(1337) == 1337);
 	}
 
-	Version GetVersion()
+	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Implements SHA-1 hashing", VF_VENDOR);
 	}

--- a/src/modules/m_shun.cpp
+++ b/src/modules/m_shun.cpp
@@ -191,7 +191,7 @@ class ModuleShun : public Module
 		ServerInstance->XLines->UnregisterFactory(&f);
 	}
 
-	void Prioritize()
+	void Prioritize() CXX11_OVERRIDE
 	{
 		Module* alias = ServerInstance->Modules->Find("m_alias.so");
 		ServerInstance->Modules->SetPriority(this, I_OnPreCommand, PRIORITY_BEFORE, alias);

--- a/src/modules/m_spanningtree/main.h
+++ b/src/modules/m_spanningtree/main.h
@@ -168,8 +168,8 @@ class ModuleSpanningTree : public Module
 	void OnUnloadModule(Module* mod) CXX11_OVERRIDE;
 	ModResult OnAcceptConnection(int newsock, ListenSocket* from, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server) CXX11_OVERRIDE;
 	void OnMode(User* source, User* u, Channel* c, const Modes::ChangeList& modes, ModeParser::ModeProcessFlag processflags, const std::string& output_mode) CXX11_OVERRIDE;
-	CullResult cull();
+	CullResult cull() CXX11_OVERRIDE;
 	~ModuleSpanningTree();
 	Version GetVersion() CXX11_OVERRIDE;
-	void Prioritize();
+	void Prioritize() CXX11_OVERRIDE;
 };

--- a/src/modules/m_spanningtree/protocolinterface.h
+++ b/src/modules/m_spanningtree/protocolinterface.h
@@ -37,7 +37,7 @@ class SpanningTreeProtocolInterface : public ProtocolInterface
 	void SendMetaData(Channel* chan, const std::string& key, const std::string& data) CXX11_OVERRIDE;
 	void SendMetaData(const std::string& key, const std::string& data) CXX11_OVERRIDE;
 	void SendSNONotice(char snomask, const std::string& text) CXX11_OVERRIDE;
-	void SendMessage(Channel* target, char status, const std::string& text, MessageType msgtype);
-	void SendMessage(User* target, const std::string& text, MessageType msgtype);
-	void GetServerList(ServerList& sl);
+	void SendMessage(Channel* target, char status, const std::string& text, MessageType msgtype) CXX11_OVERRIDE;
+	void SendMessage(User* target, const std::string& text, MessageType msgtype) CXX11_OVERRIDE;
+	void GetServerList(ServerList& sl) CXX11_OVERRIDE;
 };

--- a/src/modules/m_spanningtree/servercommand.h
+++ b/src/modules/m_spanningtree/servercommand.h
@@ -43,7 +43,7 @@ class ServerCommand : public CommandBase
 	void RegisterService() CXX11_OVERRIDE;
 
 	virtual CmdResult Handle(User* user, std::vector<std::string>& parameters) = 0;
-	virtual RouteDescriptor GetRouting(User* user, const std::vector<std::string>& parameters);
+	virtual RouteDescriptor GetRouting(User* user, const std::vector<std::string>& parameters) CXX11_OVERRIDE;
 
 	/**
 	 * Extract the TS from a string.

--- a/src/modules/m_spanningtree/treeserver.h
+++ b/src/modules/m_spanningtree/treeserver.h
@@ -219,7 +219,7 @@ class TreeServer : public Server
 	 */
 	void OnPong() { pingtimer.OnPong(); }
 
-	CullResult cull();
+	CullResult cull() CXX11_OVERRIDE;
 
 	/** Destructor, deletes ServerUser unless IsRoot()
 	 */

--- a/src/modules/m_spanningtree/treesocket.h
+++ b/src/modules/m_spanningtree/treesocket.h
@@ -200,7 +200,7 @@ class TreeSocket : public BufferedSocket
 	 */
 	void CleanNegotiationInfo();
 
-	CullResult cull();
+	CullResult cull() CXX11_OVERRIDE;
 	/** Destructor
 	 */
 	~TreeSocket();
@@ -216,7 +216,7 @@ class TreeSocket : public BufferedSocket
 	 * to server docs on the inspircd.org site, the other side
 	 * will then send back its own server string.
 	 */
-	void OnConnected();
+	void OnConnected() CXX11_OVERRIDE;
 
 	/** Handle socket error event
 	 */
@@ -270,7 +270,7 @@ class TreeSocket : public BufferedSocket
 	/** This function is called when we receive data from a remote
 	 * server.
 	 */
-	void OnDataReady();
+	void OnDataReady() CXX11_OVERRIDE;
 
 	/** Send one or more complete lines down the socket
 	 */
@@ -299,10 +299,10 @@ class TreeSocket : public BufferedSocket
 
 	/** Handle socket timeout from connect()
 	 */
-	void OnTimeout();
+	void OnTimeout() CXX11_OVERRIDE;
 	/** Handle server quit on close
 	 */
-	void Close();
+	void Close() CXX11_OVERRIDE;
 
 	/** Fixes messages coming from old servers so the new command handlers understand them
 	 */

--- a/src/modules/m_spanningtree/utils.h
+++ b/src/modules/m_spanningtree/utils.h
@@ -108,7 +108,7 @@ class SpanningTreeUtilities : public classbase
 
 	/** Prepare for class destruction
 	 */
-	CullResult cull();
+	CullResult cull() CXX11_OVERRIDE;
 
 	/** Destroy class and free listeners etc
 	 */

--- a/src/modules/m_timedbans.cpp
+++ b/src/modules/m_timedbans.cpp
@@ -218,7 +218,7 @@ class ModuleTimedBans : public Module
 		}
 	}
 
-	void OnChannelDelete(Channel* chan)
+	void OnChannelDelete(Channel* chan) CXX11_OVERRIDE
 	{
 		// Remove all timed bans affecting the channel from internal bookkeeping
 		TimedBanList.erase(std::remove_if(TimedBanList.begin(), TimedBanList.end(), ChannelMatcher(chan)), TimedBanList.end());


### PR DESCRIPTION
This fixes a ton of warnings when building on compilers that default to C++11 or newer.
