### PR TITLE
[2.0] Use clock_gettime() on macOS 10.12.

### DIFF
--- a/configure
+++ b/configure
@@ -877,6 +877,10 @@ print FILEHANDLE "#define MAXBUF " . ($config{MAXBUF}+2) . "\n";
 		}
 		if ($config{OSNAME} !~ /DARWIN/i) {
 			print FILEHANDLE "#define HAS_CLOCK_GETTIME\n";
+		} else {
+			print FILEHANDLE "#ifdef MAC_OS_X_VERSION_10_12\n";
+			print FILEHANDLE "# define HAS_CLOCK_GETTIME\n";
+			print FILEHANDLE "#endif\n";
 		}
 		my $use_hiperf = 0;
 		if (($has_kqueue) && ($config{USE_KQUEUE} eq "y")) {


### PR DESCRIPTION
This is the 2.0 equivalent of #1273.