### PR TITLE
Make RLines match against IP as well as host

### DIFF
--- a/src/modules/m_rline.cpp
+++ b/src/modules/m_rline.cpp
@@ -62,8 +62,9 @@ class RLine : public XLine
 		if (lu && lu->exempt)
 			return false;
 
-		std::string compare = u->nick + "!" + u->ident + "@" + u->host + " " + u->fullname;
-		return regex->Matches(compare);
+		const std::string host = u->nick + "!" + u->ident + "@" + u->host + " " + u->fullname;
+		const std::string ip = u->nick + "!" + u->ident + "@" + u->GetIPString() + " " + u->fullname;
+		return (regex->Matches(host) || regex->Matches(ip));
 	}
 
 	bool Matches(const std::string &compare)


### PR DESCRIPTION
RLines currently only check for a match including the User's host and not the IP. This may have been intentional but I believe to be an oversight.
One may wish to set an RLine using a portion of the IP and it stands the chance of not matching if their IP resolves to any host.

This PR replaces #1358