### PR TITLE
[2.0] Tell OpenBSD users that they need to use a different make command.

### DIFF
--- a/configure
+++ b/configure
@@ -733,6 +733,14 @@ to a newer 3.x or 4.x (or whatever is available currently) version.
 FOO2
 }
 
+if ($^O eq 'openbsd') {
+	print <<__OPENBSD_WARNING__;
+\e[1;32mWARNING!\e[0m OpenBSD 6.5 changed Make to no longer look for BSDmakefile when
+searching for the makefile. If the version of OpenBSD you are using is 6.5 or
+newer then you will need to run '\e[1;32mmake -f BSDmakefile\e[0m' or '\e[1;32mgmake\e[0m' instead.
+__OPENBSD_WARNING__
+}
+
 ################################################################################
 #			      HELPER FUNCTIONS				#
 ################################################################################


### PR DESCRIPTION
OpenBSD decided to remove `BSDmakefile` support because it is non standard (heaven forbid!) so our automagic makefile stuff no longer works. We can't do a lot about this other than warn OpenBSD users to run a different command instead.

Ref: https://github.com/openbsd/src/commit/7c8e039b953a21c37b44a481b0a7b62a845164dc

See also: #1332