### PR TITLE
Add a type for cloaked strings and switch User#host to use it.

### DIFF
--- a/include/inspstring.h
+++ b/include/inspstring.h
@@ -24,6 +24,49 @@
 #include "config.h"
 #include <cstring>
 
+namespace insp
+{
+	//! Implements a string wrapper which can have both a real value and a display value.
+	class CloakedString
+	{
+	private:
+		/** The display value. */
+		std::string display;
+
+		/** The real value. */
+		std::string real;
+
+	public:
+		/**
+		 * Initialize a cloaked string with just a real value.
+		 * @param rvalue The initial real value.
+		 */
+		CloakedString(const std::string& rvalue);
+
+		/**
+		 * Initialize a cloaked string with both a real and display value.
+		* @param rvalue The initial real value.
+		* @param dvalue The initial display value.
+		*/
+		CloakedString(const std::string& rvalue, const std::string& dvalue);
+
+		//! Retrieves the value of the cloaked string.
+		const std::string& Get(bool uncloak) const;
+
+		//! Retrieves the display value of the cloaked string.
+		const std::string& GetDisplay() const;
+
+		//! Retrieves the real value of the cloaked string.
+		const std::string& GetReal() const;
+
+		//! Sets the display value of the cloaked string.
+		void SetDisplay(const std::string& value);
+
+		//! Sets the real value of the cloaked string.
+		void SetReal(const std::string& value);
+	};
+}
+
 /** Sets ret to the formated string. last is the last parameter before ..., and format is the format in printf-style */
 #define VAFORMAT(ret, last, format) \
 	do { \

--- a/include/modules/sql.h
+++ b/include/modules/sql.h
@@ -174,7 +174,7 @@ class SQLProvider : public DataProvider
 	void PopulateUserInfo(User* user, ParamM& userinfo)
 	{
 		userinfo["nick"] = user->nick;
-		userinfo["host"] = user->host;
+		userinfo["host"] = user->host.GetReal();
 		userinfo["ip"] = user->GetIPString();
 		userinfo["gecos"] = user->fullname;
 		userinfo["ident"] = user->ident;

--- a/include/users.h
+++ b/include/users.h
@@ -28,6 +28,7 @@
 #include "inspsocket.h"
 #include "mode.h"
 #include "membership.h"
+#include "inspstring.h"
 
 /** connect class types
  */
@@ -270,11 +271,6 @@ class CoreExport User : public Extensible
 	 */
 	typedef insp::intrusive_list<Membership> ChanList;
 
-	/** Hostname of connection.
-	 * This should be valid as per RFC1035.
-	 */
-	std::string host;
-
 	/** Time that the object was instantiated (used for TS calculation etc)
 	*/
 	time_t age;
@@ -307,10 +303,9 @@ class CoreExport User : public Extensible
 	 */
 	std::string ident;
 
-	/** The host displayed to non-opers (used for cloaking etc).
-	 * This usually matches the value of User::host.
+	/** The hostname of this user.
 	 */
-	std::string dhost;
+	insp::CloakedString host;
 
 	/** The users full name (GECOS).
 	 */

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -381,8 +381,8 @@ bool Channel::CheckBan(User* user, const std::string& mask)
 	if (InspIRCd::Match(nickIdent, prefix, NULL))
 	{
 		std::string suffix(mask, at + 1);
-		if (InspIRCd::Match(user->host, suffix, NULL) ||
-			InspIRCd::Match(user->dhost, suffix, NULL) ||
+		if (InspIRCd::Match(user->host.GetReal(), suffix, NULL) ||
+			InspIRCd::Match(user->host.GetDisplay(), suffix, NULL) ||
 			InspIRCd::MatchCIDR(user->GetIPString(), suffix, NULL))
 			return true;
 	}

--- a/src/command_parse.cpp
+++ b/src/command_parse.cpp
@@ -295,7 +295,7 @@ void CommandParser::ProcessCommand(LocalUser *user, std::string &cmd)
 		}
 
 		ServerInstance->SNO->WriteToSnoMask('a', "%s denied for %s (%s@%s)",
-				command.c_str(), user->nick.c_str(), user->ident.c_str(), user->host.c_str());
+				command.c_str(), user->nick.c_str(), user->ident.c_str(), user->host.GetReal().c_str());
 		return;
 	}
 

--- a/src/coremods/core_hostname_lookup.cpp
+++ b/src/coremods/core_hostname_lookup.cpp
@@ -145,8 +145,7 @@ class UserResolver : public DNS::Request
 						hostname->insert(0, "0");
 
 					bound_user->WriteNotice("*** Found your hostname (" + *hostname + (r->cached ? ") -- cached" : ")"));
-					bound_user->host.assign(*hostname, 0, ServerInstance->Config->Limits.MaxHost);
-					bound_user->dhost = bound_user->host;
+					bound_user->host = insp::CloakedString(hostname->substr(ServerInstance->Config->Limits.MaxHost));
 
 					/* Invalidate cache */
 					bound_user->InvalidateCache();

