### PR TITLE
Do not send unset topics on channel join per RFC

### DIFF
--- a/src/coremods/core_channel/core_channel.cpp
+++ b/src/coremods/core_channel/core_channel.cpp
@@ -147,7 +147,7 @@ class CoreModChannel : public Module, public CheckExemption::EventListener
 			// Remove existing invite, if any
 			invapi.Remove(localuser, chan);
 
-			if (chan->topicset)
+			if (chan->topic.length())
 				Topic::ShowTopic(localuser, chan);
 
 			// Show all members of the channel, including invisible (+i) users


### PR DESCRIPTION
Fixes #1091. It looks like this was already fixed, and then somehow reverted in the move to modularity.

PRing against master because of the discussion in aforementioned issue.