### PR TITLE
Speed up Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 compiler:
-  - "clang"
-  - "gcc"
-language: "cpp"
+  - clang
+  - gcc
+dist: trusty
+env:
+  - TEST_BUILD_DYNAMIC=1
+  - TEST_BUILD_STATIC=1
+language: cpp
 notifications:
   email: false
-os:
-  - "linux"
-  - "osx"
 script:
-  - "sh ./tools/travis-ci.sh"
+  - sh ./tools/travis-ci.sh
 sudo: required

--- a/tools/test-build
+++ b/tools/test-build
@@ -56,15 +56,19 @@ foreach my $compiler (@compilers) {
 			say "Failed to configure using the $compiler compiler and the $socketengine socket engine!";
 			exit 1;
 		}
-		$ENV{INSPIRCD_STATIC} = 1;
-		if (system 'make', '-j'.get_cpu_count, 'install') {
-			say "Failed to compile with static modules using the $compiler compiler and the $socketengine socket engine!";
-			exit 1;
+		if (!defined $ENV{TEST_BUILD_DYNAMIC}) {
+			$ENV{INSPIRCD_STATIC} = 1;
+			if (system 'make', '-j'.get_cpu_count, 'install') {
+				say "Failed to compile with static modules using the $compiler compiler and the $socketengine socket engine!";
+				exit 1;
+			}
 		}
-		delete $ENV{INSPIRCD_STATIC};
-		if (system 'make', '-j'.get_cpu_count, 'install') {
-			say "Failed to compile with dynamic modules using the $compiler compiler and the $socketengine socket engine!";
-			exit 1;
+		if (!defined $ENV{TEST_BUILD_STATIC}) {
+			delete $ENV{INSPIRCD_STATIC};
+			if (system 'make', '-j'.get_cpu_count, 'install') {
+				say "Failed to compile with dynamic modules using the $compiler compiler and the $socketengine socket engine!";
+				exit 1;
+			}
 		}
 		say "Building using the $compiler compiler and the $socketengine socket engine succeeded!";
 	}

--- a/tools/travis-ci.sh
+++ b/tools/travis-ci.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
-set -v
+set -ev
 if [ "$TRAVIS_OS_NAME" = "linux" ]
 then
 	sudo apt-get update --assume-yes
 	sudo apt-get install --assume-yes libgeoip-dev libgnutls-dev libldap2-dev libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtre-dev
-elif [ "$TRAVIS_OS_NAME" = "osx" ]
-then
-	brew update
-	brew install geoip gnutls mysql-connector-c openssl pcre postgresql sqlite3 tre
-	brew link sqlite3 --force
 else
 	>&2 echo "'$TRAVIS_OS_NAME' is an unknown Travis CI environment!"
 	exit 1
 fi
-set -e
 export TEST_BUILD_MODULES="m_geoip.cpp,m_ldap.cpp,m_mysql.cpp,m_pgsql.cpp,m_regex_pcre.cpp,m_regex_posix.cpp,m_regex_tre.cpp,m_sqlite3.cpp,m_ssl_gnutls.cpp,m_ssl_openssl.cpp"
 ./tools/test-build $CXX


### PR DESCRIPTION
- Switch Linux builds to Ubuntu 14.04 from 12.04
- Split dynamic and static builds into different jobs.
- Remove OS X builds as the infrastructure is slow and unreliable.

---

The Linux build time has now dropped to 7m30~ for Clang and 10m30~ for GCC. This is a time saving of just over 50%.

I have looked into precompiled headers but I don't think its possible with how flaky calcdep/unit-cc are at the moment (fixing this is work in progress). 