### PR TITLE
Clarify error message when attempting to /NICK while banned

### DIFF
--- a/src/coremods/core_user/cmd_nick.cpp
+++ b/src/coremods/core_user/cmd_nick.cpp
@@ -77,7 +77,8 @@ CmdResult CommandNick::HandleLocal(const std::vector<std::string>& parameters, L
 			Channel* chan = (*i)->chan;
 			if (chan->GetPrefixValue(user) < VOICE_VALUE && chan->IsBanned(user))
 			{
-				user->WriteNumeric(ERR_CANNOTSENDTOCHAN, chan->name, "Cannot send to channel (you're banned)");
+				user->WriteNumeric(ERR_CANTCHANGENICK, InspIRCd::Format("Cannot change nickname while on %s (you're banned)",
+					chan->name.c_str()));
 				return CMD_FAILURE;
 			}
 		}

--- a/src/modules/m_nonicks.cpp
+++ b/src/modules/m_nonicks.cpp
@@ -60,7 +60,7 @@ class ModuleNoNickChange : public Module
 
 			if (!curr->GetExtBanStatus(user, 'N').check(!curr->IsModeSet(nn)))
 			{
-				user->WriteNumeric(ERR_CANTCHANGENICK, InspIRCd::Format("Can't change nickname while on %s (+N is set)",
+				user->WriteNumeric(ERR_CANTCHANGENICK, InspIRCd::Format("Cannot change nickname while on %s (+N is set)",
 					curr->name.c_str()));
 				return MOD_RES_DENY;
 			}


### PR DESCRIPTION
Currently, when a user attempts /NICK while on a channel that they're banned on, the server returns a "cannot send to channel" message. This PR changes that to a "cannot change nick" message, which makes more sense given the context of a nick change and not a PRIVMSG.

The second clarification is small: this changes "can't" to "cannot" in m_nonicks simply to match the precedent set by other error messages.