### PR TITLE
Autoptr patch

### DIFF
--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -46,9 +46,6 @@
 # endif
 #endif
 
-// Fix warnings about using std::auto_ptr on C++11 or newer.
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <gnutls/gnutls.h>
 #include <gnutls/x509.h>
 
@@ -212,9 +209,9 @@ namespace GnuTLS
 
 	 public:
 		/** Import */
-		static std::auto_ptr<DHParams> Import(const std::string& dhstr)
+		static std::unique_ptr<DHParams> Import(const std::string& dhstr)
 		{
-			std::auto_ptr<DHParams> dh(new DHParams);
+			std::unique_ptr<DHParams> dh(new DHParams);
 			int ret = gnutls_dh_params_import_pkcs3(dh->dh_params, Datum(dhstr).get(), GNUTLS_X509_FMT_PEM);
 			ThrowOnError(ret, "Unable to import DH params");
 			return dh;
@@ -426,7 +423,7 @@ namespace GnuTLS
 	{
 		/** DH parameters associated with these credentials
 		 */
-		std::auto_ptr<DHParams> dh;
+		std::unique_ptr<DHParams> dh;
 
 	 protected:
 		gnutls_certificate_credentials_t cred;
@@ -451,9 +448,9 @@ namespace GnuTLS
 
 		/** Set the given DH parameters to be used with these credentials
 		 */
-		void SetDH(std::auto_ptr<DHParams>& DH)
+		void SetDH(std::unique_ptr<DHParams>& DH)
 		{
-			dh = DH;
+            dh = std::move(DH);
 			gnutls_certificate_set_dh_params(cred, dh->get());
 		}
 	};
@@ -470,11 +467,11 @@ namespace GnuTLS
 
 		/** Trusted CA, may be NULL
 		 */
-		std::auto_ptr<X509CertList> trustedca;
+		std::unique_ptr<X509CertList> trustedca;
 
 		/** Certificate revocation list, may be NULL
 		 */
-		std::auto_ptr<X509CRL> crl;
+		std::unique_ptr<X509CRL> crl;
 
 		static int cert_callback(gnutls_session_t session, const gnutls_datum_t* req_ca_rdn, int nreqs, const gnutls_pk_algorithm_t* sign_algos, int sign_algos_length, cert_cb_last_param_type* st);
 
@@ -497,7 +494,7 @@ namespace GnuTLS
 		/** Sets the trusted CA and the certificate revocation list
 		 * to use when verifying certificates
 		 */
-		void SetCA(std::auto_ptr<X509CertList>& certlist, std::auto_ptr<X509CRL>& CRL)
+		void SetCA(std::unique_ptr<X509CertList>& certlist, std::unique_ptr<X509CRL>& CRL)
 		{
 			// Do nothing if certlist is NULL
 			if (certlist.get())
@@ -511,8 +508,8 @@ namespace GnuTLS
 					ThrowOnError(ret, "gnutls_certificate_set_x509_crl() failed");
 				}
 
-				trustedca = certlist;
-				crl = CRL;
+				trustedca = std::move(certlist);
+				crl = std::move(CRL);
 			}
 		}
 	};
@@ -631,12 +628,12 @@ namespace GnuTLS
 		{
 			std::string name;
 
-			std::auto_ptr<X509CertList> ca;
-			std::auto_ptr<X509CRL> crl;
+			std::unique_ptr<X509CertList> ca;
+			std::unique_ptr<X509CRL> crl;
 
 			std::string certstr;
 			std::string keystr;
-			std::auto_ptr<DHParams> dh;
+			std::unique_ptr<DHParams> dh;
 
 			std::string priostr;
 			unsigned int mindh;

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -450,7 +450,7 @@ namespace GnuTLS
 		 */
 		void SetDH(std::unique_ptr<DHParams>& DH)
 		{
-            dh = std::move(DH);
+			dh = std::move(DH);
 			gnutls_certificate_set_dh_params(cred, dh->get());
 		}
 	};


### PR DESCRIPTION
`std::auto_ptr` is deprecated and `std::unique_ptr` is a drop-in replacement. I used `std::move` wherever you copied an `std::auto_ptr` since semantically it is the same, but let me know if there's any place where ownership shouldn't be transferred.