### PR TITLE
m_httpd_stats: Also sanitize other server gecos

### DIFF
--- a/src/modules/m_httpd_stats.cpp
+++ b/src/modules/m_httpd_stats.cpp
@@ -213,7 +213,7 @@ class ModuleHttpStats : public Module
 					data << "<server>";
 					data << "<servername>" << b->servername << "</servername>";
 					data << "<parentname>" << b->parentname << "</parentname>";
-					data << "<gecos>" << b->gecos << "</gecos>";
+					data << "<gecos>" << Sanitize(b->gecos) << "</gecos>";
 					data << "<usercount>" << b->usercount << "</usercount>";
 // This is currently not implemented, so, commented out.
 //					data << "<opercount>" << b->opercount << "</opercount>";


### PR DESCRIPTION
The description of the local server is ``Sanitize()``'d before being printed, but those of other servers are not.
When the remote server uses a non-UTF-8 charset in its description, this causes the generated XML file to be invalid.