### PR TITLE
[2.0] Warn when capability-providing modules are loaded without m_cap.

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1154,6 +1154,9 @@
 # NAMESX module: Provides support for the NAMESX extension which allows
 # clients to see all the prefixes set on a user without getting confused.
 # This is supported by mIRC, x-chat, klient, and maybe more.
+#
+# IMPORTANT: you should also load m_cap.so so that clients can enable
+# this via the IRCv3 userhost-in-names capability.
 #<module name="m_namesx.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
@@ -1840,6 +1843,9 @@
 # each user, saving clients from doing a WHO on the channel.
 # If a client does not support UHNAMES it will not enable it, this will
 # not break incompatible clients.
+#
+# IMPORTANT: you should also load m_cap.so so that clients can enable
+# this via the IRCv3 multi-prefix capability.
 #<module name="m_uhnames.so">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -321,6 +321,10 @@ class ModuleSSLGnuTLS : public Module
 
 		ServerInstance->Modules->AddService(iohook);
 		ServerInstance->Modules->AddService(starttls);
+
+		if (starttls.enabled && !ServerInstance->Modules->Find("m_cap.so"))
+			ServerInstance->Logs->Log("m_ssl_gnutls", DEFAULT, "WARNING: m_cap.so is not loaded. The tls capability will not be available to clients without this!");
+
 	}
 
 	void OnRehash(User* user)

--- a/src/modules/m_ircv3.cpp
+++ b/src/modules/m_ircv3.cpp
@@ -83,6 +83,10 @@ class ModuleIRCv3 : public Module
 		OnRehash(NULL);
 		Implementation eventlist[] = { I_OnUserJoin, I_OnPostJoin, I_OnSetAway, I_OnEvent, I_OnRehash };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
+
+		if (!ServerInstance->Modules->Find("m_cap.so"))
+			ServerInstance->Logs->Log("m_ircv3", DEFAULT, "WARNING: m_cap.so is not loaded. The account-notify, away-notify, and extended-join capabilities will not be available to clients without this!");
+
 	}
 
 	void OnRehash(User* user)

--- a/src/modules/m_namesx.cpp
+++ b/src/modules/m_namesx.cpp
@@ -37,6 +37,9 @@ class ModuleNamesX : public Module
 	{
 		Implementation eventlist[] = { I_OnPreCommand, I_OnNamesListItem, I_On005Numeric, I_OnEvent, I_OnSendWhoLine };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
+
+		if (!ServerInstance->Modules->Find("m_cap.so"))
+			ServerInstance->Logs->Log("m_namesx", DEFAULT, "WARNING: m_cap.so is not loaded. The multi-prefix capability will not be available to clients without this!");
 	}
 
 

--- a/src/modules/m_uhnames.cpp
+++ b/src/modules/m_uhnames.cpp
@@ -37,6 +37,9 @@ class ModuleUHNames : public Module
 	{
 		Implementation eventlist[] = { I_OnEvent, I_OnPreCommand, I_OnNamesListItem, I_On005Numeric };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
+
+		if (!ServerInstance->Modules->Find("m_cap.so"))
+			ServerInstance->Logs->Log("m_uhnames", DEFAULT, "WARNING: m_cap.so is not loaded. The userhost-in-names capability will not be available to clients without this!");
 	}
 
 	~ModuleUHNames()


### PR DESCRIPTION
Also add reminders to the example configs that m_cap is required.