--- a/src/coremods/core_oper/cmd_kill.cpp
+++ b/src/coremods/core_oper/cmd_kill.cpp
@@ -102,7 +102,7 @@ CmdResult CommandKill::Handle (const std::vector<std::string>& parameters, User 
 		ServerInstance->Logs->Log("KILL", LOG_DEFAULT, "%s KILL: %s :%s!%s!%s (%s)",
 				IS_LOCAL(user) && IS_LOCAL(target) ? "LOCAL" : "REMOTE",
 				target->nick.c_str(),
-				ServerInstance->Config->ServerName.c_str(), user->dhost.c_str(), user->nick.c_str(),
+				ServerInstance->Config->ServerName.c_str(), user->host.GetDisplay().c_str(), user->nick.c_str(),
 				parameters[1].c_str());
 
 	if (IS_LOCAL(target))

--- a/src/coremods/core_oper/cmd_oper.cpp
+++ b/src/coremods/core_oper/cmd_oper.cpp
@@ -34,7 +34,7 @@ CmdResult CommandOper::HandleLocal(const std::vector<std::string>& parameters, L
 	bool match_pass = false;
 	bool match_hosts = false;
 
-	const std::string userHost = user->ident + "@" + user->host;
+	const std::string userHost = user->ident + "@" + user->host.GetReal();
 	const std::string userIP = user->ident + "@" + user->GetIPString();
 
 	ServerConfig::OperIndex::const_iterator i = ServerInstance->Config->oper_blocks.find(parameters[0]);

--- a/src/coremods/core_stats.cpp
+++ b/src/coremods/core_stats.cpp
@@ -58,7 +58,7 @@ static void GenerateStatsLl(Stats::Context& stats)
 	for (UserManager::LocalList::const_iterator i = list.begin(); i != list.end(); ++i)
 	{
 		LocalUser* u = *i;
-		stats.AddRow(211, u->nick+"["+u->ident+"@"+(stats.GetSymbol() == 'l' ? u->dhost : u->GetIPString())+"] "+ConvToStr(u->eh.getSendQSize())+" "+ConvToStr(u->cmds_out)+" "+ConvToStr(u->bytes_out)+" "+ConvToStr(u->cmds_in)+" "+ConvToStr(u->bytes_in)+" "+ConvToStr(ServerInstance->Time() - u->signon));
+		stats.AddRow(211, u->nick+"["+u->ident+"@"+(stats.GetSymbol() == 'l' ? u->host.GetDisplay() : u->GetIPString())+"] "+ConvToStr(u->eh.getSendQSize())+" "+ConvToStr(u->cmds_out)+" "+ConvToStr(u->bytes_out)+" "+ConvToStr(u->cmds_in)+" "+ConvToStr(u->bytes_in)+" "+ConvToStr(ServerInstance->Time() - u->signon));
 	}
 }
 
@@ -76,7 +76,7 @@ void CommandStats::DoStats(Stats::Context& stats)
 		ServerInstance->SNO->WriteToSnoMask('t',
 				"%s '%c' denied for %s (%s@%s)",
 				(IS_LOCAL(user) ? "Stats" : "Remote stats"),
-				statschar, user->nick.c_str(), user->ident.c_str(), user->host.c_str());
+				statschar, user->nick.c_str(), user->ident.c_str(), user->host.GetReal().c_str());
 		stats.AddRow(481, (std::string("Permission Denied - STATS ") + statschar + " requires the servers/auspex priv."));
 		return;
 	}
@@ -87,7 +87,7 @@ void CommandStats::DoStats(Stats::Context& stats)
 	{
 		stats.AddRow(219, statschar, "End of /STATS report");
 		ServerInstance->SNO->WriteToSnoMask('t',"%s '%c' requested by %s (%s@%s)",
-			(IS_LOCAL(user) ? "Stats" : "Remote stats"), statschar, user->nick.c_str(), user->ident.c_str(), user->host.c_str());
+			(IS_LOCAL(user) ? "Stats" : "Remote stats"), statschar, user->nick.c_str(), user->ident.c_str(), user->host.GetReal().c_str());
 		return;
 	}
 
