### PR TITLE
[2.0] Workaround modern Perls not adding . to @INC.

### DIFF
--- a/configure
+++ b/configure
@@ -28,6 +28,7 @@
 
 BEGIN {
 	require 5.8.0;
+	push @INC, '.';
 }
 
 use strict;

--- a/modulemanager
+++ b/modulemanager
@@ -25,6 +25,7 @@ use warnings FATAL => qw(all);
 use make::configure;
 
 BEGIN {
+	push @INC, '.';
 	unless (module_installed("LWP::Simple")) {
 		die "Your system is missing the LWP::Simple Perl module!";
 	}


### PR DESCRIPTION
For 3.0 I will work on a better fix for this but for 2.0 this just restores the old behaviour.

Thanks to @grawity for pointing this out.