### PR TITLE
Fix various compiler warnings

### DIFF
--- a/src/modules/extra/m_geoip.cpp
+++ b/src/modules/extra/m_geoip.cpp
@@ -21,6 +21,13 @@
 #include "inspircd.h"
 #include "xline.h"
 
+// Fix warnings about the use of commas at end of enumerator lists on C++03.
+#if defined __clang__
+# pragma clang diagnostic ignored "-Wc++11-extensions"
+#elif defined __GNUC__
+# pragma GCC diagnostic ignored "-pedantic"
+#endif
+
 #include <GeoIP.h>
 
 #ifdef _WIN32

--- a/src/modules/extra/m_ldap.cpp
+++ b/src/modules/extra/m_ldap.cpp
@@ -20,6 +20,11 @@
 #include "inspircd.h"
 #include "modules/ldap.h"
 
+// Ignore OpenLDAP deprecation warnings on OS X Yosemite and newer.
+#if defined __APPLE__
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <ldap.h>
 
 #ifdef _WIN32


### PR DESCRIPTION
1. The latest version of libGeoIP has commas at the end of an enumerator list which causes warnings as we are still using C++03.

2. OS X Yosemite has deprecated OpenLDAP in favour of Open Directory but like with OpenSSL it still works fine and is unlikely to be removed soon.