### PR TITLE
Undocument <power> and set the default to the server name.

### DIFF
--- a/docs/conf/helpop-full.conf.example
+++ b/docs/conf/helpop-full.conf.example
@@ -621,17 +621,15 @@ The duration may be specified in seconds, or in the format
 1y2w3d4h5m6s - meaning one year, two weeks, three days, 4 hours,
 5 minutes and 6 seconds. All fields in this format are optional.">
 
-<helpop key="die" value="/DIE <password>
+<helpop key="die" value="/DIE <server>
 
 This command shuts down the local server. A single parameter is
-required, which must match the password in the configuration for the
-command to function.">
+required, which must match the name of the local server.">
 
-<helpop key="restart" value="/RESTART <password>
+<helpop key="restart" value="/RESTART <server>
 
 This command restarts the local server. A single parameter is
-required, which must match the password in the configuration for the
-command to function.">
+required, which must match the name of the local server.">
 
 <helpop key="commands" value="/COMMANDS
 

--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -187,33 +187,6 @@
 <bind address="1.2.3.4" port="7005" type="servers" ssl="openssl">
 
 
-#-#-#-#-#-#-#-#-#-#-  DIE/RESTART CONFIGURATION   -#-#-#-#-#-#-#-#-#-#-
-#                                                                     #
-#   You can configure the passwords here which you wish to use for    #
-#   the /DIE and /RESTART commands. Only trusted ircops who will      #
-#   need this ability should know the die and restart password.       #
-#                                                                     #
-
-<power
-       # hash: what hash these passwords are hashed with.
-       # Requires the module for selected hash (md5, sha256, or
-       # ripemd160) be loaded and the password hashing module
-       # (password_hash) loaded.
-       # Options here are: "md5", "sha256" and "ripemd160", or one of
-       # these prefixed with "hmac-", e.g.: "hmac-sha256".
-       # Optional, but recommended. Create hashed passwords with:
-       # /mkpasswd <hash> <password>
-       #hash="sha256"
-
-       # diepass: Password for opers to use if they need to shutdown (die)
-       # a server.
-       diepass=""
-
-       # restartpass: Password for opers to use if they need to restart
-       # a server.
-       restartpass="">
-
-
 #-#-#-#-#-#-#-#-#-#-  CONNECTIONS CONFIGURATION  -#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #
 #   This is where you can configure which connections are allowed     #

--- a/src/coremods/core_oper/cmd_die.cpp
+++ b/src/coremods/core_oper/cmd_die.cpp
@@ -26,7 +26,7 @@ CommandDie::CommandDie(Module* parent)
 	: Command(parent, "DIE", 1)
 {
 	flags_needed = 'o';
-	syntax = "<password>";
+	syntax = "<server>";
 }
 
 static void QuitAll()

--- a/src/coremods/core_oper/cmd_restart.cpp
+++ b/src/coremods/core_oper/cmd_restart.cpp
@@ -25,7 +25,7 @@ CommandRestart::CommandRestart(Module* parent)
 	: Command(parent, "RESTART", 1, 1)
 {
 	flags_needed = 'o';
-	syntax = "<password>";
+	syntax = "<server>";
 }
 
 CmdResult CommandRestart::Handle (const std::vector<std::string>& parameters, User *user)

--- a/src/coremods/core_oper/core_oper.cpp
+++ b/src/coremods/core_oper/core_oper.cpp
@@ -27,7 +27,7 @@ namespace DieRestart
 		ConfigTag* tag = ServerInstance->Config->ConfValue("power");
 		// The hash method for *BOTH* the die and restart passwords
 		const std::string hash = tag->getString("hash");
-		const std::string correctpass = tag->getString(confentry);
+		const std::string correctpass = tag->getString(confentry,  ServerInstance->Config->ServerName);
 		return ServerInstance->PassCompare(user, correctpass, inputpass, hash);
 	}
 }


### PR DESCRIPTION
We could alternately make it an oper priv to die without the password. What do you think @attilamolnar?