### PR TITLE
Fix action extbans not triggering

### DIFF
--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -402,7 +402,10 @@ ModResult Channel::GetExtBanStatus(User *user, char type)
 	{
 		for (ListModeBase::ModeList::const_iterator it = bans->begin(); it != bans->end(); ++it)
 		{
-			if (CheckBan(user, it->mask))
+			if (it->mask[0] != type || it->mask[1] != ':')
+				continue;
+
+			if (CheckBan(user, it->mask.substr(2)))
 				return MOD_RES_DENY;
 		}
 	}


### PR DESCRIPTION
This fixes a reversion from ebe5b201aab71cf2ead1e068889be736314fbb73. See https://github.com/inspircd/inspircd/commit/ebe5b201aab71cf2ead1e068889be736314fbb73#diff-e8d9cb9a964b4f01c8b7d5fd3676aecbL480 for the specific place of the reversion.

GetExtBanStatus was passing the full ban mask to CheckBan, i.e. "m:\*!\*@\*" instead of removing the extban prefix first. This resulted in no extbans matching. Additionally, GetExtBanStatus checked all ban masks instead of just ones that began with an extban prefix, resulting in users that have a banmask apply to them (i.e. +b \*!\*@\* and in the channel on +e \*!\*@\*) matching all GetExtBanStatus calls.

Thanks to @genius3000 for his assistance in isolating the precise commit and line.