### PR TITLE
2.0: Inform the client when a SASL message cannot be sent

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1591,6 +1591,13 @@
 # Layer via AUTHENTICATE. Note: You also need to have m_cap.so loaded
 # for SASL to work.
 #<module name="m_sasl.so">
+# Define the following to your services server name to improve security
+# by ensuring the SASL messages are only sent to the services server
+# and not to all connected servers. This prevents a rogue server from
+# capturing SASL messages. Having this defined can also improve client
+# connections when your services are down, as the client will be told
+# that SASL failed rather than just timing out on registration.
+#<sasl target="services.mynetwork.com">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Secure list module: Prevent /LIST in the first minute of connection,

--- a/src/modules/m_sasl.cpp
+++ b/src/modules/m_sasl.cpp
@@ -35,6 +35,10 @@ static void SendSASL(const parameterlist& params)
 {
 	if (!ServerInstance->PI->SendEncapsulatedData(params))
 	{
+		User* u = ServerInstance->FindUUID(params[2]);
+		if (u)
+			u->WriteNumeric(904, "%s :SASL authentication failed", u->nick.c_str());
+
 		SASLFallback(NULL, params);
 	}
 }


### PR DESCRIPTION
Back when the SASL `target` variable was introduced (commit 8cb1935360087b4e38802b837981e5f41e9b87d7), the example config wasn't updated and it's not a very well known config variable. This variable allows the ENCAP message to return false if the server isn't available (ie, Services are offline). Though currently, even when used it just sends a SASLFallback event that (afaik) is not caught anywhere.

The issue here is that if Services are down and a client is connecting and sees SASL available (through CAP), it requests it, gets acknowledged and tries to use it. The message either sends to all servers (default target of '*') or fails to send to the target server. The client sits there waiting for a response, until registration timeout hits. We can't do much with sending to all servers and receiving no reply (afaik), but we can let the client know when a targeted message fails. This is a fairly small change (imo) and won't affect anything unless a target is specified and Services are down.
I know some clients do a SASL timeout, but that can still be longer than the server's registration timeout.
For reference, I know that Quassel and some (if not all) versions of ZNC have this timeout issue with SASL and Services being down. This just happened to me yesterday on ChatSpike.

3.0 (master) handles this differently by not sending the SASL CAP when the target server is offline. That's too much of a change for 2.0 though.

This has been tested to work on a 2-server insp20 + Anope network.
