### PR TITLE
[2.0] Fix exempting CTCP ACTIONs in m_blockcaps and m_noctcp.

### DIFF
--- a/src/modules/m_blockcaps.cpp
+++ b/src/modules/m_blockcaps.cpp
@@ -67,7 +67,7 @@ public:
 	{
 		if (target_type == TYPE_CHANNEL)
 		{
-			if ((!IS_LOCAL(user)) || (text.length() < minlen))
+			if ((!IS_LOCAL(user)) || (text.length() < minlen) || (text == "\1ACTION\1") || (text == "\1ACTION"))
 				return MOD_RES_PASSTHRU;
 
 			Channel* c = (Channel*)dest;

--- a/src/modules/m_noctcp.cpp
+++ b/src/modules/m_noctcp.cpp
@@ -67,7 +67,7 @@ class ModuleNoCTCP : public Module
 		if ((target_type == TYPE_CHANNEL) && (IS_LOCAL(user)))
 		{
 			Channel* c = (Channel*)dest;
-			if ((text.empty()) || (text[0] != '\001') || (!strncmp(text.c_str(),"\1ACTION ",8)))
+			if ((text.empty()) || (text[0] != '\001') || (!strncmp(text.c_str(),"\1ACTION ", 8)) || (text == "\1ACTION\1") || (text == "\1ACTION"))
 				return MOD_RES_PASSTHRU;
 
 			ModResult res = ServerInstance->OnCheckExemption(user,c,"noctcp");


### PR DESCRIPTION
Previously we assumed that CTCP ACTIONs matched "\1ACTION ". This is incorrect because "\1ACTION\1" and "\1ACTION" are valid CTCPs.
