### PR TITLE
Add Haiku support

### DIFF
--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -81,6 +81,11 @@ ifeq ($(SYSTEM), darwin)
   CORELDFLAGS = -dynamic -bind_at_load -L.
   PICLDFLAGS = -fPIC -shared -twolevel_namespace -undefined dynamic_lookup
 endif
+ifeq ($(SYSTEM), haiku)
+  LDLIBS = -lnetwork -lstdc++
+  CORELDFLAGS = -L.
+  PICLDFLAGS = -fPIC -shared
+endif
 
 ifndef INSPIRCD_DEBUG
   INSPIRCD_DEBUG=0

--- a/src/coremods/core_stats.cpp
+++ b/src/coremods/core_stats.cpp
@@ -239,12 +239,13 @@ void CommandStats::DoStats(Stats::Context& stats)
 			/* Not sure why we were doing '0' with a RUSAGE_SELF comment rather than just using RUSAGE_SELF -- Om */
 			if (!getrusage(RUSAGE_SELF,&R))	/* RUSAGE_SELF */
 			{
+#ifndef __HAIKU__
 				stats.AddRow(249, "Total allocation: "+ConvToStr(R.ru_maxrss)+"K");
 				stats.AddRow(249, "Signals:          "+ConvToStr(R.ru_nsignals));
 				stats.AddRow(249, "Page faults:      "+ConvToStr(R.ru_majflt));
 				stats.AddRow(249, "Swaps:            "+ConvToStr(R.ru_nswap));
 				stats.AddRow(249, "Context Switches: Voluntary; "+ConvToStr(R.ru_nvcsw)+" Involuntary; "+ConvToStr(R.ru_nivcsw));
-
+#endif
 				float n_elapsed = (ServerInstance->Time() - ServerInstance->stats.LastSampled.tv_sec) * 1000000
 					+ (ServerInstance->Time_ns() - ServerInstance->stats.LastSampled.tv_nsec) / 1000;
 				float n_eaten = ((R.ru_utime.tv_sec - ServerInstance->stats.LastCPU.tv_sec) * 1000000 + R.ru_utime.tv_usec - ServerInstance->stats.LastCPU.tv_usec);


### PR DESCRIPTION
Compiled on hrev51795, with the modern GCC. on gcc2h, run `setarch x86` first.
I also tried compiling `m_regex_posix`, `m_regex_stdlib`, and `m_ssl_openssl` because those have devel libs by default.

cc @SaberUK