### PR TITLE
Always append the SSL fingerprint even if EXTERNAL is not used.

### DIFF
--- a/src/modules/m_sasl.cpp
+++ b/src/modules/m_sasl.cpp
@@ -164,7 +164,7 @@ class SaslAuthenticator
 		params.push_back(method);
 
 		LocalUser* localuser = IS_LOCAL(user);
-		if (method == "EXTERNAL" && localuser)
+		if (localuser)
 		{
 			std::string fp = SSLClientCert::GetFingerprint(&localuser->eh);
 


### PR DESCRIPTION
This allows services to implement alternate mechanisms that use the SSL fingerprint.