### PR TITLE
Fixed misc. instances of ERR_NOSUCHNICK instead of channel numerics

### DIFF
--- a/include/numeric.h
+++ b/include/numeric.h
@@ -88,8 +88,7 @@ class Numeric::Numeric
 
 namespace Numerics
 {
-	/** ERR_NOSUCHNICK numeric
-	 */
+	/** Builder for the ERR_NOSUCHNICK numeric. */
 	class NoSuchNick : public Numeric::Numeric
 	{
 	 public:
@@ -97,7 +96,19 @@ namespace Numerics
 			: Numeric(ERR_NOSUCHNICK)
 		{
 			push(nick);
-			push("No such nick/channel");
+			push("No such nick");
+		}
+	};
+
+	/** Builder for the ERR_NOSUCHCHANNEL numeric. */
+	class NoSuchChannel : public Numeric::Numeric
+	{
+	 public:
+		NoSuchChannel(const std::string& chan)
+			: Numeric(ERR_NOSUCHCHANNEL)
+		{
+			push(chan);
+			push("No such channel");
 		}
 	};
 }

--- a/include/numerics.h
+++ b/include/numerics.h
@@ -161,6 +161,7 @@ enum
 	 *  -- A message from the IRC group for coder sanity, and w00t
 	 */
 	ERR_BADCHANNELKEY               = 475,
+	ERR_BADCHANMASK			= 476,
 	ERR_INVITEONLYCHAN              = 473,
 	ERR_CHANNELISFULL               = 471,
 	ERR_BANNEDFROMCHAN              = 474,

--- a/src/coremods/core_channel/cmd_invite.cpp
+++ b/src/coremods/core_channel/cmd_invite.cpp
@@ -56,9 +56,14 @@ CmdResult CommandInvite::Handle (const std::vector<std::string>& parameters, Use
 				timeout = ConvToInt(parameters[3]);
 		}
 
-		if ((!c) || (!u) || (u->registered != REG_ALL))
+		if (!c)
 		{
-			user->WriteNumeric(Numerics::NoSuchNick(c ? parameters[0] : parameters[1]));
+			user->WriteNumeric(Numerics::NoSuchChannel(parameters[1]));
+			return CMD_FAILURE;
+		}
+		if ((!u) || (u->registered != REG_ALL))
+		{
+			user->WriteNumeric(Numerics::NoSuchNick(parameters[0]));
 			return CMD_FAILURE;
 		}
 

--- a/src/coremods/core_channel/cmd_join.cpp
+++ b/src/coremods/core_channel/cmd_join.cpp
@@ -55,6 +55,6 @@ CmdResult CommandJoin::HandleLocal(const std::vector<std::string>& parameters, L
 		}
 	}
 
-	user->WriteNumeric(ERR_NOSUCHCHANNEL, parameters[0], "Invalid channel name");
+	user->WriteNumeric(ERR_BADCHANMASK, parameters[0], "Invalid channel name");
 	return CMD_FAILURE;
 }

--- a/src/coremods/core_channel/cmd_kick.cpp
+++ b/src/coremods/core_channel/cmd_kick.cpp
@@ -42,9 +42,14 @@ CmdResult CommandKick::Handle (const std::vector<std::string>& parameters, User 
 	else
 		u = ServerInstance->FindNick(parameters[1]);
 
-	if ((!u) || (!c) || (u->registered != REG_ALL))
+	if (!c)
 	{
-		user->WriteNumeric(Numerics::NoSuchNick(c ? parameters[1] : parameters[0]));
+		user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
+		return CMD_FAILURE;
+	}
+	if ((!u) || (u->registered != REG_ALL))
+	{
+		user->WriteNumeric(Numerics::NoSuchNick(parameters[1]));
 		return CMD_FAILURE;
 	}
 

--- a/src/coremods/core_channel/cmd_names.cpp
+++ b/src/coremods/core_channel/cmd_names.cpp
@@ -62,7 +62,7 @@ CmdResult CommandNames::HandleLocal(const std::vector<std::string>& parameters, 
 		}
 	}
 
-	user->WriteNumeric(Numerics::NoSuchNick(parameters[0]));
+	user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 	return CMD_FAILURE;
 }
 

