### PR TITLE
[2.0] Add a mailmap to clean up the output of git-shortlog.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,42 @@
+Adam <Adam@anope.org>                        Adam <adam@inspircd.org>
+Adam <Adam@anope.org>                        Adam <adam@sigterm.info>
+Attila Molnar <attilamolnar@hush.com>        attilamolnar <am63770@gmail.com>
+Attila Molnar <attilamolnar@hush.com>        attilamolnar <attilamolnar@hush.com>
+blitmap <blitternet@gmail.com>               Pogs McPoggerson <sir.pogsalot@gmail.com>
+blitmap <blitternet@gmail.com>               Sir Poggles <sir.pogsalot@gmail.com>
+blitmap <blitternet@gmail.com>               Sir Pogsalot <sir.pogsalot@gmail.com>
+ChrisTX <xpipe@hotmail.de>                   ChrisTX <chris@rev-crew.info>
+Craig Edwards <brain@inspircd.org>           (no author) <(no author)@e03df62e-2008-0410-955e-edbf42e46eb7>
+Craig Edwards <brain@inspircd.org>           brain <brain@e03df62e-2008-0410-955e-edbf42e46eb7>
+Craig Edwards <brain@inspircd.org>           root <root@e03df62e-2008-0410-955e-edbf42e46eb7>
+Craig McLure <craig@frostycoolslug.com>      frostycoolslug <frostycoolslug@e03df62e-2008-0410-955e-edbf42e46eb7>
+Daniel De Graaf <danieldg@inspircd.org>      danieldg <danieldg@e03df62e-2008-0410-955e-edbf42e46eb7>
+Daniel Vassdal <shutter@canternet.org>       Daniel Vassdal <daniel@daniel-VirtualBox.(none)>
+Daniel Vassdal <shutter@canternet.org>       ShutterQuick <shutter@canternet.org>
+Dennis Friis <peavey@inspircd.org>           peavey <peavey@e03df62e-2008-0410-955e-edbf42e46eb7>
+DjSlash <djslash@djslash.org>                Rutger <djslash+github@djslash.org>
+Geoff Bricker <geoff.bricker@gmail.com>      bricker <bricker@e03df62e-2008-0410-955e-edbf42e46eb7>
+jackmcbarn <jackmcbarn@inspircd.org>         Jackmcbarn <jackmcbarn@jackmcbarn.no-ip.org>
+John Brooks <special@inspircd.org>           special <special@e03df62e-2008-0410-955e-edbf42e46eb7>
+Justin Crawford <Justasic@Gmail.com>         Justasic <Justasic@gmail.com>
+Matt Smith <dz@inspircd.org>                 dz <dz@e03df62e-2008-0410-955e-edbf42e46eb7>
+Oliver Lupton <om@inspircd.org>              om <om@e03df62e-2008-0410-955e-edbf42e46eb7>
+Pippijn van Steenhoven <pip88nl@gmail.com>   pippijn <pippijn@e03df62e-2008-0410-955e-edbf42e46eb7>
+Robby <robby@chatbelgie.be>                  Robby- <robby@chat.be>
+Robby <robby@chatbelgie.be>                  Robby- <robbyke@gmail.com>
+Robin Burchell <robin+git@viroteck.net>      Robin Burchell <viroteck@viroteck.net>
+Robin Burchell <robin+git@viroteck.net>      w00t <w00t@e03df62e-2008-0410-955e-edbf42e46eb7>
+Thomas Stagner <aquanight@inspircd.org>      aquanight <aquanight@e03df62e-2008-0410-955e-edbf42e46eb7>
+Uli Schlachter <psychon@inspircd.org>        psychon <psychon@e03df62e-2008-0410-955e-edbf42e46eb7>
+William Pitcock <nenolod@dereferenced.org>   nenolod <nenolod@e03df62e-2008-0410-955e-edbf42e46eb7>
+
+# The identities of the following people could not be verified:
+#
+#   burlex <burlex@e03df62e-2008-0410-955e-edbf42e46eb7>
+#   eggy <eggy@e03df62e-2008-0410-955e-edbf42e46eb7>
+#   fez <fez@e03df62e-2008-0410-955e-edbf42e46eb7>
+#   jamie <jamie@e03df62e-2008-0410-955e-edbf42e46eb7>
+#   katsklaw <katsklaw@e03df62e-2008-0410-955e-edbf42e46eb7>
+#   Philouuu <philsliders@laptop.(none)> / PhilSliderS <philsliders@laptop.(none)>
+#   randomdan <randomdan@e03df62e-2008-0410-955e-edbf42e46eb7>
+#   typobox43 <typobox43@e03df62e-2008-0410-955e-edbf42e46eb7>


### PR DESCRIPTION
This cleans up the author list when running git-shortlog and other similar commands.

More details: https://git-scm.com/docs/git-shortlog#_mapping_authors