### PR TITLE
Show reasons in xline expiry messages.

### DIFF
--- a/src/modules/m_svshold.cpp
+++ b/src/modules/m_svshold.cpp
@@ -58,8 +58,8 @@ public:
 	{
 		if (!silent)
 		{
-			ServerInstance->SNO->WriteToSnoMask('x', "Removing expired SVSHOLD %s (set by %s %ld seconds ago)",
-				nickname.c_str(), source.c_str(), (long)(ServerInstance->Time() - set_time));
+			ServerInstance->SNO->WriteToSnoMask('x', "Removing expired SVSHOLD %s (set by %s %ld seconds ago): %s",
+				nickname.c_str(), source.c_str(), (long)(ServerInstance->Time() - set_time), reason.c_str());
 		}
 	}
 

--- a/src/xline.cpp
+++ b/src/xline.cpp
@@ -680,8 +680,8 @@ void ELine::OnAdd()
 void XLine::DisplayExpiry()
 {
 	bool onechar = (type.length() == 1);
-	ServerInstance->SNO->WriteToSnoMask('x', "Removing expired %s%s %s (set by %s %ld seconds ago)",
-		type.c_str(), (onechar ? "-Line" : ""), Displayable().c_str(), source.c_str(), (long)(ServerInstance->Time() - set_time));
+	ServerInstance->SNO->WriteToSnoMask('x', "Removing expired %s%s %s (set by %s %ld seconds ago): %s",
+		type.c_str(), (onechar ? "-Line" : ""), Displayable().c_str(), source.c_str(), (long)(ServerInstance->Time() - set_time), reason.c_str());
 }
 
 const std::string& ELine::Displayable()


### PR DESCRIPTION
This is handy for seeing at a glance what reason was associated with a now expired xline, at the time that it was first set. PR for #1434.