### PR TITLE
Prioritize checking for +ikl last to match previous behavior

### DIFF
--- a/src/coremods/core_channel/core_channel.cpp
+++ b/src/coremods/core_channel/core_channel.cpp
@@ -269,6 +269,7 @@ class CoreModChannel : public Module, public CheckExemption::EventListener
 	void Prioritize() CXX11_OVERRIDE
 	{
 		ServerInstance->Modules.SetPriority(this, I_OnPostJoin, PRIORITY_FIRST);
+		ServerInstance->Modules.SetPriority(this, I_OnUserPreJoin, PRIORITY_LAST);
 	}
 
 	Version GetVersion() CXX11_OVERRIDE


### PR DESCRIPTION
https://github.com/inspircd/inspircd/commit/b3a728d93f134684593576f8eaaf2daf8df39340 broke m_redirect by causing core_channels to return a MOD_RES_DENY if limitmode was set before m_redirect's hook could run. This fixes that issue by prioritizing core_channels' OnUserPreJoin to run after other modules, matching the behavior it had while in core.