### PR TITLE
Fix OpenSSL build errors caused by BIO/BIO_METHOD now being opaque.

### DIFF
--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -58,6 +58,15 @@
 #define INSPIRCD_OPENSSL_ENABLE_ECDH
 #endif
 
+// BIO is opaque in OpenSSL 1.1 but the access API does not exist in 1.0 and older.
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+# define BIO_get_data(BIO) BIO->ptr
+# define BIO_set_data(BIO, VALUE) BIO->ptr = VALUE;
+# define BIO_set_init(BIO, VALUE) BIO->init = VALUE;
+#else
+# define INSPIRCD_OPENSSL_OPAQUE_BIO
+#endif
+
 enum issl_status { ISSL_NONE, ISSL_HANDSHAKING, ISSL_OPEN };
 
 static bool SelfSigned = false;
@@ -372,7 +381,7 @@ namespace OpenSSL
 	{
 		static int create(BIO* bio)
 		{
-			bio->init = 1;
+			BIO_set_init(bio, 1);
 			return 1;
 		}
 
@@ -393,9 +402,25 @@ namespace OpenSSL
 
 		static int read(BIO* bio, char* buf, int len);
 		static int write(BIO* bio, const char* buf, int len);
+
+#ifdef INSPIRCD_OPENSSL_OPAQUE_BIO
+		static BIO_METHOD* alloc()
+		{
+			BIO_METHOD* meth = BIO_meth_new(100 | BIO_TYPE_SOURCE_SINK, "inspircd");
+			BIO_meth_set_write(meth, OpenSSL::BIOMethod::write);
+			BIO_meth_set_read(meth, OpenSSL::BIOMethod::read);
+			BIO_meth_set_ctrl(meth, OpenSSL::BIOMethod::ctrl);
+			BIO_meth_set_create(meth, OpenSSL::BIOMethod::create);
+			BIO_meth_set_destroy(meth, OpenSSL::BIOMethod::destroy);
+			return meth;
+		}
+#endif
 	}
 }
 
+// BIO_METHOD is opaque in OpenSSL 1.1 so we can't do this.
+// See OpenSSL::BIOMethod::alloc for the new method.
+#ifndef INSPIRCD_OPENSSL_OPAQUE_BIO
 static BIO_METHOD biomethods =
 {
 	(100 | BIO_TYPE_SOURCE_SINK),
@@ -409,6 +434,9 @@ static BIO_METHOD biomethods =
 	OpenSSL::BIOMethod::destroy, // destroy, does nothing, see function body for more info
 	NULL // callback_ctrl
 };
+#else
+static BIO_METHOD* biomethods;
+#endif
 
 static int OnVerify(int preverify_ok, X509_STORE_CTX *ctx)
 {
@@ -558,7 +586,7 @@ class OpenSSLIOHook : public SSLIOHook
 			// to ISSL_NONE so CheckRenego() closes the session
 			status = ISSL_NONE;
 			BIO* bio = SSL_get_rbio(sess);
-			EventHandler* eh = static_cast<StreamSocket*>(bio->ptr);
+			EventHandler* eh = static_cast<StreamSocket*>(BIO_get_data(bio));
 			SocketEngine::Shutdown(eh, 2);
 		}
 	}
@@ -601,8 +629,12 @@ class OpenSSLIOHook : public SSLIOHook
 		, profile(sslprofile)
 	{
 		// Create BIO instance and store a pointer to the socket in it which will be used by the read and write functions
+#ifdef INSPIRCD_OPENSSL_OPAQUE_BIO
+		BIO* bio = BIO_new(biomethods);
+#else
 		BIO* bio = BIO_new(&biomethods);
-		bio->ptr = sock;
+#endif
+		BIO_set_data(bio, sock);
 		SSL_set_bio(sess, bio, bio);
 
 		SSL_set_ex_data(sess, exdataindex, this);
@@ -759,7 +791,7 @@ static int OpenSSL::BIOMethod::write(BIO* bio, const char* buffer, int size)
 {
 	BIO_clear_retry_flags(bio);
 
-	StreamSocket* sock = static_cast<StreamSocket*>(bio->ptr);
+	StreamSocket* sock = static_cast<StreamSocket*>(BIO_get_data(bio));
 	if (sock->GetEventMask() & FD_WRITE_WILL_BLOCK)
 	{
 		// Writes blocked earlier, don't retry syscall
@@ -782,7 +814,7 @@ static int OpenSSL::BIOMethod::read(BIO* bio, char* buffer, int size)
 {
 	BIO_clear_retry_flags(bio);
 
-	StreamSocket* sock = static_cast<StreamSocket*>(bio->ptr);
+	StreamSocket* sock = static_cast<StreamSocket*>(BIO_get_data(bio));
 	if (sock->GetEventMask() & FD_READ_WILL_BLOCK)
 	{
 		// Reads blocked earlier, don't retry syscall
@@ -892,6 +924,14 @@ class ModuleSSLOpenSSL : public Module
 		// Initialize OpenSSL
 		SSL_library_init();
 		SSL_load_error_strings();
+#ifdef INSPIRCD_OPENSSL_OPAQUE_BIO
+		biomethods = OpenSSL::BIOMethod::alloc();
+	}
+
+	~ModuleSSLOpenSSL()
+	{
+		BIO_meth_free(biomethods);
+#endif
 	}
 
 	void init() CXX11_OVERRIDE


### PR DESCRIPTION
OpenSSL is developed by incompetent people who have never heard of deprecating something before removing it. That is all.
