### PR TITLE
Use "real name" to refer to the real name field.

### DIFF
--- a/docs/conf/helpop-full.conf.example
+++ b/docs/conf/helpop-full.conf.example
@@ -145,10 +145,10 @@ everything from people with a host matching *.foo.net, you would do
 
 Sends a notice to a channel indicating you wish to join.">
 
-<helpop key="user" value="/USER <ident> <local host> <remote host> :<GECOS>
+<helpop key="user" value="/USER <ident> <local host> <remote host> :<real name>
 
 This command is used by your client to register your
-IRC session, providing your ident and GECOS to the
+IRC session, providing your ident and real name to the
 server.
 
 You should not use it during an established connection.">
@@ -245,10 +245,10 @@ The following flags after the mask have the following effects:
  i      Show all users who have an ident (username) matching the given mask
  p      Show all users who are connected on the given port number (IRC
         operators only)
- r      Show all users whose realnames match the mask. When this
+ r      Show all users whose real name match the mask. When this
         flag is set it overrides the meaning of the search-pattern,
-        which must contain a glob pattern intended to match GECOS
-        (realname) fields.
+        which must contain a glob pattern intended to match the
+        real name.
  m      Search for all users with a given set of user modes. When
         this flag is set it overrides the meaning of the
         search-pattern, which must contain the mode sequence to
@@ -744,7 +744,7 @@ Sends a message to all +w users.">
 
 <helpop key="rline" value="/RLINE <regex> [<duration> :<reason>]
 
-Sets or removes an r-line (regex line) on a n!u@h\\sgecos mask. You
+Sets or removes an r-line (regex line) on a n!u@h\\srealname mask. You
 must specify all three parameters to add an rline, and one parameter
 to remove an rline (just the regex).
 
@@ -1050,8 +1050,8 @@ Matching extbans:
                wildcards (requires channelban module).
  n:<class>     Matches users in a matching connect class (requires
                classban module).
- r:<realname>  Matches users with a matching realname (requires gecosban
-               module).
+ r:<realname>  Matches users with a matching real name (requires
+               gecosban module).
  s:<server>    Matches users on a matching server (requires serverban
                module).
  z:<certfp>    Matches users with a matching SSL certificate fingerprint

--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -283,8 +283,8 @@ Matching extbans:
                wildcards (requires channelban module).
  n:<class>     Matches users in a matching connect class (requires
                classban module).
- r:<realname>  Matches users with a matching realname (requires gecosban
-               module).
+ r:<realname>  Matches users with a matching real name (requires
+               gecosban module).
  s:<server>    Matches users on a matching server (requires serverban
                module).
  z:<certfp>    Matches users having the given SSL certificate

--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -794,7 +794,7 @@
         # maxkick: Maximum length of a kick message.
         maxkick="255"
 
-        # maxgecos: Maximum length of a GECOS (realname).
+        # maxgecos: Maximum length of a real name (gecos).
         maxgecos="128"
 
         # maxaway: Maximum length of an away message.

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -813,8 +813,8 @@
 #<module name="flashpolicyd">                                         #
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Gecos ban: Implements extended ban 'r', which stops anyone matching
-# a mask like +b r:*realname?here* from joining a channel.
+# Gecos (real name) ban: Implements extended ban 'r', which stops anyone
+# matching a mask like +b r:*realname?here* from joining a channel.
 #<module name="gecosban">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#

--- a/include/protocol.h
+++ b/include/protocol.h
@@ -46,7 +46,7 @@ class CoreExport ProtocolInterface
 	 public:
 		std::string servername;
 		std::string parentname;
-		std::string gecos;
+		std::string description;
 		unsigned int usercount;
 		unsigned int opercount;
 		unsigned int latencyms;

--- a/include/server.h
+++ b/include/server.h
@@ -53,7 +53,7 @@ class CoreExport Server : public classbase
 	 */
 	const std::string& GetName() const { return name; }
 
-	/** Returns the description (GECOS) of this server
+	/** Returns the description of this server
 	 * @return The description of this server
 	 */
 	const std::string& GetDesc() const { return description; }

