### PR TITLE
[2.0] Make sure banredirect metadata can not be duplicated

### DIFF
--- a/src/modules/m_banredirect.cpp
+++ b/src/modules/m_banredirect.cpp
@@ -40,17 +40,9 @@ class BanRedirectEntry
 	: targetchan(target), banmask(mask)
 	{
 	}
-
-	bool operator<(const BanRedirectEntry& other) const
-	{
-		if (targetchan != other.targetchan)
-			return targetchan < other.targetchan;
-
-		return banmask < other.banmask;
-	}
 };
 
-typedef std::set<BanRedirectEntry> BanRedirectList;
+typedef std::vector<BanRedirectEntry> BanRedirectList;
 typedef std::deque<std::string> StringDeque;
 
 class BanRedirect : public ModeWatcher
@@ -186,9 +178,24 @@ class BanRedirect : public ModeWatcher
 						redirects = new BanRedirectList;
 						extItem.set(channel, redirects);
 					}
+					else
+					{
+						for (BanRedirectList::iterator redir = redirects->begin(); redir != redirects->end(); ++redir)
+						{
+							// Mimic the functionality used when removing the mode
+							if ((irc::string(redir->targetchan.c_str()) == irc::string(mask[CHAN].c_str())) && (irc::string(redir->banmask.c_str()) == irc::string(param.c_str())))
+							{
+								// Make sure the +b handler will still set the right ban
+								param.append(mask[CHAN]);
+								// Silently ignore the duplicate and don't set metadata
+								// This still allows channel ops to set/unset a redirect ban to clear "ghost" redirects
+								return true;
+							}
+						}
+					}
 
 					/* Here 'param' doesn't have the channel on it yet */
-					redirects->insert(BanRedirectEntry(mask[CHAN], param));
+					redirects->push_back(BanRedirectEntry(mask[CHAN], param));
 
 					/* Now it does */
 					param.append(mask[CHAN]);
@@ -267,7 +274,7 @@ class ModuleBanRedirect : public Module
 
 				for(BanRedirectList::iterator i = redirects->begin(); i != redirects->end(); i++)
 				{
-					modestack.Push('b', i->banmask + i->targetchan);
+					modestack.Push('b', i->targetchan.insert(0, i->banmask));
 				}
 
 				for(BanRedirectList::iterator i = redirects->begin(); i != redirects->end(); i++)

--- a/src/modules/m_banredirect.cpp
+++ b/src/modules/m_banredirect.cpp
@@ -43,10 +43,10 @@ class BanRedirectEntry
 
 	bool operator<(const BanRedirectEntry& other) const
 	{
-		if (this->targetchan < other.targetchan)
-			return true;
+		if (targetchan != other.targetchan)
+			return targetchan < other.targetchan;
 
-		return this->banmask < other.banmask;
+		return banmask < other.banmask;
 	}
 };
 

--- a/src/modules/m_banredirect.cpp
+++ b/src/modules/m_banredirect.cpp
@@ -40,9 +40,17 @@ class BanRedirectEntry
 	: targetchan(target), banmask(mask)
 	{
 	}
+
+	bool operator<(const BanRedirectEntry& other) const
+	{
+		if (this->targetchan < other.targetchan)
+			return true;
+
+		return this->banmask < other.banmask;
+	}
 };
 
-typedef std::vector<BanRedirectEntry> BanRedirectList;
+typedef std::set<BanRedirectEntry> BanRedirectList;
 typedef std::deque<std::string> StringDeque;
 
 class BanRedirect : public ModeWatcher
@@ -180,7 +188,7 @@ class BanRedirect : public ModeWatcher
 					}
 
 					/* Here 'param' doesn't have the channel on it yet */
-					redirects->push_back(BanRedirectEntry(mask[CHAN], param));
+					redirects->insert(BanRedirectEntry(mask[CHAN], param));
 
 					/* Now it does */
 					param.append(mask[CHAN]);
@@ -259,7 +267,7 @@ class ModuleBanRedirect : public Module
 
 				for(BanRedirectList::iterator i = redirects->begin(); i != redirects->end(); i++)
 				{
-					modestack.Push('b', i->targetchan.insert(0, i->banmask));
+					modestack.Push('b', i->banmask + i->targetchan);
 				}
 
 				for(BanRedirectList::iterator i = redirects->begin(); i != redirects->end(); i++)


### PR DESCRIPTION
During a netburst, the banredirect `ModeWatcher::BeforeMode` is called with as if the ban was being set, resulting in the metadata being duplicated for the ban. This second metadata object will not be removed when the ban is unset, resulting in a "ghost ban" where there is no ban matching a user, but they are still redirected to the redirect channel.

### Steps to Reproduce
1. Have 2 servers, `SA` and `SB`.
2. Have 2 users, `UA` and `UB` on `SA` and `SB` respectively.
3. Both users join `#channel` and `UA` gets op.
4. `UA` joins `#otherchannel`.
5. `UA` sets `MODE #channel +b UB!*@*#otherchannel`.
6. `UB` parts `#channel` and attempts to rejoin, leading to them being forwarded to `#otherchannel`.
7. `SA` and `SB` split.
8. `SA` and `SB` reconnect.
9. `UB` is still banned from `#channel` and forwarded to `#otherchannel`.
10. `UA` sets `MODE #channel -b UB!*@*#otherchannel`.
11. `UB` is still unable to join `#channel` and is still forwarded to `#otherchannel`.

### Explanation
What appears to be happening is the `ModeWatcher::BeforeMode` method is being called as if the ban was being set during the netburst, resulting in the metadata being duplicated. The obvious fix to me was changing the `BanRedirectList` to a `set::set` to make sure only one copy of each ban appears in the list. Since the channel ban list can only have one matching entry anyways, this seemed to be the easiest fix.

This fixes #1367 