### PR TITLE
Improve some documentation

### DIFF
--- a/docs/conf/helpop-full.conf.example
+++ b/docs/conf/helpop-full.conf.example
@@ -2,6 +2,8 @@
 #  Helpop Standard  #
 #####################
 
+<config format="xml">
+
 <alias text="HELP" replace="HELPOP $2-">
 
 <helpop key="start" value="InspIRCd Help System
@@ -406,11 +408,12 @@ LOCKSERV       UNLOCKSERV">
 
 Returns the ip and nickname of the given users.">
 
-<helpop key="tline" value="/TLINE <host/IP mask>
+<helpop key="tline" value="/TLINE <mask>
 
 This command returns the number of local and global clients matched,
 and the percentage of clients matched, plus how they were matched
-(by IP address or by hostname).">
+(by IP address or by hostname). Mask should be given as either a
+nick!user@host or user@IP (wildcards acceptable).">
 
 <helpop key="lockserv" value="/LOCKSERV
 
@@ -471,7 +474,7 @@ n    Block private and channel notices
 P    Block part messages
 q    Block quit messages
 o    Don't match against opers
-c    Strip all color codes from the message before matching
+c    Strip all formatting codes from the message before matching
 *    Represents all of the above flags
 -    Does nothing, a non-op for when you do not want to specify any
      flags
@@ -752,7 +755,7 @@ Sends a message to all +w users.">
 
 <helpop key="rline" value="/RLINE <regex> [<duration> :<reason>]
 
-Sets or removes an r-line (regex line) on a n!u@h\\sgecos mask. You
+Sets or removes an r-line (regex line) on a n!u@h\sgecos mask. You
 must specify all three parameters to add an rline, and one parameter
 to remove an rline (just the regex).
 
@@ -788,77 +791,79 @@ using their cloak when they quit.">
 ----------
 
  c            Blocks private messages and notices from users who do
-              not share a common channel with you (requires
+              not share a common channel with you (requires the
               commonchans module).
  d            Deaf mode. User will not receive any messages or notices
-              from channels they are in (requires deaf module).
+              from channels they are in (requires the deaf module).
  g            In combination with /ACCEPT, provides for server side
-              ignore (requires callerid module).
+              ignore (requires the callerid module).
  h            Marks as 'available for help' in WHOIS (IRCop only,
-              requires helpop module).
+              requires the helpop module).
  i            Makes invisible to /WHO if the user using /WHO is not in
               a common channel.
  k            Prevents the user from being kicked from channels, or
               having op modes removed from them (services only,
-              requires servprotect module).
+              requires the servprotect module).
  o            Marks as a IRC operator.
  s <mask>     Receives server notices specified by <mask>
               (IRCop only).
  r            Marks as a having a registered nickname
-              (requires services account module).
+              (requires the services account module).
  w            Receives wallops messages.
- x            Gives a cloaked hostname (requires cloaking module).
- B            Marks as a bot (requires botmode module).
+ x            Gives a cloaked hostname (requires the cloaking module).
+ B            Marks as a bot (requires the botmode module).
  G            Censors messages sent to the user based on filters
-              configured for the network (requires censor module).
- H            Hides an oper's oper status from WHOIS (requires
+              configured for the network (requires the censor module).
+ H            Hides an oper's oper status from WHOIS (requires the
               hideoper module).
  I            Hides a user's entire channel list in WHOIS from
-              non-IRCops (requires hidechans module).
+              non-IRCops (requires the hidechans module).
  L            Stops redirections done by m_redirect (mode must be
               enabled in the config).
  R            Blocks private messages from unregistered users
-              (requires services account module).
- S            Strips mIRC color/bold/underline codes out of private
-              messages to the user (requires stripcolor module).
+              (requires the services account module).
+ S            Strips formatting codes out of private messages
+              to the user (requires the stripcolor module).
  W            Receives notification when a user uses WHOIS on them
-              (IRCop only, requires showwhois module).">
+              (IRCop only, requires the showwhois module).">
 
 <helpop key="chmodes" value="Channel Modes
 -------------
 
  v <nickname>       Gives voice to <nickname>, allowing them to speak
                     while the channel is +m.
- h <nickname>       Gives halfop status to <nickname> (this mode can
-                    be disabled).
+ h <nickname>       Gives halfop status to <nickname> (requires the
+                    customprefix module).
  o <nickname>       Gives op status to <nickname>.
  a <nickname>       Gives protected status to <nickname>, preventing
