### PR TITLE
Fix spanningtree protocol interface sending statusmsgs to whole channel

### DIFF
--- a/src/modules/m_spanningtree/protocolinterface.cpp
+++ b/src/modules/m_spanningtree/protocolinterface.cpp
@@ -137,9 +137,6 @@ void SpanningTreeProtocolInterface::PushToClient(User* target, const std::string
 
 void SpanningTreeProtocolInterface::SendChannel(Channel* target, char status, const std::string &text)
 {
-	std::string cname = target->name;
-	if (status)
-		cname = status + cname;
 	TreeServerList list;
 	CUList exempt_list;
 	Utils->GetListOfServersForChannel(target,list,status,exempt_list);
@@ -154,12 +151,20 @@ void SpanningTreeProtocolInterface::SendChannel(Channel* target, char status, co
 
 void SpanningTreeProtocolInterface::SendChannelPrivmsg(Channel* target, char status, const std::string &text)
 {
-	SendChannel(target, status, ":" + ServerInstance->Config->GetSID()+" PRIVMSG "+target->name+" :"+text);
+	std::string cname = target->name;
+	if (status)
+		cname.insert(0, 1, status);
+
+	SendChannel(target, status, ":" + ServerInstance->Config->GetSID()+" PRIVMSG "+cname+" :"+text);
 }
 
 void SpanningTreeProtocolInterface::SendChannelNotice(Channel* target, char status, const std::string &text)
 {
-	SendChannel(target, status, ":" + ServerInstance->Config->GetSID()+" NOTICE "+target->name+" :"+text);
+	std::string cname = target->name;
+	if (status)
+		cname.insert(0, 1, status);
+
+	SendChannel(target, status, ":" + ServerInstance->Config->GetSID()+" NOTICE "+cname+" :"+text);
 }
 
 void SpanningTreeProtocolInterface::SendUserPrivmsg(User* target, const std::string &text)


### PR DESCRIPTION
This fixes a bug noticeable with m_timedbans (a few people have mentioned it in #inspircd), where sending to a status of (eg.) '@' will still send to the entire channel. From what I can see of the code, it was a small oversight in some re-writes in the past. This was the safest way I seen to fix this.
I see 3 other modules use the PI->SendChannel... functions, and they use a status of 0, that tests fine with this.
I also see this appears fixed in master with PI being rewritten quite a bit. This would be nice to have fixed in 2.0.