### PR TITLE
[2.0] Fix WEBIRC not rejecting invalid IP addresses.

### DIFF
--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -85,6 +85,7 @@ class CommandWebirc : public Command
 			irc::sockets::sockaddrs ipaddr;
 			if (!irc::sockets::aptosa(parameters[3], 0, ipaddr))
 			{
+				IS_LOCAL(user)->CommandFloodPenalty += 5000;
 				ServerInstance->SNO->WriteGlobalSno('a', "Connecting user %s tried to use WEBIRC but gave an invalid IP address.", user->GetFullRealHost().c_str());
 				return CMD_FAILURE;
 			}
@@ -116,6 +117,7 @@ class CommandWebirc : public Command
 				}
 			}
 
+			IS_LOCAL(user)->CommandFloodPenalty += 5000;
 			ServerInstance->SNO->WriteGlobalSno('a', "Connecting user %s tried to use WEBIRC, but didn't match any configured webirc blocks.", user->GetFullRealHost().c_str());
 			return CMD_FAILURE;
 		}

--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -73,6 +73,7 @@ class CommandWebirc : public Command
 		  realhost("cgiirc_realhost", Creator), realip("cgiirc_realip", Creator),
 		  webirc_hostname("cgiirc_webirc_hostname", Creator), webirc_ip("cgiirc_webirc_ip", Creator)
 		{
+			allow_empty_last_param = false;
 			works_before_reg = true;
 			this->syntax = "password client hostname ip";
 		}
@@ -80,6 +81,13 @@ class CommandWebirc : public Command
 		{
 			if(user->registered == REG_ALL)
 				return CMD_FAILURE;
+
+			irc::sockets::sockaddrs ipaddr;
+			if (!irc::sockets::aptosa(parameters[3], 0, ipaddr))
+			{
+				ServerInstance->SNO->WriteGlobalSno('a', "Connecting user %s tried to use WEBIRC but gave an invalid IP address.", user->GetFullRealHost().c_str());
+				return CMD_FAILURE;
+			}
 
 			for(CGIHostlist::iterator iter = Hosts.begin(); iter != Hosts.end(); iter++)
 			{


### PR DESCRIPTION
If an IP address which is invalid is given then the IP address given to the user `webirc_ip` will contain junk. This is not as dangerous as it looks as the core will reject the invalid IP when SetClientIP is called. It should be rejected earlier than that though to prevent incorrect notices being given.

Some examples of things this patch prevents:

```
WEBIRC password * ###################################################################### :
WEBIRC password * ###################################################################### :invalid ipaddr here
```

---

Also penalise clients that use WEBIRC incorrectly (mostly useful for preventing trolls from spamming opers with invalid WEBIRC host messages).