-                    them from them from being kicked (+q only,
-                    requires chanprotect module).
+                    them from being kicked (+q only, requires the
+                    customprefix module).
  q <nickname>       Gives owner status to <nickname>, preventing them
-                    from being kicked (Services or only, requires
-                    chanprotect module).
+                    from being kicked (Services or +q only, requires
+                    the customprefix module).
 
  b <hostmask>       Bans <hostmask> from the channel.
- e <hostmask>       Excepts <hostmask> from bans (requires
+ e <hostmask>       Excepts <hostmask> from bans (requires the
                     banexception module).
  I <hostmask>       Excepts <hostmask> from +i, allowing matching
                     users to join while the channel is invite-only
-                    (requires inviteexception module).
+                    (requires the inviteexception module).
 
- c                  Blocks messages containing mIRC color codes
-                    (requires blockcolor module).
+ c                  Blocks messages that contain formatting codes
+                    (requires the blockcolor module).
  d <time>           Blocks messages to a channel from new users
                     until they have been in the channel for <time>
-                    seconds (requires delaymsg module).
+                    seconds (requires the delaymsg module).
  f [*]<lines>:<sec> Kicks on text flood equal to or above the
                     specified rate. With *, the user is banned
-                    (requires messageflood module).
+                    (requires the messageflood module).
+ g <mask>           Blocks messages matching the given glob mask
+                    (requires the chanfilter module).
  i                  Makes the channel invite-only.
                     Users can only join if an operator
                     uses /INVITE to invite them.
  j <joins>:<sec>    Limits joins to the specified rate (requires
-                    joinflood module).
+                    the joinflood module).
  k <key>            Set the channel key (password) to <key>.
  l <limit>          Set the maximum allowed users to <limit>.
  m                  Enable moderation. Only users with +v, +h, or +o
@@ -868,70 +873,86 @@ using their cloak when they quit.">
  p                  Make channel private, hiding it in users' whoises
                     and replacing it with * in /LIST.
  r                  Marks the channel as registered with Services
-                    (requires services account module).
+                    (requires the services account module).
  s                  Make channel secret, hiding it in users' whoises
                     and /LIST.
  t                  Prevents users without +h or +o from changing the
                     topic.
  u                  Makes the channel an auditorium; normal users only
                     see themselves or themselves and the operators,
-                    while operators see all the users (requires
+                    while operators see all the users (requires the
                     auditorium module).
  w <flag>:<banmask> Adds basic channel access controls of <flag> to
                     <banmask>, via the +w listmode.
                     For example, +w o:R:Brain will op anyone identified
                     to the account 'Brain' on join.
-                    (requires autoop module)
+                    (requires the autoop module)
  z                  Blocks non-SSL clients from joining the channel.
 
  A                  Allows anyone to invite users to the channel
                     (normally only chanops can invite, requires
-                    allowinvite module).
+                    the allowinvite module).
  B                  Blocks messages with too many capital letters,
                     as determined by the network configuration
-                    (requires blockcaps module).
- C                  Blocks any CTCPs to the channel (requires noctcp
-                    module).
- D                  Delays join messages from users until they
-                    message the channel (requires delayjoin module).
+                    (requires the blockcaps module).
+ C                  Blocks any CTCPs to the channel (requires the
+                    noctcp module).
+ D                  Delays join messages from users until they message
+                    the channel (requires the delayjoin module).
  F <changes>:<sec>  Blocks nick changes when they equal or exceed the
-                    specified rate (requires nickflood module).
+                    specified rate (requires the nickflood module).
  G                  Censors messages to the channel based on the
-                    network configuration (requires censor module).
+                    network configuration (requires the censor module).
  H <num>:<duration> Displays the last <num> lines of chat to joining
                     users. <duration> is the maximum time to keep
-                    lines in the history buffer (requires chanhistory
-                    module).
+                    lines in the history buffer (requires the
+                    chanhistory module).
  J <seconds>        Prevents rejoin after kick for the specified
                     number of seconds. This prevents auto-rejoin
-                    (requires kicknorejoin module).
+                    (requires the kicknorejoin module).
  K                  Blocks /KNOCK on the channel.
  L <channel>        If the channel reaches its limit set by +l,