@@ -167,7 +167,7 @@ void CommandStats::DoStats(Stats::Context& stats)
 				if (!oper->server->IsULine())
 				{
 					LocalUser* lu = IS_LOCAL(oper);
-					stats.AddRow(249, oper->nick + " (" + oper->ident + "@" + oper->dhost + ") Idle: " +
+					stats.AddRow(249, oper->nick + " (" + oper->ident + "@" + oper->host.GetDisplay() + ") Idle: " +
 							(lu ? ConvToStr(ServerInstance->Time() - lu->idle_lastmsg) + " secs" : "unavailable"));
 					idx++;
 				}
@@ -360,7 +360,7 @@ void CommandStats::DoStats(Stats::Context& stats)
 
 	stats.AddRow(219, statschar, "End of /STATS report");
 	ServerInstance->SNO->WriteToSnoMask('t',"%s '%c' requested by %s (%s@%s)",
-		(IS_LOCAL(user) ? "Stats" : "Remote stats"), statschar, user->nick.c_str(), user->ident.c_str(), user->host.c_str());
+		(IS_LOCAL(user) ? "Stats" : "Remote stats"), statschar, user->nick.c_str(), user->ident.c_str(), user->host.GetReal().c_str());
 	return;
 }
 

--- a/src/coremods/core_userhost.cpp
+++ b/src/coremods/core_userhost.cpp
@@ -72,7 +72,7 @@ CmdResult CommandUserhost::Handle (const std::vector<std::string>& parameters, U
 			retbuf += (u->IsAway() ? '-' : '+');
 			retbuf += u->ident;
 			retbuf += '@';
-			retbuf += (((u == user) || (has_privs)) ? u->host : u->dhost);
+			retbuf += u->host.Get((u == user) || has_privs);
 			retbuf += ' ';
 		}
 	}

--- a/src/coremods/core_who.cpp
+++ b/src/coremods/core_who.cpp
@@ -128,7 +128,7 @@ bool CommandWho::whomatch(User* cuser, User* user, const char* matchtext)
 		else if (opt_realname)
 			match = InspIRCd::Match(user->fullname, matchtext);
 		else if (opt_showrealhost)
-			match = InspIRCd::Match(user->host, matchtext, ascii_case_insensitive_map);
+			match = InspIRCd::Match(user->host.GetReal(), matchtext, ascii_case_insensitive_map);
 		else if (opt_ident)
 			match = InspIRCd::Match(user->ident, matchtext, ascii_case_insensitive_map);
 		else if (opt_port)
@@ -161,7 +161,7 @@ bool CommandWho::whomatch(User* cuser, User* user, const char* matchtext)
 		 * -- w00t
 		 */
 		if (!match)
-			match = InspIRCd::Match(user->dhost, matchtext, ascii_case_insensitive_map);
+			match = InspIRCd::Match(user->host.GetDisplay(), matchtext, ascii_case_insensitive_map);
 
 		if (!match)
 			match = InspIRCd::Match(user->nick, matchtext);
@@ -198,7 +198,7 @@ void CommandWho::SendWhoLine(User* user, const std::vector<std::string>& parms, 
 
 	Numeric::Numeric wholine(RPL_WHOREPLY);
 	wholine.push(memb ? memb->chan->name : "*").push(u->ident);
-	wholine.push(opt_showrealhost ? u->host : u->dhost);
+	wholine.push(u->host.Get(opt_showrealhost));
 	if (!ServerInstance->Config->HideWhoisServer.empty() && !user->HasPrivPermission("servers/auspex"))
 		wholine.push(ServerInstance->Config->HideWhoisServer);
 	else

--- a/src/coremods/core_whois.cpp
+++ b/src/coremods/core_whois.cpp
@@ -177,10 +177,10 @@ void CommandWhois::DoWhois(LocalUser* user, User* dest, unsigned long signon, un
 {
 	WhoisContextImpl whois(user, dest, lineevprov);
 
-	whois.SendLine(311, dest->ident, dest->dhost, '*', dest->fullname);
+	whois.SendLine(311, dest->ident, dest->host.GetDisplay(), '*', dest->fullname);
 	if (whois.IsSelfWhois() || user->HasPrivPermission("users/auspex"))
 	{
-		whois.SendLine(378, InspIRCd::Format("is connecting from %s@%s %s", dest->ident.c_str(), dest->host.c_str(), dest->GetIPString().c_str()));
+		whois.SendLine(378, InspIRCd::Format("is connecting from %s@%s %s", dest->ident.c_str(), dest->host.GetReal().c_str(), dest->GetIPString().c_str()));
 	}
 
 	SendChanList(whois);

--- a/src/coremods/core_whowas.cpp
+++ b/src/coremods/core_whowas.cpp
@@ -230,8 +230,8 @@ void WhoWas::Manager::PurgeNick(WhoWas::Nick* nick)
 }
 
 WhoWas::Entry::Entry(User* user)
-	: host(user->host)
-	, dhost(user->dhost)
+	: host(user->host.GetReal())
+	, dhost(user->host.GetDisplay())
 	, ident(user->ident)
 	, server(user->server->GetName())
 	, gecos(user->fullname)

--- a/src/inspstring.cpp
+++ b/src/inspstring.cpp
@@ -124,3 +124,42 @@ bool InspIRCd::TimingSafeCompare(const std::string& one, const std::string& two)
 
 	return (diff == 0);
 }
+
+insp::CloakedString::CloakedString(const std::string& rvalue)
+	: real(rvalue)
+{
+}
+
+insp::CloakedString::CloakedString(const std::string& rvalue, const std::string& dvalue)
+	: real(rvalue)
+{
+	this->SetDisplay(dvalue);
+}
+
+const std::string& insp::CloakedString::Get(bool uncloak) const
+{
+	return uncloak ? GetReal() : GetDisplay();
+}
+const std::string& insp::CloakedString::GetDisplay() const
+{
+	return display.empty() ? real : display;
+}
+const std::string& insp::CloakedString::GetReal() const
+{
+	return real;
+}
+void insp::CloakedString::SetDisplay(const std::string& value)
+{
+	if (real == value)
+		display.clear();
+	else
+		display = value;
+}
+void insp::CloakedString::SetReal(const std::string& value)
+{
+	if (display.empty())
+		display = real;
+	else if (display == value)
+		display.clear();
+	real = value;
+}

--- a/src/modules/m_alias.cpp
+++ b/src/modules/m_alias.cpp
@@ -296,7 +296,7 @@ class ModuleAlias : public Module
 				}
 				else if (!newline.compare(i, 5, "$host", 5))
 				{
-					result.append(user->host);
+					result.append(user->host.GetReal());
 					i += 4;
 				}
 				else if (!newline.compare(i, 5, "$chan", 5))
