### PR TITLE
Improve the default ISUPPORT tokens.

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -165,13 +165,13 @@ void ISupportManager::Build()
 
 	tokens["AWAYLEN"] = ConvToStr(ServerInstance->Config->Limits.MaxAway);
 	tokens["CASEMAPPING"] = "rfc1459";
+	tokens["CHANLIMIT"] = InspIRCd::Format("#:%u", ServerInstance->Config->MaxChans);
 	tokens["CHANMODES"] = ServerInstance->Modes->GiveModeList(MODETYPE_CHANNEL);
 	tokens["CHANNELLEN"] = ConvToStr(ServerInstance->Config->Limits.ChanMax);
 	tokens["CHANTYPES"] = "#";
 	tokens["ELIST"] = "MU";
 	tokens["KICKLEN"] = ConvToStr(ServerInstance->Config->Limits.MaxKick);
 	tokens["MAXBANS"] = "64"; // TODO: make this a config setting.
-	tokens["MAXCHANNELS"] = ConvToStr(ServerInstance->Config->MaxChans);
 	tokens["MAXTARGETS"] = ConvToStr(ServerInstance->Config->MaxTargets);
 	tokens["MODES"] = ConvToStr(ServerInstance->Config->Limits.MaxModes);
 	tokens["NETWORK"] = ServerInstance->Config->Network;
@@ -179,8 +179,7 @@ void ISupportManager::Build()
 	tokens["PREFIX"] = ServerInstance->Modes->BuildPrefixes();
 	tokens["STATUSMSG"] = ServerInstance->Modes->BuildPrefixes(false);
 	tokens["TOPICLEN"] = ConvToStr(ServerInstance->Config->Limits.MaxTopic);
-
-	tokens["FNC"] = tokens["VBANLIST"];
+	tokens["VBANLIST"];
 
 	// Modules can add new tokens and also edit or remove existing tokens
 	FOREACH_MOD(On005Numeric, (tokens));


### PR DESCRIPTION
- Replace the deprecated MAXCHANNELS token with CHANLIMIT.
- Remove the deprecated FNC token (other implementations can force
  a nick change without sending this token so informing clients of
  that we might force a nick change is pointless)

---

References:

https://github.com/grawity/irc-docs/blob/master/client/RPL_ISUPPORT/draft-hardy-irc-isupport-00.txt#L922
https://github.com/grawity/irc-docs/blob/master/client/RPL_ISUPPORT/draft-hardy-irc-isupport-00.txt#L931
http://defs.ircdocs.horse/defs/isupport.html#fnc