-                    redirect users to <channel> (requires redirect
-                    module).
+                    redirect users to <channel> (requires the
+                    redirect module).
  M                  Blocks unregistered users from speaking (requires
-                    services account module).
+                    the services account module).
  N                  Prevents users on the channel from changing nick
-                    (requires nonicks module).
+                    (requires the nonicks module).
  O                  Channel is IRCops only (can only be set by IRCops,
-                    requires operchans module).
+                    requires the operchans module).
  P                  Makes the channel permanent; Bans, invites, the
                     topic, modes, and such will not be lost when it
                     empties (can only be set by IRCops, requires
-                    permchannels module).
+                    the permchannels module).
  Q                  Only ulined servers and their users can kick
-                    (requires nokicks module)
+                    (requires the nokicks module)
  R                  Blocks unregistered users from joining (requires
-                    services account module).
- S                  Strips mIRC color codes from messages to the
-                    channel (requires stripcolor module).
+                    the services account module).
+ S                  Strips formatting codes from messages to the
+                    channel (requires the stripcolor module).
  T                  Blocks /NOTICEs to the channel from users who are
-                    not at least halfop (requires nonotice module).
+                    not at least halfop (requires the nonotice module).
+ X <type>:<status>  Makes users of <status> or higher exempt to the
+                    specified restriction <type>. For example: flood:h
+                    (requires the exemptchanops module).
+ Possible restriction types to exempt with +X are:
 
- g <mask>           Blocks messages matching the given glob mask
-                    (requires chanfilter module).
- X <mode>           Makes channel operators immune to the specified
-                    restrictive mode (requires exemptchanops module).
+ auditorium-see      Permission required to see the full user list of
+                     a +u channel (requires the auditorium module).
+ auditorium-vis      Permission required to be visible in a +u channel
+                     (requires the auditorium module).
+ blockcaps           Channel mode +B
+ blockcolor          Channel mode +c
+ censor              Channel mode +G
+ filter              Channel mode +g
+ flood               Channel mode +f
+ nickflood           Channel mode +F
+ noctcp              Channel mode +C
+ nonick              Channel mode +N
+ nonotice            Channel mode +T
+ regmoderated        Channel mode +M
+ stripcolor          Channel mode +S
+ topiclock           Channel mode +t
 
 -------------
 NOTE: A large number of these modes are dependent upon server-side modules
@@ -992,30 +1013,25 @@ Note that all /STATS use is broadcast to online IRC operators.">
  A      Allows receipt of remote announcement messages.
  c      Allows receipt of local connect messages.
  C      Allows receipt of remote connect messages.
- d      Allows receipt of general (and sometimes random) debug
-        messages.
+ d      Allows receipt of general (and sometimes random) debug messages.
  f      Allows receipt of flooding notices.
- g      Allows receipt of globops (requires globops module).
- j      Allows receipt of channel creation notices (requires
-        chancreate module).
- J      Allows receipt of remote channel creation notices (requires
-        chancreate module).
+ g      Allows receipt of globops (requires the globops module).
+ j      Allows receipt of channel creation notices (requires the chancreate module).
+ J      Allows receipt of remote channel creation notices (requires the chancreate module).
  k      Allows receipt of local kill messages.
  K      Allows receipt of remote kill messages.
- l      Allows receipt of local linking related
-        messages.
- L      Allows receipt of remote linking related
-        messages.
- n      See local nickname changes (requires seenicks module).
- N      See remote nickname changes (requires seenicks modules).
- o      Allows receipt of oper-up, oper-down, and oper-failure
-        messages.
- O      Allows receipt of remote oper-up, oper-down, and oper-failure
-        messages.
+ l      Allows receipt of local linking related messages.
+ L      Allows receipt of remote linking related messages.
+ n      See local nickname changes (requires the seenicks module).
+ N      See remote nickname changes (requires the seenicks modules).
+ o      Allows receipt of oper-up, oper-down, and oper-failure messages.
+ O      Allows receipt of remote oper-up, oper-down, and oper-failure messages.
  q      Allows receipt of local quit messages.
  Q      Allows receipt of remote quit messages.
+ r      Allows receipt of local oper commands (requires the operlog module).
+ R      Allows receipt of remote oper commands (requires the operlog module).
  t      Allows receipt of attempts to use /STATS (local and remote).
