### PR TITLE
Separate secret and private channels on whois for non-opers

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -602,6 +602,13 @@
          # serverpingfreq: How often pings are sent between servers.
          serverpingfreq="1m"
 
+         # splitwhois: Whether to split private/secret channels from normal channels
+         # in WHOIS responses. Possible values for this are:
+         # 'no' - list all channels together in the WHOIS response regardless of type.
+         # 'split' - split private/secret channels to a separate WHOIS response numeric.
+         # 'splitmsg' - the same as split but also send a message explaining the split.
+         splitwhois="no"
+
          # defaultmodes: What modes are set on a empty channel when a user
          # joins it and it is unregistered.
          defaultmodes="not"
@@ -719,12 +726,6 @@
           # customversion: A custom message to be displayed in the comments field
           # of the VERSION command response. This does not hide the InspIRCd version.
           customversion=""
-
-          # operspywhois: show opers (users/auspex) the +s channels a user is in. Values:
-          #  splitmsg  Split with an explanatory message
-          #  yes       Split with no explanatory message
-          #  no        Do not show
-          operspywhois="no"
 
           # runasuser: If this is set, InspIRCd will attempt to switch
           # to run as this user, which allows binding of ports under 1024.

--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -21,6 +21,7 @@
      #  VIEWING:
      #   - channels/auspex: allows opers with this priv to see more detail about channels than normal users.
      #   - users/auspex: allows opers with this priv to view more details about users than normal users, e.g. real host and IP.
+     #   - users/channel-spy: allows opers with this priv to view the private/secret channels that a user is on.
      #   - servers/auspex: allows opers with this priv to see more detail about server information than normal users.
      # ACTIONS:
      #   - users/mass-message: allows opers with this priv to PRIVMSG and NOTICE to a server mask (e.g. NOTICE $*)

--- a/include/configreader.h
+++ b/include/configreader.h
@@ -259,7 +259,6 @@ class CoreExport ServerConfig
 
 	/** Used to indicate who we announce invites to on a channel */
 	enum InviteAnnounceState { INVITE_ANNOUNCE_NONE, INVITE_ANNOUNCE_ALL, INVITE_ANNOUNCE_OPS, INVITE_ANNOUNCE_DYNAMIC };
-	enum OperSpyWhoisState { SPYWHOIS_NONE, SPYWHOIS_SINGLEMSG, SPYWHOIS_SPLITMSG };
 
   	/** This holds all the information in the config file,
 	 * it's indexed by tag name to a vector of key/values.
@@ -376,11 +375,6 @@ class CoreExport ServerConfig
 	/** Announce invites to the channel with a server notice
 	 */
 	InviteAnnounceState AnnounceInvites;
-
-	/** If this is enabled then operators will
-	 * see invisible (+i) channels in /whois.
-	 */
-	OperSpyWhoisState OperSpyWhois;
 
 	/** True if raw I/O is being logged */
 	bool RawLog;

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -503,14 +503,6 @@ void ServerConfig::Fill()
 		AnnounceInvites = ServerConfig::INVITE_ANNOUNCE_DYNAMIC;
 	else
 		AnnounceInvites = ServerConfig::INVITE_ANNOUNCE_NONE;
-
-	v = security->getString("operspywhois");
-	if (v == "splitmsg")
-		OperSpyWhois = SPYWHOIS_SPLITMSG;
-	else if (v == "on" || v == "yes")
-		OperSpyWhois = SPYWHOIS_SINGLEMSG;
-	else
-		OperSpyWhois = SPYWHOIS_NONE;
 }
 
 // WARNING: it is not safe to use most of the codebase in this function, as it


### PR DESCRIPTION
This separates secret channels from non-secret channels when users WHOIS themselves.

This resolves #969.