--- a/src/coremods/core_user/cmd_user.cpp
+++ b/src/coremods/core_user/cmd_user.cpp
@@ -32,7 +32,7 @@ CommandUser::CommandUser(Module* parent)
 {
 	works_before_reg = true;
 	Penalty = 0;
-	syntax = "<username> <localhost> <remotehost> <GECOS>";
+	syntax = "<username> <localhost> <remotehost> <realname>";
 }
 
 CmdResult CommandUser::HandleLocal(const std::vector<std::string>& parameters, LocalUser *user)

--- a/src/modules/m_chgname.cpp
+++ b/src/modules/m_chgname.cpp
@@ -45,20 +45,20 @@ class CommandChgname : public Command
 
 		if (parameters[1].empty())
 		{
-			user->WriteNotice("*** CHGNAME: GECOS must be specified");
+			user->WriteNotice("*** CHGNAME: Real name must be specified");
 			return CMD_FAILURE;
 		}
 
 		if (parameters[1].length() > ServerInstance->Config->Limits.MaxGecos)
 		{
-			user->WriteNotice("*** CHGNAME: GECOS too long");
+			user->WriteNotice("*** CHGNAME: Real name is too long");
 			return CMD_FAILURE;
 		}
 
 		if (IS_LOCAL(dest))
 		{
 			dest->ChangeName(parameters[1]);
-			ServerInstance->SNO->WriteGlobalSno('a', "%s used CHGNAME to change %s's GECOS to '%s'", user->nick.c_str(), dest->nick.c_str(), dest->fullname.c_str());
+			ServerInstance->SNO->WriteGlobalSno('a', "%s used CHGNAME to change %s's real name to '%s'", user->nick.c_str(), dest->nick.c_str(), dest->fullname.c_str());
 		}
 
 		return CMD_SUCCESS;

--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -43,7 +43,7 @@ class DNSBLConfEntry : public refcountbase
 };
 
 
-/** Resolver for CGI:IRC hostnames encoded in ident/GECOS
+/** Resolver for CGI:IRC hostnames encoded in ident/real name
  */
 class DNSBLResolver : public DNS::Request
 {

--- a/src/modules/m_gecosban.cpp
+++ b/src/modules/m_gecosban.cpp
@@ -24,7 +24,7 @@ class ModuleGecosBan : public Module
  public:
 	Version GetVersion() CXX11_OVERRIDE
 	{
-		return Version("Extban 'r' - realname (gecos) ban", VF_OPTCOMMON|VF_VENDOR);
+		return Version("Extban 'r' - real name ban", VF_OPTCOMMON|VF_VENDOR);
 	}
 
 	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask) CXX11_OVERRIDE

