### PR TITLE
Fix referring to sqloper and sqlauth as extras in modules.conf.example.

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1781,9 +1781,6 @@
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # SQL authentication module: Allows IRCd connections to be tied into
 # a database table (for example a forum).
-# This module is in extras. Re-run configure with:
-# ./configure --enable-extras=m_sqlauth.cpp
-# and run make install, then uncomment this module to enable it.
 #
 #<module name="m_sqlauth.so">
 #
@@ -1794,9 +1791,6 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # SQL oper module: Allows you to store oper credentials in an SQL table
-# This module is in extras. Re-run configure with:
-# ./configure --enable-extras=m_sqloper.cpp
-# and run make install, then uncomment this module to enable it.
 #
 #<module name="m_sqloper.so">
 #


### PR DESCRIPTION
This fixes a docs issue that refers to m_sqloper and m_sqlauth both as extras modules, despite the fact that they are not.