@@ -312,7 +312,7 @@ class ModuleAlias : public Module
 				}
 				else if (!newline.compare(i, 6, "$vhost", 6))
 				{
-					result.append(user->dhost);
+					result.append(user->host.GetDisplay());
 					i += 5;
 				}
 				else if (!newline.compare(i, 12, "$requirement", 12))

--- a/src/modules/m_callerid.cpp
+++ b/src/modules/m_callerid.cpp
@@ -399,7 +399,7 @@ public:
 			if (now > (dat->lastnotify + (time_t)notify_cooldown))
 			{
 				user->WriteNumeric(RPL_TARGNOTIFY, dest->nick, "has been informed that you messaged them.");
-				dest->WriteRemoteNumeric(RPL_UMODEGMSG, user->nick, InspIRCd::Format("%s@%s", user->ident.c_str(), user->dhost.c_str()), InspIRCd::Format("is messaging you, and you have umode +g. Use /ACCEPT +%s to allow.",
+				dest->WriteRemoteNumeric(RPL_UMODEGMSG, user->nick, InspIRCd::Format("%s@%s", user->ident.c_str(), user->host.GetDisplay().c_str()), InspIRCd::Format("is messaging you, and you have umode +g. Use /ACCEPT +%s to allow.",
 						user->nick.c_str()));
 				dat->lastnotify = now;
 			}

--- a/src/modules/m_check.cpp
+++ b/src/modules/m_check.cpp
@@ -265,7 +265,7 @@ class CommandCheck : public Command
 				const UserManager::CloneCounts& clonecount = ServerInstance->Users->GetCloneCounts(i->first);
 				context.Write("member", InspIRCd::Format("%-3u %s%s (%s@%s) %s ", clonecount.global,
 					i->second->GetAllPrefixChars().c_str(), i->first->nick.c_str(),
-					i->first->ident.c_str(), i->first->dhost.c_str(), i->first->fullname.c_str()));
+					i->first->ident.c_str(), i->first->host.GetDisplay().c_str(), i->first->fullname.c_str()));
 			}
 
 			const ModeParser::ListModeList& listmodes = ServerInstance->Modes->GetListModes();
