### PR TITLE
Make m_kicknorejoin respect /invite

### DIFF
--- a/src/modules/m_kicknorejoin.cpp
+++ b/src/modules/m_kicknorejoin.cpp
@@ -110,6 +110,13 @@ public:
 					{
 						if (iter->first == user->uuid)
 						{
+							LocalUser* lusr = IS_LOCAL(user);
+							if (lusr && lusr->IsInvited(cname))
+							{
+								dl->erase(iter++);
+								return MOD_RES_PASSTHRU;
+							}
+
 							std::string modeparam = chan->GetModeParameter(&kr);
 							user->WriteNumeric(ERR_DELAYREJOIN, "%s %s :You must wait %s seconds after being kicked to rejoin (+J)",
 								user->nick.c_str(), chan->name.c_str(), modeparam.c_str());


### PR DESCRIPTION
This adds a check for if a kicked user has received a `/invite`, and if so, allows them to join and removes them from the list of blocked joins. This makes +J consistent with 'expected' behavior of `/invite`.