### PR TITLE
Warn the user about clock drifting when running on OpenVZ.

### DIFF
--- a/configure
+++ b/configure
@@ -240,6 +240,15 @@ $config{UID}  = $user[2];
 # Clear the screen.
 system 'tput', 'clear' if $interactive;
 
+# Warn the user about clock drifting when running on OpenVZ.
+if (-e '/proc/user_beancounters' || -e '/proc/vz/vzaquota') {
+	print_warning <<'EOW';
+You are building InspIRCd inside of an an OpenVZ container. If you
+plan to use InspIRCd in this container then you should make sure that NTP is
+configured on the Hardware Node. Failure to do so may result in clock drifting!
+EOW
+}
+
 # Check that the user actually wants this version.
 if ($version{LABEL} ne 'release') {
 	print_warning <<'EOW';


### PR DESCRIPTION
Apparently even though its 2017 and there are much better options for virtualisation available this is still a problem that people need to be warned about.