### PR TITLE
[2.0] Fix ModuleManager not being able to find make::configure.

### DIFF
--- a/modulemanager
+++ b/modulemanager
@@ -22,10 +22,15 @@
 use strict;
 use warnings FATAL => qw(all);
 
-use make::configure;
+BEGIN {
+	require 5.8.0;
+	push @INC, '.';
+}
 
 BEGIN {
-	push @INC, '.';
+	# HACK: for some reason this needs to be in a second BEGIN block
+	# or it doesn't receive the updated @INC from above.
+	use make::configure;
 	unless (module_installed("LWP::Simple")) {
 		die "Your system is missing the LWP::Simple Perl module!";
 	}


### PR DESCRIPTION
Apparently not only is the Perl documentation on BEGIN block execution order wrong but in a BEGIN block any updates to the include paths are not applied until the end of the block. Yay!