### PR TITLE
Add --nopid command line option

### DIFF
--- a/include/configreader.h
+++ b/include/configreader.h
@@ -146,6 +146,18 @@ struct CommandLineConf
 	 */
 	bool writelog;
 
+	/** If this is true, a PID file will be written
+	 * to the file given in the "file" variable of
+	 * the <pid> tag in the config file. This is
+	 * the default.
+	 * Passing --nopid as a command line argument
+	 * sets this to false; in this case, a PID file
+	 * will not be written, even the default PID
+	 * file that is usually written when the <pid>
+	 * tag is not defined in the config file.
+	 */
+	bool writepid;
+
 	/** Saved argc from startup
 	 */
 	int argc;

--- a/src/inspircd.cpp
+++ b/src/inspircd.cpp
@@ -186,6 +186,12 @@ bool InspIRCd::DaemonSeed()
 void InspIRCd::WritePID(const std::string& filename, bool exitonfail)
 {
 #ifndef _WIN32
+	if (!ServerInstance->Config->cmdline.writepid)
+	{
+		this->Logs->Log("STARTUP", LOG_DEFAULT, "--nopid specified on command line; PID file not written.");
+		return;
+	}
+
 	std::string fname(filename);
 	if (fname.empty())
 		fname = ServerInstance->Config->Paths.PrependData("inspircd.pid");
@@ -225,7 +231,7 @@ InspIRCd::InspIRCd(int argc, char** argv) :
 	FailedPortList pl;
 	// Flag variables passed to getopt_long() later
 	int do_version = 0, do_nofork = 0, do_debug = 0,
-	    do_nolog = 0, do_root = 0;
+	    do_nolog = 0, do_nopid = 0, do_root = 0;
 
 	// Initialize so that if we exit before proper initialization they're not deleted
 	this->Config = 0;
@@ -271,6 +277,7 @@ InspIRCd::InspIRCd(int argc, char** argv) :
 		{ "config",	required_argument,	NULL,		'c'	},
 		{ "debug",	no_argument,		&do_debug,	1	},
 		{ "nolog",	no_argument,		&do_nolog,	1	},
+		{ "nopid",	no_argument,		&do_nopid,	1	},
 		{ "runasroot",	no_argument,		&do_root,	1	},
 		{ "version",	no_argument,		&do_version,	1	},
 #ifdef INSPIRCD_ENABLE_TESTSUITE
@@ -297,7 +304,7 @@ InspIRCd::InspIRCd(int argc, char** argv) :
 			default:
 				/* Fall through to handle other weird values too */
 				std::cout << "Unknown parameter '" << argv[optind-1] << "'" << std::endl;
-				std::cout << "Usage: " << argv[0] << " [--nofork] [--nolog] [--debug] [--config <config>]" << std::endl <<
+				std::cout << "Usage: " << argv[0] << " [--nofork] [--nolog] [--nopid] [--debug] [--config <config>]" << std::endl <<
 					std::string(static_cast<size_t>(8+strlen(argv[0])), ' ') << "[--runasroot] [--version]" << std::endl;
 				Exit(EXIT_STATUS_ARGV);
 			break;
@@ -325,6 +332,7 @@ InspIRCd::InspIRCd(int argc, char** argv) :
 	Config->cmdline.nofork = (do_nofork != 0);
 	Config->cmdline.forcedebug = (do_debug != 0);
 	Config->cmdline.writelog = !do_nolog;
+	Config->cmdline.writepid = !do_nopid;
 
 	if (do_debug)
 	{


### PR DESCRIPTION
I'm trying to eliminate as many unneeded PID files as possible from my system (the init scripts don't use them to identify running services), but there's currently no way to tell InspIRCd not to generate one. This PR implements a `--nopid` command line option, which prevents any PID file from being written to the file system, whether at the default location or the one specified in `<pid file>`.

Although this PR is against the master branch, it's straightforward to backport it to 2.0. I've already done all the work, and can submit a separate PR against the `insp20` branch for that if you like.