### PR TITLE
Add m_bannegate

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -209,6 +209,14 @@
 #<module name="banexception">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
+# Ban negate module: Adds support for negating a ban by adding a ~
+# before the ban mask and any matching extban. Examples:
+# /mode #chan +b ~user!*@*     will ban anyone NOT user!*@*
+# /mode #chan +b m:~user!*@*   will mute anyone NOT user!*@*
+# /mode #chan +b m:~R:user     will mute anyone NOT logged into user
+#<module name="bannegate">
+
+#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Ban redirection module: Allows bans which redirect to a specified
 # channel. e.g. +b nick!ident@host#channelbanneduserissentto
 #<module name="banredirect">

--- a/src/mode.cpp
+++ b/src/mode.cpp
@@ -552,13 +552,13 @@ void ModeParser::ShowListModeList(User* user, Channel* chan, ModeHandler* mh)
 
 void ModeParser::CleanMask(std::string &mask)
 {
+	if ((mask.length() > 2 && mask[1] == ':') || (mask.length() > 3 && mask[2] == ':'))
+		return; // if it's an extban, don't even try guess how it needs to be formed.
+
 	std::string::size_type pos_of_pling = mask.find_first_of('!');
 	std::string::size_type pos_of_at = mask.find_first_of('@');
 	std::string::size_type pos_of_dot = mask.find_first_of('.');
 	std::string::size_type pos_of_colons = mask.find("::"); /* Because ipv6 addresses are colon delimited -- double so it treats extban as nick */
-
-	if (mask.length() >= 2 && mask[1] == ':')
-		return; // if it's an extban, don't even try guess how it needs to be formed.
 
 	if ((pos_of_pling == std::string::npos) && (pos_of_at == std::string::npos))
 	{

--- a/src/modules/m_bannegate.cpp
+++ b/src/modules/m_bannegate.cpp
@@ -1,0 +1,48 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2017 Dylan Frank <b00mx0r@aureus.pw>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+
+class ModuleBanNegate : public Module
+{
+ public:
+	ModResult OnCheckBan(User *source, Channel *chan, const std::string& mask) CXX11_OVERRIDE
+	{
+		// If our matching mask begins with the negate charater, but does not have multiple in a row (to avoid nested loops)
+		if (mask[0] == '~' && mask[1] != '~')
+		{
+			bool RealResult = chan->CheckBan(source, mask.substr(1));
+			return (RealResult ? MOD_RES_ALLOW : MOD_RES_DENY);
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	void Prioritize() CXX11_OVERRIDE
+	{
+		// Run before other modules to detect if it is a negated ban first
+		ServerInstance->Modules.SetPriority(this, I_OnCheckBan, PRIORITY_FIRST);
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Enables negating any ban by putting a ~ before its mask and matching extban", VF_VENDOR | VF_OPTCOMMON);
+	}
+};
+
+MODULE_INIT(ModuleBanNegate)


### PR DESCRIPTION
m_bannegate enables prepending a ~ to any ban mask or matching extban in order to match the opposite of it. Examples:

```
/mode #chan +b ~user!*@*     will ban anyone NOT user!*@*
/mode #chan +b m:~user!*@*   will mute anyone NOT user!*@*
/mode #chan +b m:~R:user     will mute anyone NOT logged into user
```

This closes and resolves https://github.com/inspircd/inspircd/issues/800.