- v      Allows receipt of oper-override notices (requires override module).
+ v      Allows receipt of oper-override notices (requires the override module).
  x      Allows receipt of local Xline notices (g/Z/q/k/e/R/shuns).
  X      Allows receipt of remote Xline notices (g/Z/q/k/e/R/shuns).">
 
@@ -1040,42 +1056,42 @@ setting +I <extban>.
 Matching extbans:
 
  j:<channel>   Matches anyone in the given channel. Does not support
-               wildcards (requires channelban module).
- r:<realname>  Matches users with a matching realname (requires gecosban
-               module).
- s:<server>    Matches users on a matching server (requires serverban
-               module).
+               wildcards (requires the channelban module).
+ r:<realname>  Matches users with a matching realname (requires the
+               gecosban module).
+ s:<server>    Matches users on a matching server (requires the
+               serverban module).
  z:<certfp>    Matches users having the given SSL certificate
-               fingerprint (requires sslmodes module).
+               fingerprint (requires the sslmodes module).
  O:<opertype>  Matches IRCops of a matching type, mostly useful as an
-               an invite exception (requires operchans module).
+               an invite exception (requires the operchans module).
  R:<account>   Matches users logged into a matching account (requires
-               services account module).
+               the services account module).
  U:<banmask>   Matches unregistered users matching the given banmask.
-               (requires services account module).
+               (requires the services account module).
 
 Acting extbans:
 
- c:<banmask>   Blocks any messages that contain color codes from
-               matching users (requires blockcolor module).
- m:<banmask>   Blocks messages from matching users (requires muteban
+ c:<banmask>   Blocks any messages that contain formatting codes from
+               matching users (requires the blockcolor module).
+ m:<banmask>   Blocks messages from matching users (requires the muteban
                module). Users with +v or above are not affected.
  p:<banmask>   Blocks part messages from matching users (requires
-               nopartmsg module).
+               the nopartmsg module).
  A:<banmask>   Blocks invites by matching users even when +A is set
-               (requires allowinvite module).
+               (requires the allowinvite module).
  B:<banmask>   Blocks all capital or nearly all capital messages from
-               matching users (requires blockcaps module).
- C:<banmask>   Blocks CTCPs from matching users (requires noctcp
+               matching users (requires the blockcaps module).
+ C:<banmask>   Blocks CTCPs from matching users (requires the noctcp
                module).
  N:<banmask>   Blocks nick changes from matching users (requires
-               nonicks module).
- Q:<banmask>   Blocks kicks by matching users (requires nokicks
+               the nonicks module).
+ Q:<banmask>   Blocks kicks by matching users (requires the nokicks
                module).
- S:<banmask>   Strips color/bold/underline from messages from matching
-               users (requires stripcolor module).
- T:<banmask>   Blocks notices from matching users (requires nonotice
-               module).
+ S:<banmask>   Strips formatting codes from messages from matching
+               users (requires the stripcolor module).
+ T:<banmask>   Blocks notices from matching users (requires the
+               nonotice module).
 
 A ban given to an Acting extban may either be a nick!user@host mask
 (unless stated otherwise), matched against users as for a normal ban,
@@ -1084,4 +1100,4 @@ or a Matching extban.
 There is an additional special type of extended ban, a redirect ban:
 
  Redirect      n!u@h#channel will redirect the banned user to #channel
-               when they try to join (requires banredirect module).">
+               when they try to join (requires the banredirect module).">

--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -76,77 +76,79 @@ LOCKSERV       UNLOCKSERV">
 ----------
 
  c            Blocks private messages and notices from users who do
-              not share a common channel with you (requires
+              not share a common channel with you (requires the
               commonchans module).
  d            Deaf mode. User will not receive any messages or notices
-              from channels they are in (requires deaf module).
+              from channels they are in (requires the deaf module).
  g            In combination with /ACCEPT, provides for server side
-              ignore (requires callerid module).
+              ignore (requires the callerid module).
  h            Marks as 'available for help' in WHOIS (IRCop only,
-              requires helpop module).
+              requires the helpop module).
  i            Makes invisible to /WHO if the user using /WHO is not in
               a common channel.
  k            Prevents the user from being kicked from channels, or
               having op modes removed from them (services only,
-              requires servprotect module).
+              requires the servprotect module).
  o            Marks as a IRC operator.
  s <mask>     Receives server notices specified by <mask>
               (IRCop only).
  r            Marks as a having a registered nickname
