### PR TITLE
WIP: Add SSL log messages.

### DIFF
--- a/src/modules/m_sslinfo.cpp
+++ b/src/modules/m_sslinfo.cpp
@@ -239,6 +239,19 @@ class ModuleSSLInfo : public Module
 		if (myclass->config->getString("requiressl") == "trusted")
 		{
 			ok = (req.cert && req.cert->IsCAVerified());
+			if (!ok) {
+				ServerInstance->Logs->Log("m_sslinfo", DEFAULT,
+					"Invalid client certificate from '%s' port '%d': '%s'",
+					user->GetIPString(), user->GetServerPort(),
+					req.cert ? req.cert->GetError().c_str() : "No SSL in use");
+			} else {
+				ServerInstance->Logs->Log("m_sslinfo", DEFAULT,
+					"Accepted client certificate from '%s' port '%d' with DN '%s', Issuer '%s', and FP '%s'",
+					user->GetIPString(), user->GetServerPort(),
+					req.cert->GetDN().c_str(),
+					req.cert->GetIssuer().c_str(),
+					req.cert->GetFingerprint().c_str());
+			}
 		}
 		else if (myclass->config->getBool("requiressl"))
 		{


### PR DESCRIPTION
Specifically, add messages for:

	- OpenSSL handshake errors
	- Valid/invalid client certificate when connecting to a
	  'trusted' connection class

--------
Example log messages

Connecting to SSL-only without SSL:
`Fri Jan 27 21:29:30 2017: OpenSSL handshake error 'error:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol' for '127.0.0.1' port '7001'`

Connecting without SSL certificate:
`Fri Jan 27 21:30:20 2017: Invalid client certificate for '127.0.0.1' port '7001': 'Could not get peer certificate'`

Connecting with invalid SSL certificate:
`Fri Jan 27 21:31:37 2017: Invalid client certificate for '127.0.0.1' port '7001': 'self signed certificate'`

Connecting with valid SSL certificate:
`Fri Jan 27 21:32:59 2017: Accepted client certificate for '127.0.0.1' port '7001' with Distinguished Name '/CN=frostsnow', Issuer '/CN=frostsnow.net', and Fingerprint '49cdd9dbabd83feb214b3a53a273eb2de9fbcccc'`
