### PR TITLE
Allow filtering WebIRC connections into a connect class by gateway.

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -287,6 +287,10 @@
          # useident: Defines if users in this class MUST respond to a ident query or not.
          useident="no"
 
+         # webirc: Restricts usage of this class to the specified WebIRC gateway.
+         # This setting only has effect when the cgiirc module is loaded.
+         #webirc="name"
+
          # limit: How many users are allowed in this class
          limit="5000"
 


### PR DESCRIPTION
I have also renamed the `client` field to `gateway` to match the IRCv3 WebIRC specification.

http://ircv3.net/specs/extensions/webirc.html