### PR TITLE
[2.0] Properly check E-Lines in general and specifically from CGI:IRC

### DIFF
--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -201,8 +201,8 @@ class ModuleCgiIRC : public Module
 	{
 		cmd.realhost.set(user, user->host);
 		cmd.realip.set(user, user->GetIPString());
-		ChangeIP(user, newip);
 		user->host = user->dhost = user->GetIPString();
+		ChangeIP(user, newip);
 		user->InvalidateCache();
 		RecheckClass(user);
 		// Don't create the resolver if the core couldn't put the user in a connect class or when dns is disabled
@@ -296,10 +296,10 @@ public:
 		if (!webirc_ip)
 			return MOD_RES_PASSTHRU;
 
-		ChangeIP(user, *webirc_ip);
-
 		std::string* webirc_hostname = cmd.webirc_hostname.get(user);
 		user->host = user->dhost = (webirc_hostname ? *webirc_hostname : user->GetIPString());
+
+		ChangeIP(user, *webirc_ip);
 		user->InvalidateCache();
 
 		RecheckClass(user);

--- a/src/xline.cpp
+++ b/src/xline.cpp
@@ -593,9 +593,6 @@ void GLine::Apply(User* u)
 
 bool ELine::Matches(User *u)
 {
-	if (u->exempt)
-		return false;
-
 	if (InspIRCd::Match(u->ident, this->identmask, ascii_case_insensitive_map))
 	{
 		if (InspIRCd::MatchCIDR(u->host, this->hostmask, ascii_case_insensitive_map) ||


### PR DESCRIPTION
This PR accomplishes two things:
1. Fixes CGI:IRC checking E-Lines on a user while their host is still that of the CGI:IRC server. Which allows a false match to happen and remain.
2. Fixes the ELine::Matches() function to not return 'false' when the user is already marked exempt (previously matched an E-Line). Looking in the history, this was fixed once already and reverted as it caused issue #989.  
I believe that the root cause of this issue was the user's host still being the CGI:IRC server which was E-Lined, as it had to match an active E-Line in order to return 'true' again. This is fixed as commit 1 here.  
To the best of my searching, the `user->exempt` flag is set:
    * upon initial connection by checking for E-Lines matching the user (if a matched E-Line is returned, set true; else false)
    * whenever User::SetClientIP() is called (unless specified not to recheck e-lines) and this does the same true/false setting as above
    * within the full server userlist re-check of E-Lines; this marks each user's exempt flag false prior to checking and marks it true if a match was found. This will not be affected by this.

I've tested this with debug SNOTICEs showing user nick, IP, host, and exempt status throughout the 'OnCheckReady()' of m_cgiirc (using WEBIRC syntax). The findings of #989 were not seen and could only be seen if the first commit was reverted (user host being incorrect). I would still appreciate if @B00mX0r could confirm that this doesn't bring the issue back.  
The issue as noted in #1465 was tested, with positive results. The E-Line on the user's IP was correctly matched even with an E-Line originally matched on the CGI:IRC server.

Fixes #1465