-              (requires services account module).
+              (requires the services account module).
  w            Receives wallops messages.
- x            Gives a cloaked hostname (requires cloaking module).
- B            Marks as a bot (requires botmode module).
+ x            Gives a cloaked hostname (requires the cloaking module).
+ B            Marks as a bot (requires the botmode module).
  G            Censors messages sent to the user based on filters
-              configured for the network (requires censor module).
- H            Hides an oper's oper status from WHOIS (requires
+              configured for the network (requires the censor module).
+ H            Hides an oper's oper status from WHOIS (requires the
               hideoper module).
  I            Hides a user's entire channel list in WHOIS from
-              non-IRCops (requires hidechans module).
+              non-IRCops (requires the hidechans module).
  L            Stops redirections done by m_redirect (mode must be
               enabled in the config).
  R            Blocks private messages from unregistered users
-              (requires services account module).
- S            Strips mIRC color/bold/underline codes out of private
-              messages to the user (requires stripcolor module).
+              (requires the services account module).
+ S            Strips formatting codes out of private messages
+              to the user (requires the stripcolor module).
  W            Receives notification when a user uses WHOIS on them
-              (IRCop only, requires showwhois module).">
+              (IRCop only, requires the showwhois module).">
 
 <helpop key="chmodes" value="Channel Modes
 -------------
 
  v <nickname>       Gives voice to <nickname>, allowing them to speak
                     while the channel is +m.
- h <nickname>       Gives halfop status to <nickname> (this mode can
-                    be disabled).
+ h <nickname>       Gives halfop status to <nickname> (requires the
+                    customprefix module).
  o <nickname>       Gives op status to <nickname>.
  a <nickname>       Gives protected status to <nickname>, preventing
-                    them from them from being kicked (+q only,
-                    requires chanprotect module).
+                    them from being kicked (+q only, requires the
+                    customprefix module).
  q <nickname>       Gives owner status to <nickname>, preventing them
-                    from being kicked (Services or only, requires
-                    chanprotect module).
+                    from being kicked (Services or +q only, requires
+                    the customprefix module).
 
  b <hostmask>       Bans <hostmask> from the channel.
- e <hostmask>       Excepts <hostmask> from bans (requires
+ e <hostmask>       Excepts <hostmask> from bans (requires the
                     banexception module).
  I <hostmask>       Excepts <hostmask> from +i, allowing matching
                     users to join while the channel is invite-only
-                    (requires inviteexception module).
+                    (requires the inviteexception module).
 
- c                  Blocks messages containing mIRC color codes
-                    (requires blockcolor module).
+ c                  Blocks messages that contain formatting codes
+                    (requires the blockcolor module).
  d <time>           Blocks messages to a channel from new users
                     until they have been in the channel for <time>
-                    seconds (requires delaymsg module).
+                    seconds (requires the delaymsg module).
  f [*]<lines>:<sec> Kicks on text flood equal to or above the
                     specified rate. With *, the user is banned
-                    (requires messageflood module).
+                    (requires the messageflood module).
+ g <mask>           Blocks messages matching the given glob mask
+                    (requires the chanfilter module).
  i                  Makes the channel invite-only.
                     Users can only join if an operator
                     uses /INVITE to invite them.
  j <joins>:<sec>    Limits joins to the specified rate (requires
-                    joinflood module).
+                    the joinflood module).
  k <key>            Set the channel key (password) to <key>.
  l <limit>          Set the maximum allowed users to <limit>.
  m                  Enable moderation. Only users with +v, +h, or +o
@@ -156,70 +158,68 @@ LOCKSERV       UNLOCKSERV">
  p                  Make channel private, hiding it in users' whoises
                     and replacing it with * in /LIST.
  r                  Marks the channel as registered with Services
-                    (requires services account module).
+                    (requires the services account module).
  s                  Make channel secret, hiding it in users' whoises
                     and /LIST.
  t                  Prevents users without +h or +o from changing the
                     topic.
  u                  Makes the channel an auditorium; normal users only
                     see themselves or themselves and the operators,
