### PR TITLE
[2.0] Invalidate the caches properly when User::SetClientIP is called.

### DIFF
--- a/src/users.cpp
+++ b/src/users.cpp
@@ -837,6 +837,7 @@ void LocalUser::FullConnect()
 void User::InvalidateCache()
 {
 	/* Invalidate cache */
+	cachedip.clear();
 	cached_fullhost.clear();
 	cached_hostip.clear();
 	cached_makehost.clear();
@@ -1001,8 +1002,7 @@ irc::sockets::cidr_mask User::GetCIDRMask()
 
 bool User::SetClientIP(const char* sip, bool recheck_eline)
 {
-	cachedip.clear();
-	cached_hostip.clear();
+	this->InvalidateCache();
 	return irc::sockets::aptosa(sip, 0, client_sa);
 }
 


### PR DESCRIPTION
This fixes #1229 and has been tested by @Robby- in production for a few days now.

```
[21:00]  <SaberUK>  Robby: how did that dnsbl patch go 
[21:00]  <Robby>    its still running
[21:00]  <Robby>    no issues thus far
```
