### PR TITLE
Fix compatibility with the legacy <channels> tag.

### DIFF
--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -181,7 +181,7 @@ Channel* Channel::JoinUser(LocalUser* user, std::string cname, bool override, co
 		{
 			unsigned int opermaxchans = ConvToInt(user->oper->getConfig("maxchans"));
 			// If not set, use 2.0's <channels:opers>, if that's not set either, use limit from CC
-			if (!opermaxchans)
+			if (!opermaxchans && user->HasPrivPermission("channels/high-join-limit"))
 				opermaxchans = ServerInstance->Config->OperMaxChans;
 			if (opermaxchans)
 				maxchans = opermaxchans;


### PR DESCRIPTION
We should only use OperMaxChans if they have the right privilege.