-                    while operators see all the users (requires
+                    while operators see all the users (requires the
                     auditorium module).
  w <flag>:<banmask> Adds basic channel access controls of <flag> to
                     <banmask>, via the +w listmode.
                     For example, +w o:R:Brain will op anyone identified
                     to the account 'Brain' on join.
-                    (requires autoop module)
+                    (requires the autoop module)
  z                  Blocks non-SSL clients from joining the channel.
 
  A                  Allows anyone to invite users to the channel
                     (normally only chanops can invite, requires
-                    allowinvite module).
+                    the allowinvite module).
  B                  Blocks messages with too many capital letters,
                     as determined by the network configuration
-                    (requires blockcaps module).
- C                  Blocks any CTCPs to the channel (requires noctcp
-                    module).
- D                  Delays join messages from users until they
-                    message the channel (requires delayjoin module).
+                    (requires the blockcaps module).
+ C                  Blocks any CTCPs to the channel (requires the
+                    noctcp module).
+ D                  Delays join messages from users until they message
+                    the channel (requires the delayjoin module).
  F <changes>:<sec>  Blocks nick changes when they equal or exceed the
-                    specified rate (requires nickflood module).
+                    specified rate (requires the nickflood module).
  G                  Censors messages to the channel based on the
-                    network configuration (requires censor module).
+                    network configuration (requires the censor module).
  H <num>:<duration> Displays the last <num> lines of chat to joining
                     users. <duration> is the maximum time to keep
-                    lines in the history buffer (requires chanhistory
-                    module).
+                    lines in the history buffer (requires the
+                    chanhistory module).
  J <seconds>        Prevents rejoin after kick for the specified
                     number of seconds. This prevents auto-rejoin
-                    (requires kicknorejoin module).
+                    (requires the kicknorejoin module).
  K                  Blocks /KNOCK on the channel.
  L <channel>        If the channel reaches its limit set by +l,
-                    redirect users to <channel> (requires redirect
-                    module).
+                    redirect users to <channel> (requires the
+                    redirect module).
  M                  Blocks unregistered users from speaking (requires
-                    services account module).
+                    the services account module).
  N                  Prevents users on the channel from changing nick
-                    (requires nonicks module).
+                    (requires the nonicks module).
  O                  Channel is IRCops only (can only be set by IRCops,
-                    requires operchans module).
+                    requires the operchans module).
  P                  Makes the channel permanent; Bans, invites, the
                     topic, modes, and such will not be lost when it
                     empties (can only be set by IRCops, requires
-                    permchannels module).
+                    the permchannels module).
  Q                  Only ulined servers and their users can kick
-                    (requires nokicks module)
+                    (requires the nokicks module)
  R                  Blocks unregistered users from joining (requires
-                    services account module).
- S                  Strips mIRC color codes from messages to the
-                    channel (requires stripcolor module).
+                    the services account module).
+ S                  Strips formatting codes from messages to the
+                    channel (requires the stripcolor module).
  T                  Blocks /NOTICEs to the channel from users who are
-                    not at least halfop (requires nonotice module).
-
- g <mask>           Blocks messages matching the given glob mask
-                    (requires chanfilter module).
- X <mode>           Makes channel operators immune to the specified
-                    restrictive mode (requires exemptchanops module).
+                    not at least halfop (requires the nonotice module).
+ X <type>:<status>  Makes users of <status> or higher exempt to the
+                    specified restriction <type>. For example: flood:h
+                    (requires the exemptchanops module).
 
 -------------
 NOTE: A large number of these modes are dependent upon server-side modules
@@ -233,30 +233,25 @@ help channel if you have any questions.">
  A      Allows receipt of remote announcement messages.
  c      Allows receipt of local connect messages.
  C      Allows receipt of remote connect messages.
- d      Allows receipt of general (and sometimes random) debug
-        messages.
+ d      Allows receipt of general (and sometimes random) debug messages.
  f      Allows receipt of flooding notices.
- g      Allows receipt of globops (requires globops module).
- j      Allows receipt of channel creation notices (requires
-        chancreate module).
- J      Allows receipt of remote channel creation notices (requires
-        chancreate module).
+ g      Allows receipt of globops (requires the globops module).
+ j      Allows receipt of channel creation notices (requires the chancreate module).
+ J      Allows receipt of remote channel creation notices (requires the chancreate module).
  k      Allows receipt of local kill messages.
  K      Allows receipt of remote kill messages.