@@ -283,7 +283,7 @@ class CommandCheck : public Command
 			const user_hash& users = ServerInstance->Users->GetUsers();
 			for (user_hash::const_iterator a = users.begin(); a != users.end(); ++a)
 			{
-				if (InspIRCd::Match(a->second->host, parameters[0], ascii_case_insensitive_map) || InspIRCd::Match(a->second->dhost, parameters[0], ascii_case_insensitive_map))
+				if (InspIRCd::Match(a->second->host.GetReal(), parameters[0], ascii_case_insensitive_map) || InspIRCd::Match(a->second->host.GetDisplay(), parameters[0], ascii_case_insensitive_map))
 				{
 					/* host or vhost matches mask */
 					context.Write("match", ConvToStr(++x) + " " + a->second->GetFullRealHost() + " " + a->second->GetIPString() + " " + a->second->fullname);

--- a/src/modules/m_chghost.cpp
+++ b/src/modules/m_chghost.cpp
@@ -66,7 +66,7 @@ class CommandChghost : public Command
 			if ((dest->ChangeDisplayedHost(parameters[1])) && (!user->server->IsULine()))
 			{
 				// fix by brain - ulines set hosts silently
-				ServerInstance->SNO->WriteGlobalSno('a', user->nick+" used CHGHOST to make the displayed host of "+dest->nick+" become "+dest->dhost);
+				ServerInstance->SNO->WriteGlobalSno('a', user->nick+" used CHGHOST to make the displayed host of "+dest->nick+" become "+dest->host.GetDisplay());
 			}
 		}
 

--- a/src/modules/m_clearchan.cpp
+++ b/src/modules/m_clearchan.cpp
@@ -116,7 +116,7 @@ class CommandClearChan : public Command
 				XLine* xline;
 				try
 				{
-					mask = ((method[0] == 'Z') ? curr->GetIPString() : "*@" + curr->host);
+					mask = ((method[0] == 'Z') ? curr->GetIPString() : "*@" + curr->host.GetReal());
 					xline = xlf->Generate(ServerInstance->Time(), 60*60, user->nick, reason, mask);
 				}
 				catch (ModuleException&)

--- a/src/modules/m_cloaking.cpp
+++ b/src/modules/m_cloaking.cpp
@@ -90,7 +90,7 @@ class CloakUser : public ModeHandler
 		if (adding)
 		{
 			// assume this is more correct
-			if (user->registered != REG_ALL && user->host != user->dhost)
+			if (user->registered != REG_ALL && user->host.GetReal() != user->host.GetDisplay())
 				return MODEACTION_DENY;
 
 			std::string* cloak = ext.get(user);
@@ -116,7 +116,7 @@ class CloakUser : public ModeHandler
 			 * and make it match the displayed one.
 			 */
 			user->SetMode(this, false);
-			user->ChangeDisplayedHost(user->host.c_str());
+			user->ChangeDisplayedHost(user->host.GetReal());
 			return MODEACTION_ALLOW;
 		}
 	}
@@ -280,7 +280,7 @@ class ModuleCloaking : public Module
 		OnUserConnect(lu);
 		std::string* cloak = cu.ext.get(user);
 		/* Check if they have a cloaked host, but are not using it */
-		if (cloak && *cloak != user->dhost)
+		if (cloak && *cloak != user->host.GetDisplay())
 		{
 			const std::string cloakMask = user->nick + "!" + user->ident + "@" + *cloak;
 			if (InspIRCd::Match(cloakMask, mask))
@@ -372,7 +372,7 @@ class ModuleCloaking : public Module
 		if (cloak)
 			return;
 
-		cu.ext.set(dest, GenCloak(dest->client_sa, dest->GetIPString(), dest->host));
+		cu.ext.set(dest, GenCloak(dest->client_sa, dest->GetIPString(), dest->host.GetReal()));
 	}
 };
 

--- a/src/modules/m_customtitle.cpp
+++ b/src/modules/m_customtitle.cpp
@@ -35,7 +35,7 @@ class CommandTitle : public Command
 
 	CmdResult Handle(const std::vector<std::string> &parameters, User* user)
 	{
-		const std::string userHost = user->ident + "@" + user->host;
+		const std::string userHost = user->ident + "@" + user->host.GetReal();
 		const std::string userIP = user->ident + "@" + user->GetIPString();
 
 		ConfigTagList tags = ServerInstance->Config->ConfTags("title");

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -181,7 +181,7 @@ class CommandDccallow : public Command
 						}
 					}
 
-					std::string mask = target->nick+"!"+target->ident+"@"+target->dhost;
+					std::string mask = target->nick+"!"+target->ident+"@"+target->host.GetDisplay();
 					std::string default_length = ServerInstance->Config->ConfValue("dccallow")->getString("length");
 
 					unsigned long length;
@@ -382,14 +382,14 @@ class ModuleDCCAllow : public Module
 							return MOD_RES_PASSTHRU;
 
 						user->WriteNotice("The user " + u->nick + " is not accepting DCC SENDs from you. Your file " + filename + " was not sent.");
-						u->WriteNotice(user->nick + " (" + user->ident + "@" + user->dhost + ") attempted to send you a file named " + filename + ", which was blocked.");
+						u->WriteNotice(user->nick + " (" + user->ident + "@" + user->host.GetDisplay() + ") attempted to send you a file named " + filename + ", which was blocked.");
 						u->WriteNotice("If you trust " + user->nick + " and were expecting this, you can type /DCCALLOW HELP for information on the DCCALLOW system.");
 						return MOD_RES_DENY;
 					}
 					else if ((blockchat) && (stdalgo::string::equalsci(type, "CHAT")))
 					{
 						user->WriteNotice("The user " + u->nick + " is not accepting DCC CHAT requests from you.");
-						u->WriteNotice(user->nick + " (" + user->ident + "@" + user->dhost + ") attempted to initiate a DCC CHAT session, which was blocked.");
+						u->WriteNotice(user->nick + " (" + user->ident + "@" + user->host.GetDisplay() + ") attempted to initiate a DCC CHAT session, which was blocked.");
 						u->WriteNotice("If you trust " + user->nick + " and were expecting this, you can type /DCCALLOW HELP for information on the DCCALLOW system.");
 						return MOD_RES_DENY;
 					}

