### PR TITLE
Add support for case-insensitive host cloaking (on by default)

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -511,12 +511,14 @@
 #                                                                     #
 # The methods use a single key that can be any length of text.        #
 # An optional prefix may be specified to mark cloaked hosts.          #
+# Casesensitive controls whether hosts are case-sensitive.            #
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 #
 #<cloak mode="half"
 #       key="secret"
 #       domainparts="3"
-#       prefix="net-">
+#       prefix="net-"
+#       casesensitive="false">
 
 #-#-#-#-#-#-#-#-#-#-#-#- CLOSE MODULE #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Close module: Allows an oper to close all unregistered connections.

--- a/src/modules/m_cloaking.cpp
+++ b/src/modules/m_cloaking.cpp
@@ -145,6 +145,7 @@ class ModuleCloaking : public Module
 	std::string key;
 	unsigned int domainparts;
 	dynamic_reference<HashProvider> Hash;
+	bool caseSensitive;
 
 	ModuleCloaking() : cu(this), mode(MODE_OPAQUE), ck(this), Hash(this, "hash/md5")
 	{
@@ -187,8 +188,10 @@ class ModuleCloaking : public Module
 	 * @param id A unique ID for this type of item (to make it unique if the item matches)
 	 * @param len The length of the output. Maximum for MD5 is 16 characters.
 	 */
-	std::string SegmentCloak(const std::string& item, char id, size_t len)
+	std::string SegmentCloak(std::string item, char id, size_t len)
 	{
+		if (!caseSensitive)
+			std::transform(item.begin(), item.end(), item.begin(), ::tolower);
 		std::string input;
 		input.reserve(key.length() + 3 + item.length());
 		input.append(1, id);
@@ -352,6 +355,8 @@ class ModuleCloaking : public Module
 		key = tag->getString("key");
 		if (key.empty() || key == "secret")
 			throw ModuleException("You have not defined cloak keys for m_cloaking. Define <cloak:key> as a network-wide secret.");
+
+		caseSensitive = tag->getBool("casesensitive", true);
 	}
 
 	std::string GenCloak(const irc::sockets::sockaddrs& ip, const std::string& ipstr, const std::string& host)


### PR DESCRIPTION
This PR allows for all hosts to be lowercased before m_cloaking runs on them. Case-sensitivity can be re-enabled via a config option for the cloak tag.

This resolves https://github.com/inspircd/inspircd/issues/480.