- l      Allows receipt of local linking related
-        messages.
- L      Allows receipt of remote linking related
-        messages.
- n      See local nickname changes (requires seenicks module).
- N      See remote nickname changes (requires seenicks modules).
- o      Allows receipt of oper-up, oper-down, and oper-failure
-        messages.
- O      Allows receipt of remote oper-up, oper-down, and oper-failure
-        messages.
+ l      Allows receipt of local linking related messages.
+ L      Allows receipt of remote linking related messages.
+ n      See local nickname changes (requires the seenicks module).
+ N      See remote nickname changes (requires the seenicks modules).
+ o      Allows receipt of oper-up, oper-down, and oper-failure messages.
+ O      Allows receipt of remote oper-up, oper-down, and oper-failure messages.
  q      Allows receipt of local quit messages.
  Q      Allows receipt of remote quit messages.
+ r      Allows receipt of local oper commands (requires the operlog module).
+ R      Allows receipt of remote oper commands (requires the operlog module).
  t      Allows receipt of attempts to use /STATS (local and remote).
- v      Allows receipt of oper-override notices (requires override module).
+ v      Allows receipt of oper-override notices (requires the override module).
  x      Allows receipt of local Xline notices (g/Z/q/k/e/R/shuns).
  X      Allows receipt of remote Xline notices (g/Z/q/k/e/R/shuns).">
 
@@ -277,42 +272,42 @@ setting +I <extban>.
 Matching extbans:
 
  j:<channel>   Matches anyone in the given channel. Does not support
-               wildcards (requires channelban module).
- r:<realname>  Matches users with a matching realname (requires gecosban
-               module).
- s:<server>    Matches users on a matching server (requires serverban
-               module).
+               wildcards (requires the channelban module).
+ r:<realname>  Matches users with a matching realname (requires the
+               gecosban module).
+ s:<server>    Matches users on a matching server (requires the
+               serverban module).
  z:<certfp>    Matches users having the given SSL certificate
-               fingerprint (requires sslmodes module).
+               fingerprint (requires the sslmodes module).
  O:<opertype>  Matches IRCops of a matching type, mostly useful as an
-               an invite exception (requires operchans module).
+               an invite exception (requires the operchans module).
  R:<account>   Matches users logged into a matching account (requires
-               services account module).
+               the services account module).
  U:<banmask>   Matches unregistered users matching the given banmask.
-               (requires services account module).
+               (requires the services account module).
 
 Acting extbans:
 
- c:<banmask>   Blocks any messages that contain color codes from
-               matching users (requires blockcolor module).
- m:<banmask>   Blocks messages from matching users (requires muteban
+ c:<banmask>   Blocks any messages that contain formatting codes from
+               matching users (requires the blockcolor module).
+ m:<banmask>   Blocks messages from matching users (requires the muteban
                module). Users with +v or above are not affected.
  p:<banmask>   Blocks part messages from matching users (requires
-               nopartmsg module).
+               the nopartmsg module).
  A:<banmask>   Blocks invites by matching users even when +A is set
-               (requires allowinvite module).
+               (requires the allowinvite module).
  B:<banmask>   Blocks all capital or nearly all capital messages from