--- a/src/coremods/core_channel/cmd_topic.cpp
+++ b/src/coremods/core_channel/cmd_topic.cpp
@@ -38,7 +38,7 @@ CmdResult CommandTopic::HandleLocal(const std::vector<std::string>& parameters, 
 	Channel* c = ServerInstance->FindChan(parameters[0]);
 	if (!c)
 	{
-		user->WriteNumeric(Numerics::NoSuchNick(parameters[0]));
+		user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 		return CMD_FAILURE;
 	}
 
@@ -46,7 +46,7 @@ CmdResult CommandTopic::HandleLocal(const std::vector<std::string>& parameters, 
 	{
 		if ((c->IsModeSet(secretmode)) && (!c->HasUser(user)))
 		{
-			user->WriteNumeric(Numerics::NoSuchNick(c->name));
+			user->WriteNumeric(Numerics::NoSuchChannel(c->name));
 			return CMD_FAILURE;
 		}
 

--- a/src/coremods/core_privmsg.cpp
+++ b/src/coremods/core_privmsg.cpp
@@ -180,8 +180,8 @@ CmdResult MessageCommandBase::HandleMessage(const std::vector<std::string>& para
 		}
 		else
 		{
-			/* no such nick/channel */
-			user->WriteNumeric(Numerics::NoSuchNick(target));
+			/* channel does not exist */
+			user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 			return CMD_FAILURE;
 		}
 		return CMD_SUCCESS;

--- a/src/coremods/core_user/cmd_mode.cpp
+++ b/src/coremods/core_user/cmd_mode.cpp
@@ -45,7 +45,10 @@ CmdResult CommandMode::Handle(const std::vector<std::string>& parameters, User* 
 
 	if ((!targetchannel) && (!targetuser))
 	{
-		user->WriteNumeric(Numerics::NoSuchNick(target));
+		if (target[0] == '#')
+			user->WriteNumeric(Numerics::NoSuchChannel(target));
+		else
+			user->WriteNumeric(Numerics::NoSuchNick(target));
 		return CMD_FAILURE;
 	}
 	if (parameters.size() == 1)

--- a/src/coremods/core_user/cmd_part.cpp
+++ b/src/coremods/core_user/cmd_part.cpp
@@ -46,7 +46,7 @@ CmdResult CommandPart::Handle (const std::vector<std::string>& parameters, User 
 
 	if (!c)
 	{
-		user->WriteNumeric(Numerics::NoSuchNick(parameters[0]));
+		user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 		return CMD_FAILURE;
 	}
 

--- a/src/modules/m_cycle.cpp
+++ b/src/modules/m_cycle.cpp
@@ -44,7 +44,7 @@ class CommandCycle : public SplitCommand
 
 		if (!channel)
 		{
-			user->WriteNumeric(ERR_NOSUCHCHANNEL, parameters[0], "No such channel");
+			user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_knock.cpp
+++ b/src/modules/m_knock.cpp
@@ -45,7 +45,7 @@ class CommandKnock : public Command
 		Channel* c = ServerInstance->FindChan(parameters[0]);
 		if (!c)
 		{
-			user->WriteNumeric(Numerics::NoSuchNick(parameters[0]));
+			user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_namedmodes.cpp
+++ b/src/modules/m_namedmodes.cpp
@@ -57,7 +57,7 @@ class CommandProp : public SplitCommand
 		Channel* const chan = ServerInstance->FindChan(parameters[0]);
 		if (!chan)
 		{
-			src->WriteNumeric(Numerics::NoSuchNick(parameters[0]));
+			src->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_redirect.cpp
+++ b/src/modules/m_redirect.cpp
@@ -38,7 +38,7 @@ class Redirect : public ParamMode<Redirect, LocalStringExt>
 		{
 			if (!ServerInstance->IsChannel(parameter))
 			{
-				source->WriteNumeric(ERR_NOSUCHCHANNEL, parameter, "Invalid channel name");
+				source->WriteNumeric(Numerics::NoSuchChannel(parameter));
 				return MODEACTION_DENY;
 			}
 		}

--- a/src/modules/m_remove.cpp
+++ b/src/modules/m_remove.cpp
@@ -74,9 +74,14 @@ class RemoveBase : public Command
 		channel = ServerInstance->FindChan(channame);
 
 		/* Fix by brain - someone needs to learn to validate their input! */
-		if ((!target) || (target->registered != REG_ALL) || (!channel))
+		if (!channel)
 		{
-			user->WriteNumeric(Numerics::NoSuchNick(channel ? username.c_str() : channame.c_str()));
+			user->WriteNumeric(Numerics::NoSuchChannel(channame));
+			return CMD_FAILURE;
+		}
+		if ((!target) || (target->registered != REG_ALL))
+		{
+			user->WriteNumeric(Numerics::NoSuchNick(username));
 			return CMD_FAILURE;
 		}
 

--- a/src/modules/m_satopic.cpp
+++ b/src/modules/m_satopic.cpp
@@ -52,7 +52,7 @@ class CommandSATopic : public Command
 		}
 		else
 		{
-			user->WriteNumeric(Numerics::NoSuchNick(parameters[0]));
+			user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 			return CMD_FAILURE;
 		}
 	}

--- a/src/modules/m_timedbans.cpp
+++ b/src/modules/m_timedbans.cpp
@@ -73,7 +73,7 @@ class CommandTban : public Command
 		Channel* channel = ServerInstance->FindChan(parameters[0]);
 		if (!channel)
 		{
-			user->WriteNumeric(Numerics::NoSuchNick(parameters[0]));
+			user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 			return CMD_FAILURE;
 		}
 		unsigned int cm = channel->GetPrefixValue(user);

--- a/src/modules/m_uninvite.cpp
+++ b/src/modules/m_uninvite.cpp
@@ -51,7 +51,7 @@ class CommandUninvite : public Command
 		{
 			if (!c)
 			{
-				user->WriteNumeric(Numerics::NoSuchNick(parameters[1]));
+				user->WriteNumeric(Numerics::NoSuchChannel(parameters[1]));
 			}
 			else
 			{


### PR DESCRIPTION
Per #1122, this PR replaces multiple instances of ERR_NOSUCHNICK with the proper channel numerics. This includes mostly ERR_NOSUCHCHANNEL, but also a couple of ERR_NOTONCHANNEL instances.