--- a/src/modules/m_httpd_stats.cpp
+++ b/src/modules/m_httpd_stats.cpp
@@ -97,8 +97,8 @@ class ModuleHttpStats : public Module, public HTTPRequestEventListener
 
 			if ((http->GetURI() == "/stats") || (http->GetURI() == "/stats/"))
 			{
-				data << "<inspircdstats><server><name>" << ServerInstance->Config->ServerName << "</name><gecos>"
-					<< Sanitize(ServerInstance->Config->ServerDesc) << "</gecos><version>"
+				data << "<inspircdstats><server><name>" << ServerInstance->Config->ServerName << "</name><description>"
+					<< Sanitize(ServerInstance->Config->ServerDesc) << "</description><version>"
 					<< Sanitize(ServerInstance->GetVersionString()) << "</version></server>";
 
 				data << "<general>";
@@ -211,7 +211,7 @@ class ModuleHttpStats : public Module, public HTTPRequestEventListener
 					data << "<server>";
 					data << "<servername>" << b->servername << "</servername>";
 					data << "<parentname>" << b->parentname << "</parentname>";
-					data << "<gecos>" << Sanitize(b->gecos) << "</gecos>";
+					data << "<description>" << Sanitize(b->description) << "</description>";
 					data << "<usercount>" << b->usercount << "</usercount>";
 // This is currently not implemented, so, commented out.
 //					data << "<opercount>" << b->opercount << "</opercount>";

--- a/src/modules/m_httpd_stats.cpp
+++ b/src/modules/m_httpd_stats.cpp
@@ -183,8 +183,8 @@ class ModuleHttpStats : public Module, public HTTPRequestEventListener
 
 					data << "<user>";
 					data << "<nickname>" << u->nick << "</nickname><uuid>" << u->uuid << "</uuid><realhost>"
-						<< u->GetRealHost() << "</realhost><displayhost>" << u->GetDisplayedHost() << "</displayhost><gecos>"
-						<< Sanitize(u->fullname) << "</gecos><server>" << u->server->GetName() << "</server>";
+						<< u->GetRealHost() << "</realhost><displayhost>" << u->GetDisplayedHost() << "</displayhost><realname>"
+						<< Sanitize(u->fullname) << "</realname><server>" << u->server->GetName() << "</server>";
 					if (u->IsAway())
 						data << "<away>" << Sanitize(u->awaymsg) << "</away><awaytime>" << u->awaytime << "</awaytime>";
 					if (u->IsOper())

--- a/src/modules/m_setname.cpp
+++ b/src/modules/m_setname.cpp
@@ -29,20 +29,20 @@ class CommandSetname : public Command
 	CommandSetname(Module* Creator) : Command(Creator,"SETNAME", 1, 1)
 	{
 		allow_empty_last_param = false;
-		syntax = "<new-gecos>";
+		syntax = "<newname>";
 	}
 
 	CmdResult Handle(const std::vector<std::string>& parameters, User* user) CXX11_OVERRIDE
 	{
 		if (parameters[0].size() > ServerInstance->Config->Limits.MaxGecos)
 		{
-			user->WriteNotice("*** SETNAME: GECOS too long");
+			user->WriteNotice("*** SETNAME: Real name is too long");
 			return CMD_FAILURE;
 		}
 
 		if (user->ChangeName(parameters[0]))
 		{
-			ServerInstance->SNO->WriteGlobalSno('a', "%s used SETNAME to change their GECOS to '%s'", user->nick.c_str(), parameters[0].c_str());
+			ServerInstance->SNO->WriteGlobalSno('a', "%s used SETNAME to change their real name to '%s'", user->nick.c_str(), parameters[0].c_str());
 		}
 
 		return CMD_SUCCESS;

--- a/src/modules/m_spanningtree/compat.cpp
+++ b/src/modules/m_spanningtree/compat.cpp
@@ -267,7 +267,7 @@ void TreeSocket::WriteLine(const std::string& original_line)
 				}
 				else if (command == "SERVER")
 				{
-					// :001 SERVER inspircd.test 002 [<anything> ...] :gecos
+					// :001 SERVER inspircd.test 002 [<anything> ...] :description
 					//     A      B             C
 					std::string::size_type c = line.find(' ', b + 1);
 					if (c == std::string::npos)

--- a/src/modules/m_spanningtree/protocolinterface.cpp
+++ b/src/modules/m_spanningtree/protocolinterface.cpp
@@ -38,7 +38,7 @@ void SpanningTreeProtocolInterface::GetServerList(ServerList& sl)
 		ps.parentname = s ? s->GetName() : "";
 		ps.usercount = i->second->UserCount;
 		ps.opercount = i->second->OperCount;
-		ps.gecos = i->second->GetDesc();
+		ps.description = i->second->GetDesc();
 		ps.latencyms = i->second->rtt;
 		sl.push_back(ps);
 	}


### PR DESCRIPTION
Currently, "gecos" is used in the `ServerInfo` class for "description" and in the `User` class for "real name", named (in `User`) "fullname".  
This PR is:
* Changing the ServerInfo "gecos" field to "description", only a few small changes here.
* Changing documentation and server sent messages that use "gecos" to mean "real name" to use a more clear form of "real name", "realname", "name" (whichever fits best with the current adjacent form).

The module m_gecosban example in modules.conf.example remains with "Gecos" as the primary name, as it fits the alphabetical order of the file and needs to remain the module name (2.0 compat).

Edit: more changes regarding "realname" to come at a later time.
~~With staying clear of compat issues for now, I would still like to accomplish in this PR:~~
~~- [ ] Changing the `User` "fullname" to "realname"~~
~~- [ ] Changing the `OnChangeLocalUserGECOS` to something...~~
    ~~`OnChangeLocalUserName` matches the current `OnChangeName` but does look misleading with the `UserName`.~~