--- a/src/modules/m_hideoper.cpp
+++ b/src/modules/m_hideoper.cpp
@@ -138,7 +138,7 @@ class ModuleHideOper : public Module, public Whois::LineEventListener
 			if (!oper->server->IsULine() && (stats.GetSource()->IsOper() || !oper->IsModeSet(hm)))
 			{
 				LocalUser* lu = IS_LOCAL(oper);
-				stats.AddRow(249, oper->nick + " (" + oper->ident + "@" + oper->dhost + ") Idle: " +
+				stats.AddRow(249, oper->nick + " (" + oper->ident + "@" + oper->host.GetDisplay() + ") Idle: " +
 						(lu ? ConvToStr(ServerInstance->Time() - lu->idle_lastmsg) + " secs" : "unavailable"));
 				count++;
 			}

--- a/src/modules/m_hostcycle.cpp
+++ b/src/modules/m_hostcycle.cpp
@@ -109,7 +109,7 @@ class ModuleHostCycle : public Module
 
 	void OnChangeIdent(User* user, const std::string& newident) CXX11_OVERRIDE
 	{
-		DoHostCycle(user, newident, user->dhost, "Changing ident");
+		DoHostCycle(user, newident, user->host.GetDisplay(), "Changing ident");
 	}
 
 	void OnChangeHost(User* user, const std::string& newhost) CXX11_OVERRIDE

--- a/src/modules/m_httpd_stats.cpp
+++ b/src/modules/m_httpd_stats.cpp
@@ -183,7 +183,7 @@ class ModuleHttpStats : public Module, public HTTPRequestEventListener
 
 					data << "<user>";
 					data << "<nickname>" << u->nick << "</nickname><uuid>" << u->uuid << "</uuid><realhost>"
-						<< u->host << "</realhost><displayhost>" << u->dhost << "</displayhost><gecos>"
+						<< u->host.GetReal() << "</realhost><displayhost>" << u->host.GetDisplay() << "</displayhost><gecos>"
 						<< Sanitize(u->fullname) << "</gecos><server>" << u->server->GetName() << "</server>";
 					if (u->IsAway())
 						data << "<away>" << Sanitize(u->awaymsg) << "</away><awaytime>" << u->awaytime << "</awaytime>";

--- a/src/modules/m_ircv3_chghost.cpp
+++ b/src/modules/m_ircv3_chghost.cpp
@@ -40,7 +40,7 @@ class ModuleIRCv3ChgHost : public Module
 
 	void OnChangeIdent(User* user, const std::string& newident) CXX11_OVERRIDE
 	{
-		DoChgHost(user, newident, user->dhost);
+		DoChgHost(user, newident, user->host.GetDisplay());
 	}
 
 	void OnChangeHost(User* user, const std::string& newhost) CXX11_OVERRIDE

--- a/src/modules/m_ldapoper.cpp
+++ b/src/modules/m_ldapoper.cpp
@@ -217,7 +217,7 @@ class ModuleLDAPAuth : public Module
 				return MOD_RES_PASSTHRU;
 
 			std::string acceptedhosts = tag->getString("host");
-			std::string hostname = user->ident + "@" + user->host;
+			std::string hostname = user->ident + "@" + user->host.GetReal();
 			if (!InspIRCd::MatchMask(acceptedhosts, hostname, user->GetIPString()))
 				return MOD_RES_PASSTHRU;
 

--- a/src/modules/m_messageflood.cpp
+++ b/src/modules/m_messageflood.cpp
@@ -139,7 +139,7 @@ class ModuleMsgFlood : public Module
 				if (f->ban)
 				{
 					Modes::ChangeList changelist;
-					changelist.push_add(ServerInstance->Modes->FindMode('b', MODETYPE_CHANNEL), "*!*@" + user->dhost);
+					changelist.push_add(ServerInstance->Modes->FindMode('b', MODETYPE_CHANNEL), "*!*@" + user->host.GetDisplay());
 					ServerInstance->Modes->Process(ServerInstance->FakeClient, dest, NULL, changelist);
 				}
 

--- a/src/modules/m_repeat.cpp
+++ b/src/modules/m_repeat.cpp
@@ -385,7 +385,7 @@ class RepeatModule : public Module
 			if (settings->Action == ChannelSettings::ACT_BAN)
 			{
 				Modes::ChangeList changelist;
-				changelist.push_add(ServerInstance->Modes->FindMode('b', MODETYPE_CHANNEL), "*!*@" + user->dhost);
+				changelist.push_add(ServerInstance->Modes->FindMode('b', MODETYPE_CHANNEL), "*!*@" + user->host.GetDisplay());
 				ServerInstance->Modes->Process(ServerInstance->FakeClient, chan, NULL, changelist);
 			}
 

--- a/src/modules/m_rline.cpp
+++ b/src/modules/m_rline.cpp
@@ -62,7 +62,7 @@ class RLine : public XLine
 		if (lu && lu->exempt)
 			return false;
 
-		std::string compare = u->nick + "!" + u->ident + "@" + u->host + " " + u->fullname;
+		std::string compare = u->nick + "!" + u->ident + "@" + u->host.GetReal() + " " + u->fullname;
 		return regex->Matches(compare);
 	}
 

