### PR TITLE
Optimize multiple redundant function calls in core

### DIFF
--- a/src/coremods/core_channel/cmd_names.cpp
+++ b/src/coremods/core_channel/cmd_names.cpp
@@ -36,7 +36,7 @@ CmdResult CommandNames::HandleLocal(const std::vector<std::string>& parameters, 
 {
 	Channel* c;
 
-	if (!parameters.size())
+	if (parameters.empty())
 	{
 		user->WriteNumeric(RPL_ENDOFNAMES, '*', "End of /NAMES list.");
 		return CMD_SUCCESS;

--- a/src/inspsocket.cpp
+++ b/src/inspsocket.cpp
@@ -293,7 +293,7 @@ void StreamSocket::FlushSendQ(SendQueue& sq)
 					const SendQueue::Element& elem = *i;
 					iovecs[j].iov_base = const_cast<char*>(elem.data());
 					iovecs[j].iov_len = elem.length();
-					rv_max += elem.length();
+					rv_max += iovecs[j].iov_len;
 				}
 				rv = SocketEngine::WriteV(this, iovecs, bufcount);
 			}


### PR DESCRIPTION
This PR optimizes loops inside of InspIRCd's core to remove redundant function calls and unnecessary memory reallocation. For most of the files affected here, that means STL optimization in the for loops. For users.cpp, a few redundant calls to mathematical operations in the write function (very commonly used) were optimized.