### PR TITLE
Fix an invalid mode parameters numeric upon attempting to view listmodes

### DIFF
--- a/include/listmode.h
+++ b/include/listmode.h
@@ -178,6 +178,15 @@ class CoreExport ListModeBase : public ModeHandler
 	 */
 	virtual bool ValidateParam(User* user, Channel* channel, std::string& parameter);
 
+	/** In the event that the mode should be given a parameter, and no parameter was provided, this method is called.
+	 * This allows you to give special information to the user, or handle this any way you like.
+	 * @param user The user issuing the mode change
+	 * @param dest For user mode changes, the target of the mode. For channel mode changes, NULL.
+	 * @param channel For channel mode changes, the target of the mode. For user mode changes, NULL.
+	 * See mode.h
+	 */
+	virtual void OnParameterMissing(User* user, User* dest, Channel* channel) CXX11_OVERRIDE;
+
 	/** Tell the user the list is too long.
 	 * Overridden by implementing module.
 	 * @param source Source user adding the parameter

--- a/src/listmode.cpp
+++ b/src/listmode.cpp
@@ -221,6 +221,10 @@ bool ListModeBase::ValidateParam(User*, Channel*, std::string&)
 	return true;
 }
 
+void ListModeBase::OnParameterMissing(User*, User*, Channel*)
+{
+}
+
 void ListModeBase::TellListTooLong(User* source, Channel* channel, std::string& parameter)
 {
 	source->WriteNumeric(ERR_BANLISTFULL, channel->name, parameter, "Channel ban list is full");


### PR DESCRIPTION
This fixes an issue where after https://github.com/inspircd/inspircd/commit/d5a6054948502625d7f0c235f6faaeea58734de5, attempting to view the list for a listmode will cause a "You must specify a parameter" error under https://github.com/inspircd/inspircd/commit/d5a6054948502625d7f0c235f6faaeea58734de5#diff-34903a46f53c58683aa794a80721ce8eR92.