### PR TITLE
Add a way of saying that 2.0 feature compatibility is required.

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -537,6 +537,10 @@
          # to this value.
          #fixedpart=""
 
+         # legacymode: If enabled then new features which might conflict when linking to
+         # older servers are disabled by default.
+         legacymode="no"
+
          # syntaxhints: If enabled, if a user fails to send the correct parameters
          # for a command, the ircd will give back some help text of what
          # the correct parameters are.

--- a/include/configreader.h
+++ b/include/configreader.h
@@ -438,6 +438,9 @@ class CoreExport ServerConfig
 	 */
 	bool CycleHostsFromUser;
 
+	/** Whether we need to maintain feature compatibility with 2.0 */
+	bool LegacyMode;
+
 	/** If set to true, the full nick!user\@host will be shown in the TOPIC command
 	 * for who set the topic last. If false, only the nick is shown.
 	 */

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -56,7 +56,7 @@ ServerConfig::ServerConfig()
 	, NoSnoticeStack(false)
 {
 	RawLog = HideBans = HideSplits = false;
-	WildcardIPv6 = true;
+	LegacyMode = WildcardIPv6 = true;
 	dns_timeout = 5;
 	MaxTargets = 20;
 	NetBufferSize = 10240;
@@ -414,6 +414,7 @@ void ServerConfig::Fill()
 	GenericOper = security->getBool("genericoper");
 	SyntaxHints = options->getBool("syntaxhints");
 	CycleHostsFromUser = options->getBool("cyclehostsfromuser");
+	LegacyMode = options->getBool("legacymode", true);
 	FullHostInTopic = options->getBool("hostintopic");
 	MaxTargets = security->getInt("maxtargets", 20, 1, 31);
 	DefaultModes = options->getString("defaultmodes", "not");

--- a/src/modes/cmode_l.cpp
+++ b/src/modes/cmode_l.cpp
@@ -36,7 +36,8 @@ bool ModeChannelLimit::ResolveModeConflict(std::string &their_param, const std::
 ModeAction ModeChannelLimit::OnSet(User* user, Channel* chan, std::string& parameter)
 {
 	int limit = ConvToInt(parameter);
-	if (limit < 0)
+	int minimum = ServerInstance->Config->LegacyMode ? 0 : 1;
+	if (limit < minimum)
 		return MODEACTION_DENY;
 
 	ext.set(chan, limit);

--- a/src/modules/m_joinflood.cpp
+++ b/src/modules/m_joinflood.cpp
@@ -101,7 +101,8 @@ class JoinFlood : public ParamMode<JoinFlood, SimpleExtItem<joinfloodsettings> >
 
 		/* Set up the flood parameters for this channel */
 		unsigned int njoins = ConvToInt(parameter.substr(0, colon));
-		unsigned int nsecs = ConvToInt(parameter.substr(colon+1));
+		const std::string duration = parameter.substr(colon + 1);
+		unsigned int nsecs = ServerInstance->Config->LegacyMode ? ConvToInt(duration) : InspIRCd::Duration(duration);
 		if ((njoins<1) || (nsecs<1))
 		{
 			source->WriteNumeric(608, channel->name, "Invalid flood parameter");

--- a/src/modules/m_messageflood.cpp
+++ b/src/modules/m_messageflood.cpp
@@ -80,7 +80,8 @@ class MsgFlood : public ParamMode<MsgFlood, SimpleExtItem<floodsettings> >
 		/* Set up the flood parameters for this channel */
 		bool ban = (parameter[0] == '*');
 		unsigned int nlines = ConvToInt(parameter.substr(ban ? 1 : 0, ban ? colon-1 : colon));
-		unsigned int nsecs = ConvToInt(parameter.substr(colon+1));
+		const std::string duration = parameter.substr(colon + 1);
+		unsigned int nsecs = ServerInstance->Config->LegacyMode ? ConvToInt(duration) : InspIRCd::Duration(duration);
 
 		if ((nlines<2) || (nsecs<1))
 		{

--- a/src/modules/m_nickflood.cpp
+++ b/src/modules/m_nickflood.cpp
@@ -97,7 +97,8 @@ class NickFlood : public ParamMode<NickFlood, SimpleExtItem<nickfloodsettings> >
 
 		/* Set up the flood parameters for this channel */
 		unsigned int nnicks = ConvToInt(parameter.substr(0, colon));
-		unsigned int nsecs = ConvToInt(parameter.substr(colon+1));
+		const std::string duration = parameter.substr(colon + 1);
+		unsigned int nsecs = ServerInstance->Config->LegacyMode ? ConvToInt(duration) : InspIRCd::Duration(duration);
 
 		if ((nnicks<1) || (nsecs<1))
 		{

--- a/src/modules/m_spanningtree/capab.cpp
+++ b/src/modules/m_spanningtree/capab.cpp
@@ -235,6 +235,12 @@ bool TreeSocket::Capab(const parameterlist &params)
 		if (params.size() > 1)
 			proto_version = ConvToInt(params[1]);
 
+		if (!ServerInstance->Config->LegacyMode && proto_version < 1205)
+		{
+			SendError("CAPAB negotiation failed: <options:legacymode> is disabled on this server!");
+			return false;
+		}
+
 		if (proto_version < MinCompatProtocol)
 		{
 			SendError("CAPAB negotiation failed: Server is using protocol version " + (proto_version ? ConvToStr(proto_version) : "1201 or older")


### PR DESCRIPTION
This allows us to enable things without breaking linking compatibility with 2.0.

I have ported #451 which was waiting for this. If there are any more things I can port to use this then stick them in a reply and i'll add them.
