### PR TITLE
Add OpenSSL rehash messages.

### DIFF
--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -1059,6 +1059,10 @@ class ModuleSSLOpenSSL : public Module
 		if (!irc::equals(param, "ssl"))
 			return;
 
+		ServerInstance->SNO->WriteGlobalSno('a', (user ? (user->nick + " is r") : "R") + "ehashing OpenSSL module on " + ServerInstance->Config->ServerName);
+		if (user)
+			user->WriteRemoteNotice("*** Rehashing OpenSSL module...");
+
 		try
 		{
 			ReadProfiles();
@@ -1066,6 +1070,8 @@ class ModuleSSLOpenSSL : public Module
 		}
 		catch (ModuleException& ex)
 		{
+			if (user)
+				user->WriteRemoteNotice("*** Error rehashing OpenSSL module: " + ex.GetReason());
 			ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, ex.GetReason() + " Not applying settings.");
 		}
 	}


### PR DESCRIPTION
Example of successful rehash:

irssi client:
```
00:42 !frostsnow.net *** Rehashing OpenSSL module...
00:42 !frostsnow.net *** Successfully rehashed OpenSSL module.
```
log file:
```
Fri Dec 08 2017 00:44:56 snomask: ANNOUNCEMENT: frostsnow is rehashing OpenSSL module on frostsnow.net
Fri Dec 08 2017 00:44:56 m_ssl_openssl: No <sslprofile> tags found, using settings from the <openssl> tag            
Fri Dec 08 2017 00:44:56 m_ssl_openssl: openssl server context options: 123420676                                    
Fri Dec 08 2017 00:44:56 m_ssl_openssl: openssl client context options: 123420676 
Fri Dec 08 2017 00:44:56 snomask: ANNOUNCEMENT: *** Successfully rehashed OpenSSL module on frostsnow.net
```

Example of failing rehash:

irssi client:
```
00:47 !frostsnow.net *** Rehashing OpenSSL module...
00:47 !frostsnow.net *** Error rehashing OpenSSL module: Error while
          initializing the default SSL profile - Can't read certificate file:
          140688996805368:error:02001002:system library:fopen:No such file or
directory:bss_file.c:406:fopen('/etc/ssl/frostsnow.net/certs/cert.pem','r')
```
log file:
```
Fri Dec 08 2017 00:49:02 snomask: ANNOUNCEMENT: frostsnow is rehashing OpenSSL module on frostsnow.net
Fri Dec 08 2017 00:49:02 m_ssl_openssl: No <sslprofile> tags found, using settings from the <openssl> tag 
Fri Dec 08 2017 00:49:02 m_ssl_openssl: openssl server context options: 123420676 
Fri Dec 08 2017 00:49:02 m_ssl_openssl: openssl client context options: 123420676 
Fri Dec 08 2017 00:49:02 m_ssl_openssl: Error while initializing the default SSL profile - Can't read certificate file: 140688996805368:error:02001002:system library:fopen:No such file or directory:bss_file.c:406:fopen('/etc/ssl/frostsnow.net/certs/cert.pem','r') Not applying settings.
```