--- a/src/modules/m_sasl.cpp
+++ b/src/modules/m_sasl.cpp
@@ -188,7 +188,7 @@ class SaslAuthenticator
 
 		if (!ReadCGIIRCExt("cgiirc_webirc_hostname", user, host))
 		{
-			host = user->host;
+			host = user->host.GetReal();
 		}
 		if (!ReadCGIIRCExt("cgiirc_webirc_ip", user, ip))
 		{

--- a/src/modules/m_sethost.cpp
+++ b/src/modules/m_sethost.cpp
@@ -53,7 +53,7 @@ class CommandSethost : public Command
 
 		if (user->ChangeDisplayedHost(parameters[0]))
 		{
-			ServerInstance->SNO->WriteGlobalSno('a', user->nick+" used SETHOST to change their displayed host to "+user->dhost);
+			ServerInstance->SNO->WriteGlobalSno('a', user->nick+" used SETHOST to change their displayed host to "+user->host.GetDisplay());
 			return CMD_SUCCESS;
 		}
 

--- a/src/modules/m_showwhois.cpp
+++ b/src/modules/m_showwhois.cpp
@@ -50,7 +50,7 @@ class WhoisNoticeCmd : public Command
 	void HandleFast(User* dest, User* src)
 	{
 		dest->WriteNotice("*** " + src->nick + " (" + src->ident + "@" +
-			(dest->HasPrivPermission("users/auspex") ? src->host : src->dhost) +
+			src->host.Get(dest->HasPrivPermission("users/auspex")) +
 			") did a /whois on you");
 	}
 

--- a/src/modules/m_spanningtree/opertype.cpp
+++ b/src/modules/m_spanningtree/opertype.cpp
@@ -55,7 +55,7 @@ CmdResult CommandOpertype::HandleRemote(RemoteUser* u, std::vector<std::string>&
 			return CMD_SUCCESS;
 	}
 
-	ServerInstance->SNO->WriteToSnoMask('O',"From %s: User %s (%s@%s) is now an IRC operator of type %s",u->server->GetName().c_str(), u->nick.c_str(),u->ident.c_str(), u->host.c_str(), opertype.c_str());
+	ServerInstance->SNO->WriteToSnoMask('O',"From %s: User %s (%s@%s) is now an IRC operator of type %s",u->server->GetName().c_str(), u->nick.c_str(),u->ident.c_str(), u->host.GetReal().c_str(), opertype.c_str());
 	return CMD_SUCCESS;
 }
 

