### PR TITLE
Store config values in a map instead of a unique vector of pairs.

### DIFF
--- a/include/configparser.h
+++ b/include/configparser.h
@@ -41,7 +41,7 @@ enum ParseFlags
 struct ParseStack
 {
 	std::vector<std::string> reading;
-	insp::flat_map<std::string, std::string> vars;
+	insp::flat_map<std::string, std::string, irc::insensitive_swo> vars;
 	ConfigDataHash& output;
 	ConfigFileCache& FilesOutput;
 	std::stringstream& errstr;

--- a/include/configreader.h
+++ b/include/configreader.h
@@ -35,7 +35,7 @@
 /** Structure representing a single \<tag> in config */
 class CoreExport ConfigTag : public refcountbase
 {
-	std::vector<KeyVal> items;
+	ConfigItems items;
  public:
 	const std::string tag;
 	const std::string src_name;
@@ -80,10 +80,10 @@ class CoreExport ConfigTag : public refcountbase
 
 	std::string getTagLocation();
 
-	inline const std::vector<KeyVal>& getItems() const { return items; }
+	inline const ConfigItems& getItems() const { return items; }
 
-	/** Create a new ConfigTag, giving access to the private KeyVal item list */
-	static ConfigTag* create(const std::string& Tag, const std::string& file, int line, std::vector<KeyVal>*& Items);
+	/** Create a new ConfigTag, giving access to the private ConfigItems item list */
+	static ConfigTag* create(const std::string& Tag, const std::string& file, int line, ConfigItems*& Items);
  private:
 	ConfigTag(const std::string& Tag, const std::string& file, int line);
 };

--- a/include/typedefs.h
+++ b/include/typedefs.h
@@ -66,9 +66,9 @@ typedef std::vector<Membership*> IncludeChanList;
  */
 typedef std::vector<std::string> file_cache;
 
-/** A configuration key and value pair
+/** A mapping of configuration keys to their assigned values.
  */
-typedef std::pair<std::string, std::string> KeyVal;
+typedef insp::flat_map<std::string, std::string> ConfigItems;
 
 /** The entire configuration
  */

--- a/include/typedefs.h
+++ b/include/typedefs.h
@@ -68,11 +68,11 @@ typedef std::vector<std::string> file_cache;
 
 /** A mapping of configuration keys to their assigned values.
  */
-typedef insp::flat_map<std::string, std::string> ConfigItems;
+typedef insp::flat_map<std::string, std::string, irc::insensitive_swo> ConfigItems;
 
 /** The entire configuration
  */
-typedef std::multimap<std::string, reference<ConfigTag> > ConfigDataHash;
+typedef std::multimap<std::string, reference<ConfigTag>, irc::insensitive_swo> ConfigDataHash;
 
 /** Iterator of ConfigDataHash */
 typedef ConfigDataHash::const_iterator ConfigIter;

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -46,7 +46,7 @@ ServerLimits::ServerLimits(ConfigTag* tag)
 
 static ConfigTag* CreateEmptyTag()
 {
-	std::vector<KeyVal>* items;
+	ConfigItems* items;
 	return ConfigTag::create("empty", "<auto>", 0, items);
 }
 
@@ -220,9 +220,9 @@ void ServerConfig::CrossCheckConnectBlocks(ServerConfig* current)
 	if (blk_count == 0)
 	{
 		// No connect blocks found; make a trivial default block
-		std::vector<KeyVal>* items;
+		ConfigItems* items;
 		ConfigTag* tag = ConfigTag::create("connect", "<auto>", 0, items);
-		items->push_back(std::make_pair("allow", "*"));
+		(*items)["allow"] = "*";
 		config_data.insert(std::make_pair("connect", tag));
 		blk_count = 1;
 	}

--- a/src/modules/m_httpd_config.cpp
+++ b/src/modules/m_httpd_config.cpp
@@ -81,8 +81,8 @@ class ModuleHttpConfig : public Module, public HTTPRequestEventListener
 				for (ConfigDataHash::iterator x = ServerInstance->Config->config_data.begin(); x != ServerInstance->Config->config_data.end(); ++x)
 				{
 					data << "&lt;" << x->first << " ";
-					ConfigTag* tag = x->second;
-					for (std::vector<KeyVal>::const_iterator j = tag->getItems().begin(); j != tag->getItems().end(); j++)
+					const ConfigItems& items = x->second->getItems();
+					for (ConfigItems::const_iterator j = items.begin(); j != items.end(); j++)
 					{
 						data << Sanitize(j->first) << "=&quot;" << Sanitize(j->second) << "&quot; ";
 					}


### PR DESCRIPTION
… and now the config is stored in a sane way make the config system case insensitive 