### PR TITLE
Add optional oper override umode +O

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1384,8 +1384,19 @@
 #
 #-#-#-#-#-#-#-#-#-#-#   OVERRIDE CONFIGURATION   -#-#-#-#-#-#-#-#-#-#-#
 #                                                                     #
-# override is too complex it describe here, see the wiki:             #
-# http://wiki.inspircd.org/Modules/override                           #
+# Much of override's configuration relates to your oper blocks.       #
+# For more information on how to allow opers to override, see:        #
+# https://wiki.inspircd.org/Modules/3.0/override                      #
+#                                                                     #
+# noisy         - If enabled, all oper overrides will be announced    #
+#                 via channel notice.                                 #
+#                                                                     #
+# requirekey    - If enabled, overriding on join requires a channel   #
+#                 key of "override" to be specified                   #
+#                                                                     #
+# enableumode   - If enabled, usermode +O is required for override.   #
+#                                                                     #
+#<override noisy="yes" requirekey="no" enableumode="true">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Oper levels module: Gives each oper a level and prevents actions


### PR DESCRIPTION
This adds the optional user mode "O". If the user mode is enabled, then only opers who have given it to themselves may use oper override. If the user mode is disabled (default if config option left blank), then override works normally.

Requiring a usermode for override to work requires opers to actively enable overriding in order to prevent accidental overrides. This allows opers to continue to act as normal users when not doing oper-related tasks. In my opinion, this was worth it because override, unlike SA*, is focused solely on the operator rather than other users (SAJOIN can be used on others).

This resolves https://github.com/inspircd/inspircd/issues/363.