### PR TITLE
Fix blank instead of empty PART message when a user is shunned

### DIFF
--- a/src/modules/m_shun.cpp
+++ b/src/modules/m_shun.cpp
@@ -280,7 +280,7 @@ class ModuleShun : public Module
 		else if ((command == "PART") && (parameters.size() > 1))
 		{
 			/* same for PART */
-			parameters[1].clear();
+			parameters.pop_back();
 		}
 
 		/* if we're here, allow the command. */


### PR DESCRIPTION
This fixes an issue where, if a shunned user parted a channel, their PART message would be truncated to nothing rather than deleted. This resulted in users who leave with a message leaving with "" as their message, whereas shunned users executing PART with no message would cause expected behavior.