### PR TITLE
Fixed noexec defaulting to true when including files.

### DIFF
--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -328,7 +328,7 @@ void ParseStack::DoInclude(ConfigTag* tag, int flags)
 			throw CoreException("Invalid <include:executable> tag in file included with noexec=\"yes\"");
 		if (tag->getBool("noinclude", false))
 			flags |= FLAG_NO_INC;
-		if (tag->getBool("noexec", true))
+		if (tag->getBool("noexec", false))
 			flags |= FLAG_NO_EXEC;
 		if (!ParseFile(name, flags, mandatorytag, true))
 			throw CoreException("Included");


### PR DESCRIPTION
If noexec is not set on an include tag it will default to true, preventing include:executable from working in inspircd.conf.