-               matching users (requires blockcaps module).
- C:<banmask>   Blocks CTCPs from matching users (requires noctcp
+               matching users (requires the blockcaps module).
+ C:<banmask>   Blocks CTCPs from matching users (requires the noctcp
                module).
  N:<banmask>   Blocks nick changes from matching users (requires
-               nonicks module).
- Q:<banmask>   Blocks kicks by matching users (requires nokicks
+               the nonicks module).
+ Q:<banmask>   Blocks kicks by matching users (requires the nokicks
                module).
- S:<banmask>   Strips color/bold/underline from messages from matching
-               users (requires stripcolor module).
- T:<banmask>   Blocks notices from matching users (requires nonotice
-               module).
+ S:<banmask>   Strips formatting codes from messages from matching
+               users (requires the stripcolor module).
+ T:<banmask>   Blocks notices from matching users (requires the
+               nonotice module).
 
 A ban given to an Acting extban may either be a nick!user@host mask
 (unless stated otherwise), matched against users as for a normal ban,
@@ -321,4 +316,4 @@ or a Matching extban.
 There is an additional special type of extended ban, a redirect ban:
 
  Redirect      n!u@h#channel will redirect the banned user to #channel
-               when they try to join (requires banredirect module).">
+               when they try to join (requires the banredirect module).">

--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -613,8 +613,38 @@
          # banned from the server.
          moronbanner="You're banned! Email abuse@example.com with the ERROR line below for help."
 
-         # exemptchanops: exemptions for channel access restrictions based on prefix.
-         exemptchanops="nonick:v flood:o"
+         # exemptchanops: Allows users with with a status mode to be exempt
+         # from various channel restrictions. Possible restrictions are:
+         #  - auditorium-see  Permission required to see the full user list of
+         #                    a +u channel (requires the auditorium module).
+         #  - auditorium-vis  Permission required to be visible in a +u channel
+         #                    (requires the auditorium module).
+         #  - blockcaps       Channel mode +B - blocks messages with too many capital
+         #                    letters (requires the blockcaps module).
+         #  - blockcolor      Channel mode +c - blocks messages with formatting codes
+         #                    (requires the blockcolor module).
+         #  - censor          Channel mode +G - censors messages based on the network
+         #                    configuration (requires the censor module).
+         #  - filter          Channel mode +g - blocks messages containing the given
+         #                    glob mask (requires the chanfilter module).
+         #  - flood           Channel mode +f - kicks (and bans) on text flood of a
+         #                    specified rate (requires the messageflood module).
+         #  - nickflood       Channel mode +F - blocks nick changes after a specified
+         #                    rate (requires the nickflood module).
+         #  - noctcp          Channel mode +C - blocks any CTCPs to the channel
+         #                    (requires the noctcp module).
+         #  - nonick          Channel mode +N - prevents users on the channel from
+         #                    changing nicks (requires the nonicks module).
+         #  - nonotice        Channel mode +T - blocks /NOTICEs to the channel
+         #                    (requires the nonotice module).
+         #  - regmoderated    Channel mode +M - blocks unregistered users from
+         #                    speaking (requires the services account module).
+         #  - stripcolor      Channel mode +S - strips formatting codes from
+         #                    messages (requires the stripcolor module).
+         #  - topiclock       Channel mode +t - limits changing the topic to (half)ops
+         # You can also configure this on a per-channel basis with a channel mode.
+         # See m_exemptchanops in modules.conf.example for more details.
+         exemptchanops="censor:o filter:o nickflood:o nonick:v regmoderated:o"
 
          # invitebypassmodes: This allows /invite to bypass other channel modes.
          # (Such as +k, +j, +l, etc.)

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -750,9 +750,13 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Exempt channel operators module: Provides support for allowing      #
-# channel operators to be exempt from some channel modes.  Supported  #
-# modes are blockcaps, noctcp, blockcolor, nickflood, flood, censor,  #
-# filter, regmoderated, nonick, nonotice, and stripcolor.             #
+# users of a specified channel status to be exempt from some channel  #
+# restriction modes. Supported restrictions are                       #
+# blockcaps, blockcolor, censor, filter, flood, nickflood, noctcp,    #
+# nonick, nonotice, regmoderated, stripcolor, and topiclock.          #
+# See <options:exemptchanops> in inspircd.conf.example for a more     #
+# detailed list of the restriction modes that can be exempted.        #
+# These are settable using /mode #chan +X <restriction>:<status>      #
 #<module name="m_exemptchanops.so">                                   #
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
@@ -845,7 +849,7 @@
 #                                                                     #
 # If you specify to use the m_helpop.so module, then specify below    #
 # the path to the helpop.conf file.                                   #
-#<include file="conf/examples/inspircd.helpop-full.example">
+#<include file="conf/examples/helpop-full.conf.example">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Hide chans module: Allows users to hide their channels list from non-


### PR DESCRIPTION
* Improve exemptchanops in inspircd.conf.example (`<options>`) and modules.conf.example; along with both helpop examples.
* Add "the" to all "requires X module" in both helpop examples.
* Add SNOMASK 'r' and 'R' (OPERLOG) to both helpop examples.
* Clean up unnecessarily split SNOMASK lines in both helpop examples.
* Move chmode 'g' to be in alphabetical order in both helpops examples.
* Specify the needed mask formats for TLINE in helpop-full example.
* Remove extra `\` in RLINE mask format in helpop-full example.

Resolves #1481