### PR TITLE
Add snomask alert on m_filter quit/part G-Line

### DIFF
--- a/src/modules/m_filter.cpp
+++ b/src/modules/m_filter.cpp
@@ -440,6 +440,7 @@ ModResult ModuleFilter::OnPreCommand(std::string &command, std::vector<std::stri
 			{
 				/* Note: We gline *@IP so that if their host doesnt resolve the gline still applies. */
 				GLine* gl = new GLine(ServerInstance->Time(), f->gline_time, ServerInstance->Config->ServerName.c_str(), f->reason.c_str(), "*", user->GetIPString());
+				ServerInstance->SNO->WriteGlobalSno('a', "FILTER: " + user->nick + " had their " + command + " message filtered and was G-Lined: " + f->reason);
 				if (ServerInstance->XLines->AddLine(gl,NULL))
 				{
 					ServerInstance->XLines->ApplyLines();


### PR DESCRIPTION
There was an oversight in https://github.com/inspircd/inspircd/pull/1264, where G-Lines as a result from a PART/QUIT message filter were not broadcast to opers via snomask.