--- a/src/modules/m_spanningtree/uid.cpp
+++ b/src/modules/m_spanningtree/uid.cpp
@@ -73,8 +73,7 @@ CmdResult CommandUID::HandleServer(TreeServer* remoteserver, std::vector<std::st
 	RemoteUser* _new = new SpanningTree::RemoteUser(params[0], remoteserver);
 	ServerInstance->Users->clientlist[params[2]] = _new;
 	_new->nick = params[2];
-	_new->host = params[3];
-	_new->dhost = params[4];
+	_new->host = insp::CloakedString(params[3], params[4]);
 	_new->ident = params[5];
 	_new->fullname = params.back();
 	_new->registered = REG_ALL;
@@ -157,8 +156,8 @@ CommandUID::Builder::Builder(User* user)
 	push(user->uuid);
 	push_int(user->age);
 	push(user->nick);
-	push(user->host);
-	push(user->dhost);
+	push(user->host.GetReal());
+	push(user->host.GetDisplay());
 	push(user->ident);
 	push(user->GetIPString());
 	push_int(user->signon);

--- a/src/modules/m_sqloper.cpp
+++ b/src/modules/m_sqloper.cpp
@@ -88,7 +88,7 @@ class OpMeQuery : public SQLQuery
 
 		std::string hostname(user->ident);
 
-		hostname.append("@").append(user->host);
+		hostname.append("@").append(user->host.GetReal());
 
 		if (InspIRCd::MatchMask(pattern, hostname, user->GetIPString()))
 		{

--- a/src/modules/m_watch.cpp
+++ b/src/modules/m_watch.cpp
@@ -53,9 +53,9 @@ class CommandWatch : public SplitCommand
 		{
 			// The away state should only be sent if the client requests away notifications for a nick but 2.0 always sends them so we do that too
 			if (target->IsAway())
-				user->WriteNumeric(RPL_NOWISAWAY, target->nick, target->ident, target->dhost, (unsigned long)target->awaytime, "is away");
+				user->WriteNumeric(RPL_NOWISAWAY, target->nick, target->ident, target->host.GetDisplay(), (unsigned long)target->awaytime, "is away");
 			else
-				user->WriteNumeric(RPL_NOWON, target->nick, target->ident, target->dhost, (unsigned long)target->age, "is online");
+				user->WriteNumeric(RPL_NOWON, target->nick, target->ident, target->host.GetDisplay(), (unsigned long)target->age, "is online");
 		}
 		else if (show_offline)
 			user->WriteNumeric(RPL_NOWOFF, nick, "*", "*", "0", "is offline");
@@ -88,7 +88,7 @@ class CommandWatch : public SplitCommand
 
 		User* target = IRCv3::Monitor::Manager::FindNick(nick);
 		if (target)
-			user->WriteNumeric(RPL_WATCHOFF, target->nick, target->ident, target->dhost, (unsigned long)target->age, "stopped watching");
+			user->WriteNumeric(RPL_WATCHOFF, target->nick, target->ident, target->host.GetDisplay(), (unsigned long)target->age, "stopped watching");
 		else
 			user->WriteNumeric(RPL_WATCHOFF, nick, "*", "*", "0", "stopped watching");
 	}
@@ -190,7 +190,7 @@ class ModuleWatch : public Module
 			return;
 
 		Numeric::Numeric num(numeric);
-		num.push(nick).push(user->ident).push(user->dhost).push(ConvToStr(shownts)).push(numerictext);
+		num.push(nick).push(user->ident).push(user->host.GetDisplay()).push(ConvToStr(shownts)).push(numerictext);
 		for (IRCv3::Monitor::WatcherList::const_iterator i = list->begin(); i != list->end(); ++i)
 		{
 			LocalUser* curr = *i;

--- a/src/usermanager.cpp
+++ b/src/usermanager.cpp
@@ -177,7 +177,7 @@ void UserManager::QuitUser(User* user, const std::string& quitreason, const std:
 	user->quitting = true;
 
 	ServerInstance->Logs->Log("USERS", LOG_DEBUG, "QuitUser: %s=%s '%s'", user->uuid.c_str(), user->nick.c_str(), quitreason.c_str());
-	user->Write("ERROR :Closing link: (%s@%s) [%s]", user->ident.c_str(), user->host.c_str(), operreason ? operreason->c_str() : quitreason.c_str());
+	user->Write("ERROR :Closing link: (%s@%s) [%s]", user->ident.c_str(), user->host.GetReal().c_str(), operreason ? operreason->c_str() : quitreason.c_str());
 
 	std::string reason;
 	reason.assign(quitreason, 0, ServerInstance->Config->Limits.MaxQuit);

--- a/src/xline.cpp
+++ b/src/xline.cpp
@@ -554,7 +554,7 @@ bool KLine::Matches(User *u)
 
 	if (InspIRCd::Match(u->ident, this->identmask, ascii_case_insensitive_map))
 	{
-		if (InspIRCd::MatchCIDR(u->host, this->hostmask, ascii_case_insensitive_map) ||
+		if (InspIRCd::MatchCIDR(u->host.GetReal(), this->hostmask, ascii_case_insensitive_map) ||
 		    InspIRCd::MatchCIDR(u->GetIPString(), this->hostmask, ascii_case_insensitive_map))
 		{
 			return true;
@@ -577,7 +577,7 @@ bool GLine::Matches(User *u)
 
 	if (InspIRCd::Match(u->ident, this->identmask, ascii_case_insensitive_map))
 	{
-		if (InspIRCd::MatchCIDR(u->host, this->hostmask, ascii_case_insensitive_map) ||
+		if (InspIRCd::MatchCIDR(u->host.GetReal(), this->hostmask, ascii_case_insensitive_map) ||
 		    InspIRCd::MatchCIDR(u->GetIPString(), this->hostmask, ascii_case_insensitive_map))
 		{
 			return true;
@@ -600,7 +600,7 @@ bool ELine::Matches(User *u)
 
 	if (InspIRCd::Match(u->ident, this->identmask, ascii_case_insensitive_map))
 	{
-		if (InspIRCd::MatchCIDR(u->host, this->hostmask, ascii_case_insensitive_map) ||
+		if (InspIRCd::MatchCIDR(u->host.GetReal(), this->hostmask, ascii_case_insensitive_map) ||
 		    InspIRCd::MatchCIDR(u->GetIPString(), this->hostmask, ascii_case_insensitive_map))
 		{
 			return true;


### PR DESCRIPTION
This adds a type which represents cloaked strings which makes the behaviour of User#host generic. It also adds a tiny memory saving by not holding the hostname in two places.

This might be useful for when we add the concept of "display idents" but i'm honestly undecided on it. Any comments would be appreciated.