### PR TITLE
Make more modules rehash atomically

### DIFF
--- a/src/coremods/core_channel/core_channel.cpp
+++ b/src/coremods/core_channel/core_channel.cpp
@@ -148,16 +148,8 @@ class CoreModChannel : public Module, public CheckExemption::EventListener
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* optionstag = ServerInstance->Config->ConfValue("options");
-		Implementation events[] = { I_OnCheckKey, I_OnCheckLimit, I_OnCheckChannelBan };
-		if (optionstag->getBool("invitebypassmodes", true))
-			ServerInstance->Modules.Attach(events, this, sizeof(events)/sizeof(Implementation));
-		else
-		{
-			for (unsigned int i = 0; i < sizeof(events)/sizeof(Implementation); i++)
-				ServerInstance->Modules.Detach(events[i], this);
-		}
-
-		joinhook.modefromuser = optionstag->getBool("cyclehostsfromuser");
+		bool bypassmodes = optionstag->getBool("invitebypassmodes", true);
+		bool modefromuser = optionstag->getBool("cyclehostsfromuser");
 
 		std::string current;
 		irc::spacesepstream defaultstream(optionstag->getString("exemptchanops"));
@@ -174,26 +166,43 @@ class CoreModChannel : public Module, public CheckExemption::EventListener
 			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Exempting prefix %c from %s", prefix, restriction.c_str());
 			exempts[restriction] = prefix;
 		}
-		exemptions.swap(exempts);
 
 		ConfigTag* securitytag = ServerInstance->Config->ConfValue("security");
 		const std::string announceinvites = securitytag->getString("announceinvites", "dynamic");
+		Invite::AnnounceState newstate;
 		if (stdalgo::string::equalsci(announceinvites, "none"))
-			cmdinvite.announceinvites = Invite::ANNOUNCE_NONE;
+			newstate = Invite::ANNOUNCE_NONE;
 		else if (stdalgo::string::equalsci(announceinvites, "all"))
-			cmdinvite.announceinvites = Invite::ANNOUNCE_ALL;
+			newstate = Invite::ANNOUNCE_ALL;
 		else if (stdalgo::string::equalsci(announceinvites, "ops"))
-			cmdinvite.announceinvites = Invite::ANNOUNCE_OPS;
+			newstate = Invite::ANNOUNCE_OPS;
 		else if (stdalgo::string::equalsci(announceinvites, "dynamic"))
-			cmdinvite.announceinvites = Invite::ANNOUNCE_DYNAMIC;
+			newstate = Invite::ANNOUNCE_DYNAMIC;
 		else
 			throw ModuleException(announceinvites + " is an invalid <security:announceinvites> value, at " + securitytag->getTagLocation());
 
 		// In 2.0 we allowed limits of 0 to be set. This is non-standard behaviour
 		// and will be removed in the next major release.
-		limitmode.minlimit = optionstag->getBool("allowzerolimit", true) ? 0 : 1;
+		size_t minlimit = optionstag->getBool("allowzerolimit", true) ? 0 : 1;
 
+		// Config is valid, apply it
+
+		// Validates and applies <banlist> tags, so do it first
 		banmode.DoRehash();
+
+		exemptions.swap(exempts);
+		limitmode.minlimit = minlimit;
+		cmdinvite.announceinvites = newstate;
+		joinhook.modefromuser = modefromuser;
+
+		Implementation events[] = { I_OnCheckKey, I_OnCheckLimit, I_OnCheckChannelBan };
+		if (bypassmodes)
+			ServerInstance->Modules.Attach(events, this, sizeof(events)/sizeof(Implementation));
+		else
+		{
+			for (unsigned int i = 0; i < sizeof(events)/sizeof(Implementation); i++)
+				ServerInstance->Modules.Detach(events[i], this);
+		}
 	}
 
 	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE

--- a/src/coremods/core_channel/core_channel.cpp
+++ b/src/coremods/core_channel/core_channel.cpp
@@ -167,15 +167,15 @@ class CoreModChannel : public Module, public CheckExemption::EventListener
 
 		ConfigTag* securitytag = ServerInstance->Config->ConfValue("security");
 		const std::string announceinvites = securitytag->getString("announceinvites", "dynamic");
-		Invite::AnnounceState newstate;
+		Invite::AnnounceState newannouncestate;
 		if (stdalgo::string::equalsci(announceinvites, "none"))
-			newstate = Invite::ANNOUNCE_NONE;
+			newannouncestate = Invite::ANNOUNCE_NONE;
 		else if (stdalgo::string::equalsci(announceinvites, "all"))
-			newstate = Invite::ANNOUNCE_ALL;
+			newannouncestate = Invite::ANNOUNCE_ALL;
 		else if (stdalgo::string::equalsci(announceinvites, "ops"))
-			newstate = Invite::ANNOUNCE_OPS;
+			newannouncestate = Invite::ANNOUNCE_OPS;
 		else if (stdalgo::string::equalsci(announceinvites, "dynamic"))
-			newstate = Invite::ANNOUNCE_DYNAMIC;
+			newannouncestate = Invite::ANNOUNCE_DYNAMIC;
 		else
 			throw ModuleException(announceinvites + " is an invalid <security:announceinvites> value, at " + securitytag->getTagLocation());
 
@@ -188,7 +188,7 @@ class CoreModChannel : public Module, public CheckExemption::EventListener
 		// In 2.0 we allowed limits of 0 to be set. This is non-standard behaviour
 		// and will be removed in the next major release.
 		limitmode.minlimit = optionstag->getBool("allowzerolimit", true) ? 0 : 1;;
-		cmdinvite.announceinvites = newstate;
+		cmdinvite.announceinvites = newannouncestate;
 		joinhook.modefromuser = optionstag->getBool("cyclehostsfromuser");
 
 		Implementation events[] = { I_OnCheckKey, I_OnCheckLimit, I_OnCheckChannelBan };

--- a/src/coremods/core_channel/core_channel.cpp
+++ b/src/coremods/core_channel/core_channel.cpp
@@ -148,8 +148,6 @@ class CoreModChannel : public Module, public CheckExemption::EventListener
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* optionstag = ServerInstance->Config->ConfValue("options");
-		bool bypassmodes = optionstag->getBool("invitebypassmodes", true);
-		bool modefromuser = optionstag->getBool("cyclehostsfromuser");
 
 		std::string current;
 		irc::spacesepstream defaultstream(optionstag->getString("exemptchanops"));
@@ -193,10 +191,10 @@ class CoreModChannel : public Module, public CheckExemption::EventListener
 		exemptions.swap(exempts);
 		limitmode.minlimit = minlimit;
 		cmdinvite.announceinvites = newstate;
-		joinhook.modefromuser = modefromuser;
+		joinhook.modefromuser = optionstag->getBool("cyclehostsfromuser");
 
 		Implementation events[] = { I_OnCheckKey, I_OnCheckLimit, I_OnCheckChannelBan };
-		if (bypassmodes)
+		if (optionstag->getBool("invitebypassmodes", true))
 			ServerInstance->Modules.Attach(events, this, sizeof(events)/sizeof(Implementation));
 		else
 		{

--- a/src/coremods/core_channel/core_channel.cpp
+++ b/src/coremods/core_channel/core_channel.cpp
@@ -179,17 +179,15 @@ class CoreModChannel : public Module, public CheckExemption::EventListener
 		else
 			throw ModuleException(announceinvites + " is an invalid <security:announceinvites> value, at " + securitytag->getTagLocation());
 
-		// In 2.0 we allowed limits of 0 to be set. This is non-standard behaviour
-		// and will be removed in the next major release.
-		size_t minlimit = optionstag->getBool("allowzerolimit", true) ? 0 : 1;
-
 		// Config is valid, apply it
 
 		// Validates and applies <banlist> tags, so do it first
 		banmode.DoRehash();
 
 		exemptions.swap(exempts);
-		limitmode.minlimit = minlimit;
+		// In 2.0 we allowed limits of 0 to be set. This is non-standard behaviour
+		// and will be removed in the next major release.
+		limitmode.minlimit = optionstag->getBool("allowzerolimit", true) ? 0 : 1;;
 		cmdinvite.announceinvites = newstate;
 		joinhook.modefromuser = optionstag->getBool("cyclehostsfromuser");
 

--- a/src/coremods/core_info/core_info.cpp
+++ b/src/coremods/core_info/core_info.cpp
@@ -103,15 +103,16 @@ class CoreModInfo : public Module
 		ConfigFileCache newmotds;
 		for (ServerConfig::ClassVector::const_iterator iter = ServerInstance->Config->Classes.begin(); iter != ServerInstance->Config->Classes.end(); ++iter)
 		{
+			ConfigTag* tag = (*iter)->config;
 			// Don't process the file if it has already been processed.
-			const std::string motd = (*iter)->config->getString("motd", "motd");
+			const std::string motd = tag->getString("motd", "motd");
 			if (newmotds.find(motd) != newmotds.end())
 				continue;
 
 			// We can't process the file if it doesn't exist.
 			ConfigFileCache::iterator file = ServerInstance->Config->Files.find(motd);
 			if (file == ServerInstance->Config->Files.end())
-				continue;
+				throw ModuleException(InspIRCd::Format("MOTD file %s not specified in <files>, at %s", motd.c_str(), tag->getTagLocation().c_str()));
 
 			// Process escape codes.
 			newmotds[file->first] = file->second;

--- a/src/coremods/core_info/core_info.cpp
+++ b/src/coremods/core_info/core_info.cpp
@@ -112,7 +112,7 @@ class CoreModInfo : public Module
 			// We can't process the file if it doesn't exist.
 			ConfigFileCache::iterator file = ServerInstance->Config->Files.find(motd);
 			if (file == ServerInstance->Config->Files.end())
-				throw ModuleException(InspIRCd::Format("MOTD file %s not specified in <files>, at %s", motd.c_str(), tag->getTagLocation().c_str()));
+				continue;
 
 			// Process escape codes.
 			newmotds[file->first] = file->second;

--- a/src/coremods/core_info/core_info.cpp
+++ b/src/coremods/core_info/core_info.cpp
@@ -99,12 +99,6 @@ class CoreModInfo : public Module
 
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
-		ConfigTag* tag = ServerInstance->Config->ConfValue("admin");
-		std::string name, email, nick;
-		name = tag->getString("name");
-		email = tag->getString("email", "null@example.com");
-		nick = tag->getString("nick", "admin");
-
 		// Process the escape codes in the MOTDs.
 		ConfigFileCache newmotds;
 		for (ServerConfig::ClassVector::const_iterator iter = ServerInstance->Config->Classes.begin(); iter != ServerInstance->Config->Classes.end(); ++iter)
@@ -125,9 +119,11 @@ class CoreModInfo : public Module
 		}
 
 		cmdmotd.motds.swap(newmotds);
-		cmdadmin.AdminName = name;
-		cmdadmin.AdminEmail = email;
-		cmdadmin.AdminNick = nick;
+
+		ConfigTag* tag = ServerInstance->Config->ConfValue("admin");
+		cmdadmin.AdminName = tag->getString("name");
+		cmdadmin.AdminEmail = tag->getString("email", "null@example.com");
+		cmdadmin.AdminNick = tag->getString("nick", "admin");
 	}
 
 	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE

--- a/src/coremods/core_loadmodule.cpp
+++ b/src/coremods/core_loadmodule.cpp
@@ -59,10 +59,12 @@ class CommandUnloadmodule : public Command
 {
  public:
 	bool allowcoreunload;
+
 	/** Constructor for unloadmodule.
 	 */
 	CommandUnloadmodule(Module* parent)
-		: Command(parent,"UNLOADMODULE", 1), allowcoreunload(false)
+		: Command(parent, "UNLOADMODULE", 1)
+		, allowcoreunload(false)
 	{
 		flags_needed = 'o';
 		syntax = "<modulename>";
@@ -121,7 +123,7 @@ class CoreModLoadModule : public Module
 		return Version("Provides the LOADMODULE and UNLOADMODULE commands", VF_VENDOR|VF_CORE);
 	}
 
-	void ReadConfig(ConfigStatus &status) CXX11_OVERRIDE
+	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("security");
 		cmdunloadmod.allowcoreunload = tag->getBool("allowcoreunload");

--- a/src/coremods/core_loadmodule.cpp
+++ b/src/coremods/core_loadmodule.cpp
@@ -58,10 +58,11 @@ CmdResult CommandLoadmodule::Handle(User* user, const Params& parameters)
 class CommandUnloadmodule : public Command
 {
  public:
+	bool allowcoreunload;
 	/** Constructor for unloadmodule.
 	 */
 	CommandUnloadmodule(Module* parent)
-		: Command(parent,"UNLOADMODULE", 1)
+		: Command(parent,"UNLOADMODULE", 1), allowcoreunload(false)
 	{
 		flags_needed = 'o';
 		syntax = "<modulename>";
@@ -77,8 +78,7 @@ class CommandUnloadmodule : public Command
 
 CmdResult CommandUnloadmodule::Handle(User* user, const Params& parameters)
 {
-	if (!ServerInstance->Config->ConfValue("security")->getBool("allowcoreunload") &&
-		InspIRCd::Match(parameters[0], "core_*.so", ascii_case_insensitive_map))
+	if (!allowcoreunload && InspIRCd::Match(parameters[0], "core_*.so", ascii_case_insensitive_map))
 	{
 		user->WriteNumeric(ERR_CANTUNLOADMODULE, parameters[0], "You cannot unload core commands!");
 		return CMD_FAILURE;
@@ -119,6 +119,12 @@ class CoreModLoadModule : public Module
 	Version GetVersion() CXX11_OVERRIDE
 	{
 		return Version("Provides the LOADMODULE and UNLOADMODULE commands", VF_VENDOR|VF_CORE);
+	}
+
+	void ReadConfig(ConfigStatus &status) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("security");
+		cmdunloadmod.allowcoreunload = tag->getBool("allowcoreunload");
 	}
 };
 

--- a/src/coremods/core_oper/cmd_die.cpp
+++ b/src/coremods/core_oper/cmd_die.cpp
@@ -30,14 +30,6 @@ CommandDie::CommandDie(Module* parent, std::string& hashref)
 	syntax = "<server>";
 }
 
-CommandDie::CommandDie(Module* parent, const std::string& cmd, std::string& hashref)
-	: Command(parent, cmd, 1, 1)
-	, hash(hashref)
-{
-	flags_needed = 'o';
-	syntax = "<server>";
-}
-
 static void QuitAll()
 {
 	const std::string quitmsg = "Server shutdown";

--- a/src/coremods/core_oper/cmd_die.cpp
+++ b/src/coremods/core_oper/cmd_die.cpp
@@ -23,7 +23,14 @@
 #include "core_oper.h"
 
 CommandDie::CommandDie(Module* parent)
-	: Command(parent, "DIE", 1)
+	: Command(parent, "DIE", 1, 1)
+{
+	flags_needed = 'o';
+	syntax = "<server>";
+}
+
+CommandDie::CommandDie(Module* parent, const std::string& cmd)
+	: Command(parent, cmd, 1, 1)
 {
 	flags_needed = 'o';
 	syntax = "<server>";
@@ -61,7 +68,7 @@ void DieRestart::SendError(const std::string& message)
  */
 CmdResult CommandDie::Handle(User* user, const Params& parameters)
 {
-	if (DieRestart::CheckPass(user, parameters[0], "diepass"))
+	if (CheckPass(user, parameters[0]))
 	{
 		{
 			std::string diebuf = "*** DIE command from " + user->GetFullHost() + ". Terminating.";
@@ -79,4 +86,9 @@ CmdResult CommandDie::Handle(User* user, const Params& parameters)
 		return CMD_FAILURE;
 	}
 	return CMD_SUCCESS;
+}
+
+bool CommandDie::CheckPass(User* user, const std::string& inputpass) const
+{
+	return ServerInstance->PassCompare(user, password, inputpass, hash);
 }

--- a/src/coremods/core_oper/cmd_die.cpp
+++ b/src/coremods/core_oper/cmd_die.cpp
@@ -22,15 +22,17 @@
 #include "exitcodes.h"
 #include "core_oper.h"
 
-CommandDie::CommandDie(Module* parent)
+CommandDie::CommandDie(Module* parent, std::string& hashref)
 	: Command(parent, "DIE", 1, 1)
+	, hash(hashref)
 {
 	flags_needed = 'o';
 	syntax = "<server>";
 }
 
-CommandDie::CommandDie(Module* parent, const std::string& cmd)
+CommandDie::CommandDie(Module* parent, const std::string& cmd, std::string& hashref)
 	: Command(parent, cmd, 1, 1)
+	, hash(hashref)
 {
 	flags_needed = 'o';
 	syntax = "<server>";

--- a/src/coremods/core_oper/cmd_die.cpp
+++ b/src/coremods/core_oper/cmd_die.cpp
@@ -70,7 +70,7 @@ void DieRestart::SendError(const std::string& message)
  */
 CmdResult CommandDie::Handle(User* user, const Params& parameters)
 {
-	if (CheckPass(user, parameters[0]))
+	if (ServerInstance->PassCompare(user, password, parameters[0], hash))
 	{
 		{
 			std::string diebuf = "*** DIE command from " + user->GetFullHost() + ". Terminating.";
@@ -88,9 +88,4 @@ CmdResult CommandDie::Handle(User* user, const Params& parameters)
 		return CMD_FAILURE;
 	}
 	return CMD_SUCCESS;
-}
-
-bool CommandDie::CheckPass(User* user, const std::string& inputpass) const
-{
-	return ServerInstance->PassCompare(user, password, inputpass, hash);
 }

--- a/src/coremods/core_oper/cmd_restart.cpp
+++ b/src/coremods/core_oper/cmd_restart.cpp
@@ -31,7 +31,7 @@ CommandRestart::CommandRestart(Module* parent, std::string& hashref)
 CmdResult CommandRestart::Handle(User* user, const Params& parameters)
 {
 	ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Restart: %s", user->nick.c_str());
-	if (CheckPass(user, parameters[0]))
+	if (ServerInstance->PassCompare(user, password, parameters[0], hash))
 	{
 		ServerInstance->SNO->WriteGlobalSno('a', "RESTART command from %s, restarting server.", user->GetFullRealHost().c_str());
 

--- a/src/coremods/core_oper/cmd_restart.cpp
+++ b/src/coremods/core_oper/cmd_restart.cpp
@@ -22,7 +22,8 @@
 #include "core_oper.h"
 
 CommandRestart::CommandRestart(Module* parent, std::string& hashref)
-	: CommandDie(parent, "RESTART", hashref)
+	: Command(parent, "RESTART", 1, 1)
+	, hash(hashref)
 {
 	flags_needed = 'o';
 	syntax = "<server>";

--- a/src/coremods/core_oper/cmd_restart.cpp
+++ b/src/coremods/core_oper/cmd_restart.cpp
@@ -21,8 +21,8 @@
 #include "inspircd.h"
 #include "core_oper.h"
 
-CommandRestart::CommandRestart(Module* parent)
-	: CommandDie(parent, "RESTART")
+CommandRestart::CommandRestart(Module* parent, std::string& hashref)
+	: CommandDie(parent, "RESTART", hashref)
 {
 	flags_needed = 'o';
 	syntax = "<server>";

--- a/src/coremods/core_oper/cmd_restart.cpp
+++ b/src/coremods/core_oper/cmd_restart.cpp
@@ -22,7 +22,7 @@
 #include "core_oper.h"
 
 CommandRestart::CommandRestart(Module* parent)
-	: Command(parent, "RESTART", 1, 1)
+	: CommandDie(parent, "RESTART")
 {
 	flags_needed = 'o';
 	syntax = "<server>";
@@ -31,7 +31,7 @@ CommandRestart::CommandRestart(Module* parent)
 CmdResult CommandRestart::Handle(User* user, const Params& parameters)
 {
 	ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Restart: %s", user->nick.c_str());
-	if (DieRestart::CheckPass(user, parameters[0], "restartpass"))
+	if (CheckPass(user, parameters[0]))
 	{
 		ServerInstance->SNO->WriteGlobalSno('a', "RESTART command from %s, restarting server.", user->GetFullRealHost().c_str());
 

--- a/src/coremods/core_oper/core_oper.cpp
+++ b/src/coremods/core_oper/core_oper.cpp
@@ -49,8 +49,8 @@ class CoreModOper : public Module
 		ConfigTag* tag = ServerInstance->Config->ConfValue("power");
 		// The hash method for *BOTH* the die and restart passwords
 		const std::string hash = tag->getString("hash");
-		const std::string diepass = tag->getString("diepass", ServerInstance->Config->ServerName);
-		const std::string restartpass = tag->getString("restartpass", ServerInstance->Config->ServerName);
+		const std::string diepass = tag->getString("diepass", ServerInstance->Config->ServerName, 1);
+		const std::string restartpass = tag->getString("restartpass", ServerInstance->Config->ServerName, 1);
 
 		powerhash = hash;
 

--- a/src/coremods/core_oper/core_oper.cpp
+++ b/src/coremods/core_oper/core_oper.cpp
@@ -42,14 +42,16 @@ class CoreModOper : public Module
 
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
-		ConfigTag* security = ServerInstance->Config->ConfValue("security");
+		
 		ConfigTag* tag = ServerInstance->Config->ConfValue("power");
+	
 		// The hash method for *BOTH* the die and restart passwords
 		powerhash = tag->getString("hash");
 
 		cmddie.password = tag->getString("diepass", ServerInstance->Config->ServerName, 1);
 		cmdrestart.password = tag->getString("restartpass", ServerInstance->Config->ServerName, 1);
 
+		ConfigTag* security = ServerInstance->Config->ConfValue("security");
 		cmdkill.hidenick = security->getString("hidekills");
 		cmdkill.hideuline = security->getBool("hideulinekills");
 	}

--- a/src/coremods/core_oper/core_oper.cpp
+++ b/src/coremods/core_oper/core_oper.cpp
@@ -43,22 +43,15 @@ class CoreModOper : public Module
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* security = ServerInstance->Config->ConfValue("security");
-		std::string hidenick = security->getString("hidekills");
-		bool hideuline = security->getBool("hideulinekills");
-
 		ConfigTag* tag = ServerInstance->Config->ConfValue("power");
 		// The hash method for *BOTH* the die and restart passwords
-		const std::string hash = tag->getString("hash");
-		const std::string diepass = tag->getString("diepass", ServerInstance->Config->ServerName, 1);
-		const std::string restartpass = tag->getString("restartpass", ServerInstance->Config->ServerName, 1);
+		powerhash = tag->getString("hash");
 
-		powerhash = hash;
+		cmddie.password = tag->getString("diepass", ServerInstance->Config->ServerName, 1);
+		cmdrestart.password = tag->getString("restartpass", ServerInstance->Config->ServerName, 1);
 
-		cmddie.password = diepass;
-		cmdrestart.password = restartpass;
-
-		cmdkill.hidenick = hidenick;
-		cmdkill.hideuline = hideuline;
+		cmdkill.hidenick = security->getString("hidekills");
+		cmdkill.hideuline = security->getBool("hideulinekills");
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/coremods/core_oper/core_oper.cpp
+++ b/src/coremods/core_oper/core_oper.cpp
@@ -20,18 +20,6 @@
 #include "inspircd.h"
 #include "core_oper.h"
 
-namespace DieRestart
-{
-	bool CheckPass(User* user, const std::string& inputpass, const char* confentry)
-	{
-		ConfigTag* tag = ServerInstance->Config->ConfValue("power");
-		// The hash method for *BOTH* the die and restart passwords
-		const std::string hash = tag->getString("hash");
-		const std::string correctpass = tag->getString(confentry,  ServerInstance->Config->ServerName);
-		return ServerInstance->PassCompare(user, correctpass, inputpass, hash);
-	}
-}
-
 class CoreModOper : public Module
 {
 	CommandDie cmddie;
@@ -49,13 +37,28 @@ class CoreModOper : public Module
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* security = ServerInstance->Config->ConfValue("security");
-		cmdkill.hidenick = security->getString("hidekills");
-		cmdkill.hideuline = security->getBool("hideulinekills");
+		std::string hidenick = security->getString("hidekills");
+		bool hideuline = security->getBool("hideulinekills");
+
+		ConfigTag* tag = ServerInstance->Config->ConfValue("power");
+		// The hash method for *BOTH* the die and restart passwords
+		const std::string hash = tag->getString("hash");
+		const std::string diepass = tag->getString("diepass", ServerInstance->Config->ServerName);
+		const std::string restartpass = tag->getString("restartpass", ServerInstance->Config->ServerName);
+
+		cmddie.hash = hash;
+		cmddie.password = diepass;
+
+		cmdrestart.hash = hash;
+		cmdrestart.password = restartpass;
+
+		cmdkill.hidenick = hidenick;
+		cmdkill.hideuline = hideuline;
 	}
 
 	Version GetVersion() CXX11_OVERRIDE
 	{
-		return Version("Provides the DIE, KILL, OPER, REHASH, and RESTART commands", VF_VENDOR|VF_CORE);
+		return Version("Provides the DIE, KILL, OPER, REHASH, and RESTART commands", VF_VENDOR | VF_CORE);
 	}
 };
 

--- a/src/coremods/core_oper/core_oper.cpp
+++ b/src/coremods/core_oper/core_oper.cpp
@@ -22,6 +22,8 @@
 
 class CoreModOper : public Module
 {
+	std::string powerhash;
+
 	CommandDie cmddie;
 	CommandKill cmdkill;
 	CommandOper cmdoper;
@@ -30,7 +32,11 @@ class CoreModOper : public Module
 
  public:
 	CoreModOper()
-		: cmddie(this), cmdkill(this), cmdoper(this), cmdrehash(this), cmdrestart(this)
+		: cmddie(this, powerhash)
+		, cmdkill(this)
+		, cmdoper(this)
+		, cmdrehash(this)
+		, cmdrestart(this, powerhash)
 	{
 	}
 
@@ -46,10 +52,9 @@ class CoreModOper : public Module
 		const std::string diepass = tag->getString("diepass", ServerInstance->Config->ServerName);
 		const std::string restartpass = tag->getString("restartpass", ServerInstance->Config->ServerName);
 
-		cmddie.hash = hash;
-		cmddie.password = diepass;
+		powerhash = hash;
 
-		cmdrestart.hash = hash;
+		cmddie.password = diepass;
 		cmdrestart.password = restartpass;
 
 		cmdkill.hidenick = hidenick;

--- a/src/coremods/core_oper/core_oper.h
+++ b/src/coremods/core_oper/core_oper.h
@@ -23,14 +23,6 @@
 
 namespace DieRestart
 {
-	/** Checks a die or restart password
-	 * @param user The user executing /DIE or /RESTART
-	 * @param inputpass The password given by the user
-	 * @param confkey The name of the key in the power tag containing the correct password
-	 * @return True if the given password was correct, false if it was not
-	 */
-	bool CheckPass(User* user, const std::string& inputpass, const char* confkey);
-
 	/** Send an ERROR to unregistered users and a NOTICE to all registered local users
 	 * @param message Message to send
 	 */
@@ -41,10 +33,17 @@ namespace DieRestart
  */
 class CommandDie : public Command
 {
+ protected:
+	bool CheckPass(User* user, const std::string& inputpass) const;
+
  public:
+	std::string hash, password;
+
 	/** Constructor for die.
 	 */
 	CommandDie(Module* parent);
+
+	CommandDie(Module* parent, const std::string& cmd);
 
 	/** Handle command.
 	 * @param parameters The parameters to the command
@@ -79,6 +78,7 @@ class CommandKill : public Command
 	 * @return A value from CmdResult to indicate command success or failure.
 	 */
 	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE;
+
 	RouteDescriptor GetRouting(User* user, const Params& parameters) CXX11_OVERRIDE;
 
 	void EncodeParameter(std::string& param, unsigned int index) CXX11_OVERRIDE;
@@ -120,7 +120,7 @@ class CommandRehash : public Command
 
 /** Handle /RESTART
  */
-class CommandRestart : public Command
+class CommandRestart : public CommandDie
 {
  public:
 	/** Constructor for restart.

--- a/src/coremods/core_oper/core_oper.h
+++ b/src/coremods/core_oper/core_oper.h
@@ -41,8 +41,6 @@ class CommandDie : public Command
 	 */
 	CommandDie(Module* parent, std::string& hashref);
 
-	CommandDie(Module* parent, const std::string& cmd, std::string& hashref);
-
 	/** Handle command.
 	 * @param parameters The parameters to the command
 	 * @param user The user issuing the command
@@ -118,9 +116,12 @@ class CommandRehash : public Command
 
 /** Handle /RESTART
  */
-class CommandRestart : public CommandDie
+class CommandRestart : public Command
 {
  public:
+	std::string& hash;
+	std::string password;
+
 	/** Constructor for restart.
 	 */
 	CommandRestart(Module* parent, std::string& hashref);

--- a/src/coremods/core_oper/core_oper.h
+++ b/src/coremods/core_oper/core_oper.h
@@ -33,9 +33,6 @@ namespace DieRestart
  */
 class CommandDie : public Command
 {
- protected:
-	bool CheckPass(User* user, const std::string& inputpass) const;
-
  public:
 	std::string& hash;
 	std::string password;

--- a/src/coremods/core_oper/core_oper.h
+++ b/src/coremods/core_oper/core_oper.h
@@ -37,13 +37,14 @@ class CommandDie : public Command
 	bool CheckPass(User* user, const std::string& inputpass) const;
 
  public:
-	std::string hash, password;
+	std::string& hash;
+	std::string password;
 
 	/** Constructor for die.
 	 */
-	CommandDie(Module* parent);
+	CommandDie(Module* parent, std::string& hashref);
 
-	CommandDie(Module* parent, const std::string& cmd);
+	CommandDie(Module* parent, const std::string& cmd, std::string& hashref);
 
 	/** Handle command.
 	 * @param parameters The parameters to the command
@@ -125,7 +126,7 @@ class CommandRestart : public CommandDie
  public:
 	/** Constructor for restart.
 	 */
-	CommandRestart(Module* parent);
+	CommandRestart(Module* parent, std::string& hashref);
 
 	/** Handle command.
 	 * @param user User issuing the command

--- a/src/coremods/core_whois.cpp
+++ b/src/coremods/core_whois.cpp
@@ -369,7 +369,6 @@ class CoreModWhois : public Module
 
 		ConfigTag* security = ServerInstance->Config->ConfValue("security");
 		cmd.genericoper = security->getBool("genericoper");
-		// So set the rest of the config after it since that is already validated
 		cmd.splitwhois = newsplitstate;
 	}
 

--- a/src/coremods/core_whois.cpp
+++ b/src/coremods/core_whois.cpp
@@ -357,17 +357,21 @@ class CoreModWhois : public Module
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("options");
 		const std::string splitwhois = tag->getString("splitwhois", "no");
+		SplitWhoisState newstate;
 		if (stdalgo::string::equalsci(splitwhois, "no"))
-			cmd.splitwhois = SPLITWHOIS_NONE;
+			newstate = SPLITWHOIS_NONE;
 		else if (stdalgo::string::equalsci(splitwhois, "split"))
-			cmd.splitwhois = SPLITWHOIS_SPLIT;
+			newstate = SPLITWHOIS_SPLIT;
 		else if (stdalgo::string::equalsci(splitwhois, "splitmsg"))
-			cmd.splitwhois = SPLITWHOIS_SPLITMSG;
+			newstate = SPLITWHOIS_SPLITMSG;
 		else
 			throw ModuleException(splitwhois + " is an invalid <security:splitwhois> value, at " + tag->getTagLocation()); 
 
 		ConfigTag* security = ServerInstance->Config->ConfValue("security");
+		// In the future this may error if an invalid value is set
 		cmd.genericoper = security->getBool("genericoper");
+		// So set the rest of the config after it since that is already validated
+		cmd.splitwhois = newstate;
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/coremods/core_whois.cpp
+++ b/src/coremods/core_whois.cpp
@@ -357,21 +357,20 @@ class CoreModWhois : public Module
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("options");
 		const std::string splitwhois = tag->getString("splitwhois", "no");
-		SplitWhoisState newstate;
+		SplitWhoisState newsplitstate;
 		if (stdalgo::string::equalsci(splitwhois, "no"))
-			newstate = SPLITWHOIS_NONE;
+			newsplitstate = SPLITWHOIS_NONE;
 		else if (stdalgo::string::equalsci(splitwhois, "split"))
-			newstate = SPLITWHOIS_SPLIT;
+			newsplitstate = SPLITWHOIS_SPLIT;
 		else if (stdalgo::string::equalsci(splitwhois, "splitmsg"))
-			newstate = SPLITWHOIS_SPLITMSG;
+			newsplitstate = SPLITWHOIS_SPLITMSG;
 		else
 			throw ModuleException(splitwhois + " is an invalid <security:splitwhois> value, at " + tag->getTagLocation()); 
 
 		ConfigTag* security = ServerInstance->Config->ConfValue("security");
-		// In the future this may error if an invalid value is set
 		cmd.genericoper = security->getBool("genericoper");
 		// So set the rest of the config after it since that is already validated
-		cmd.splitwhois = newstate;
+		cmd.splitwhois = newsplitstate;
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/listmode.cpp
+++ b/src/listmode.cpp
@@ -62,8 +62,7 @@ void ListModeBase::DoRehash()
 {
 	ConfigTagList tags = ServerInstance->Config->ConfTags(configtag);
 
-	limitlist oldlimits = chanlimits;
-	chanlimits.clear();
+	limitlist newlimits;
 
 	for (ConfigIter i = tags.first; i != tags.second; i++)
 	{
@@ -72,16 +71,18 @@ void ListModeBase::DoRehash()
 		ListLimit limit(c->getString("chan"), c->getUInt("limit", 0));
 
 		if (limit.mask.size() && limit.limit > 0)
-			chanlimits.push_back(limit);
+			newlimits.push_back(limit);
 	}
 
 	// Add the default entry. This is inserted last so if the user specifies a
 	// wildcard record in the config it will take precedence over this entry.
-	chanlimits.push_back(ListLimit("*", DEFAULT_LIST_SIZE));
+	newlimits.push_back(ListLimit("*", DEFAULT_LIST_SIZE));
 
 	// Most of the time our settings are unchanged, so we can avoid iterating the chanlist
-	if (oldlimits == chanlimits)
+	if (chanlimits == newlimits)
 		return;
+
+	chanlimits.swap(newlimits);
 
 	const chan_hash& chans = ServerInstance->GetChans();
 	for (chan_hash::const_iterator i = chans.begin(); i != chans.end(); ++i)

--- a/src/listmode.cpp
+++ b/src/listmode.cpp
@@ -70,8 +70,13 @@ void ListModeBase::DoRehash()
 		ConfigTag* c = i->second;
 		ListLimit limit(c->getString("chan"), c->getUInt("limit", 0));
 
-		if (limit.mask.size() && limit.limit > 0)
-			newlimits.push_back(limit);
+		if (limit.mask.empty())
+			throw ModuleException(InspIRCd::Format("<%s:chan> is empty at %s", configtag.c_str(), c->getTagLocation().c_str()));
+
+		if (limit.limit <= 0)
+			throw ModuleException(InspIRCd::Format("<%s:limit> must be greater than 0, at %s", configtag.c_str(), c->getTagLocation().c_str()));
+
+		newlimits.push_back(limit);
 	}
 
 	// Add the default entry. This is inserted last so if the user specifies a

--- a/src/modules/m_alias.cpp
+++ b/src/modules/m_alias.cpp
@@ -75,10 +75,10 @@ class ModuleAlias : public Module
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* fantasy = ServerInstance->Config->ConfValue("fantasy");
-		AllowBots = fantasy->getBool("allowbots", false);
-		fprefix = fantasy->getString("prefix", "!", 1, ServerInstance->Config->Limits.MaxLine);
+		bool bots = fantasy->getBool("allowbots", false);
+		std::string pfx = fantasy->getString("prefix", "!", 1, ServerInstance->Config->Limits.MaxLine);
 
-		Aliases.clear();
+		AliasMap newAliases;
 		ConfigTagList tags = ServerInstance->Config->ConfTags("alias");
 		for(ConfigIter i = tags.first; i != tags.second; ++i)
 		{
@@ -93,8 +93,12 @@ class ModuleAlias : public Module
 			a.UserCommand = tag->getBool("usercommand", true);
 			a.OperOnly = tag->getBool("operonly");
 			a.format = tag->getString("format");
-			Aliases.insert(std::make_pair(a.AliasedCommand, a));
+			newAliases.insert(std::make_pair(a.AliasedCommand, a));
 		}
+
+		AllowBots = bots;
+		fprefix = pfx;
+		Aliases.swap(newAliases);
 	}
 
 	ModuleAlias()

--- a/src/modules/m_alias.cpp
+++ b/src/modules/m_alias.cpp
@@ -81,8 +81,14 @@ class ModuleAlias : public Module
 			ConfigTag* tag = i->second;
 			Alias a;
 			a.AliasedCommand = tag->getString("text");
+			if (a.AliasedCommand.empty())
+				throw ModuleException("<alias:text> is empty! at " + tag->getTagLocation());
+
 			std::transform(a.AliasedCommand.begin(), a.AliasedCommand.end(), a.AliasedCommand.begin(), ::toupper);
 			tag->readString("replace", a.ReplaceFormat, true);
+			if (a.ReplaceFormat.empty())
+				throw ModuleException("<alias:replace> is empty! at " + tag->getTagLocation());
+
 			a.RequiredNick = tag->getString("requires");
 			a.ULineOnly = tag->getBool("uline");
 			a.ChannelCommand = tag->getBool("channelcommand", false);

--- a/src/modules/m_alias.cpp
+++ b/src/modules/m_alias.cpp
@@ -84,7 +84,6 @@ class ModuleAlias : public Module
 			if (a.AliasedCommand.empty())
 				throw ModuleException("<alias:text> is empty! at " + tag->getTagLocation());
 
-			std::transform(a.AliasedCommand.begin(), a.AliasedCommand.end(), a.AliasedCommand.begin(), ::toupper);
 			tag->readString("replace", a.ReplaceFormat, true);
 			if (a.ReplaceFormat.empty())
 				throw ModuleException("<alias:replace> is empty! at " + tag->getTagLocation());
@@ -95,6 +94,8 @@ class ModuleAlias : public Module
 			a.UserCommand = tag->getBool("usercommand", true);
 			a.OperOnly = tag->getBool("operonly");
 			a.format = tag->getString("format");
+
+			std::transform(a.AliasedCommand.begin(), a.AliasedCommand.end(), a.AliasedCommand.begin(), ::toupper);
 			newAliases.insert(std::make_pair(a.AliasedCommand, a));
 		}
 

--- a/src/modules/m_alias.cpp
+++ b/src/modules/m_alias.cpp
@@ -74,10 +74,6 @@ class ModuleAlias : public Module
  public:
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
-		ConfigTag* fantasy = ServerInstance->Config->ConfValue("fantasy");
-		bool bots = fantasy->getBool("allowbots", false);
-		std::string pfx = fantasy->getString("prefix", "!", 1, ServerInstance->Config->Limits.MaxLine);
-
 		AliasMap newAliases;
 		ConfigTagList tags = ServerInstance->Config->ConfTags("alias");
 		for(ConfigIter i = tags.first; i != tags.second; ++i)
@@ -96,8 +92,9 @@ class ModuleAlias : public Module
 			newAliases.insert(std::make_pair(a.AliasedCommand, a));
 		}
 
-		AllowBots = bots;
-		fprefix = pfx;
+		ConfigTag* fantasy = ServerInstance->Config->ConfValue("fantasy");
+		AllowBots = fantasy->getBool("allowbots", false);
+		fprefix = fantasy->getString("prefix", "!", 1, ServerInstance->Config->Limits.MaxLine);
 		Aliases.swap(newAliases);
 	}
 

--- a/src/modules/m_censor.cpp
+++ b/src/modules/m_censor.cpp
@@ -112,7 +112,7 @@ class ModuleCensor : public Module
 			ConfigTag* tag = i->second;
 			const std::string text = tag->getString("text");
 			if (text.empty())
-				continue;
+				throw ModuleException("<badword:text> is empty! at " + tag->getTagLocation());
 
 			const std::string replace = tag->getString("replace");
 			newcensors[text] = replace;

--- a/src/modules/m_censor.cpp
+++ b/src/modules/m_censor.cpp
@@ -104,7 +104,7 @@ class ModuleCensor : public Module
 		 * reload our config file on rehash - we must destroy and re-allocate the classes
 		 * to call the constructor again and re-read our data.
 		 */
-		censors.clear();
+		censor_t newcensors;
 
 		ConfigTagList badwords = ServerInstance->Config->ConfTags("badword");
 		for (ConfigIter i = badwords.first; i != badwords.second; ++i)
@@ -115,8 +115,9 @@ class ModuleCensor : public Module
 				continue;
 
 			const std::string replace = tag->getString("replace");
-			censors[text] = replace;
+			newcensors[text] = replace;
 		}
+		censors.swap(newcensors);
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -338,12 +338,13 @@ class ModuleCgiIRC
 			}
 		}
 
-		// The host configuration was valid so we can apply it.
+		// Do we send an oper notice when a m_cgiirc client has their IP changed?
+		bool notify = ServerInstance->Config->ConfValue("cgiirc")->getBool("opernotice", true);
+
+		// The configuration was valid so we can apply it.
 		hosts.swap(identhosts);
 		cmd.hosts.swap(webirchosts);
-
-		// Do we send an oper notice when a m_cgiirc client has their IP changed?
-		cmd.notify = ServerInstance->Config->ConfValue("cgiirc")->getBool("opernotice", true);
+		cmd.notify = notify;
 	}
 
 	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass) CXX11_OVERRIDE

--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -338,12 +338,12 @@ class ModuleCgiIRC
 			}
 		}
 
-		// Do we send an oper notice when a m_cgiirc client has their IP changed?
-		cmd.notify = ServerInstance->Config->ConfValue("cgiirc")->getBool("opernotice", true);
-
 		// The configuration was valid so we can apply it.
 		hosts.swap(identhosts);
 		cmd.hosts.swap(webirchosts);
+
+		// Do we send an oper notice when a m_cgiirc client has their IP changed?
+		cmd.notify = ServerInstance->Config->ConfValue("cgiirc")->getBool("opernotice", true);
 	}
 
 	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass) CXX11_OVERRIDE

--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -338,7 +338,7 @@ class ModuleCgiIRC
 			}
 		}
 
-		// The configuration was valid so we can apply it.
+		// The host configuration was valid so we can apply it.
 		hosts.swap(identhosts);
 		cmd.hosts.swap(webirchosts);
 

--- a/src/modules/m_cgiirc.cpp
+++ b/src/modules/m_cgiirc.cpp
@@ -339,12 +339,11 @@ class ModuleCgiIRC
 		}
 
 		// Do we send an oper notice when a m_cgiirc client has their IP changed?
-		bool notify = ServerInstance->Config->ConfValue("cgiirc")->getBool("opernotice", true);
+		cmd.notify = ServerInstance->Config->ConfValue("cgiirc")->getBool("opernotice", true);
 
 		// The configuration was valid so we can apply it.
 		hosts.swap(identhosts);
 		cmd.hosts.swap(webirchosts);
-		cmd.notify = notify;
 	}
 
 	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass) CXX11_OVERRIDE

--- a/src/modules/m_chanlog.cpp
+++ b/src/modules/m_chanlog.cpp
@@ -43,8 +43,7 @@ class ModuleChanLog : public Module
 
 			if (channel.empty() || snomasks.empty())
 			{
-				ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Malformed chanlog tag, ignoring");
-				continue;
+				throw ModuleException("Malformed chanlog tag at " i->second->getTagLocation());
 			}
 
 			for (std::string::const_iterator it = snomasks.begin(); it != snomasks.end(); it++)

--- a/src/modules/m_chanlog.cpp
+++ b/src/modules/m_chanlog.cpp
@@ -33,8 +33,7 @@ class ModuleChanLog : public Module
 	{
 		std::string snomasks;
 		std::string channel;
-
-		logstreams.clear();
+		ChanLogTargets newlogs;
 
 		ConfigTagList tags = ServerInstance->Config->ConfTags("chanlog");
 		for (ConfigIter i = tags.first; i != tags.second; ++i)
@@ -50,10 +49,11 @@ class ModuleChanLog : public Module
 
 			for (std::string::const_iterator it = snomasks.begin(); it != snomasks.end(); it++)
 			{
-				logstreams.insert(std::make_pair(*it, channel));
+				newlogs.insert(std::make_pair(*it, channel));
 				ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Logging %c to %s", *it, channel.c_str());
 			}
 		}
+		logstreams.swap(newlogs);
 
 	}
 

--- a/src/modules/m_chanlog.cpp
+++ b/src/modules/m_chanlog.cpp
@@ -43,7 +43,7 @@ class ModuleChanLog : public Module
 
 			if (channel.empty() || snomasks.empty())
 			{
-				throw ModuleException("Malformed chanlog tag at " i->second->getTagLocation());
+				throw ModuleException("Malformed chanlog tag at " + i->second->getTagLocation());
 			}
 
 			for (std::string::const_iterator it = snomasks.begin(); it != snomasks.end(); it++)

--- a/src/modules/m_customtitle.cpp
+++ b/src/modules/m_customtitle.cpp
@@ -125,7 +125,7 @@ class ModuleCustomTitle : public Module, public Whois::LineEventListener
 			reference<ConfigTag> tag = i->second;
 			std::string name = tag->getString("name", "", 1);
 			if (name.empty())
-				continue;
+				throw ModuleException("<title:name> is empty! at " + tag->getTagLocation());
 
 			std::string pass = tag->getString("password");
 			std::string hash = tag->getString("hash");

--- a/src/modules/m_customtitle.cpp
+++ b/src/modules/m_customtitle.cpp
@@ -30,10 +30,20 @@ enum
 
 struct CustomTitle
 {
-	const std::string name, password, hash, host, title, vhost;
+	const std::string name;
+	const std::string password;
+	const std::string hash;
+	const std::string host;
+	const std::string title;
+	const std::string vhost;
 
 	CustomTitle(const std::string& n, const std::string& p, const std::string& h, const std::string& hst, const std::string& t, const std::string& v)
-		: name(n), password(p), hash(h), host(hst), title(t), vhost(v)
+		: name(n)
+		, password(p)
+		, hash(h)
+		, host(hst)
+		, title(t)
+		, vhost(v)
 	{
 	}
 
@@ -106,7 +116,7 @@ class ModuleCustomTitle : public Module, public Whois::LineEventListener
 	{
 	}
 
-	void ReadConfig(ConfigStatus &status) CXX11_OVERRIDE
+	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTagList tags = ServerInstance->Config->ConfTags("title");
 		CustomVhostMap newtitles;

--- a/src/modules/m_customtitle.cpp
+++ b/src/modules/m_customtitle.cpp
@@ -125,9 +125,12 @@ class ModuleCustomTitle : public Module, public Whois::LineEventListener
 			reference<ConfigTag> tag = i->second;
 			std::string name = tag->getString("name", "", 1);
 			if (name.empty())
-				throw ModuleException("<title:name> is empty! at " + tag->getTagLocation());
+				throw ModuleException("<title:name> is empty at " + tag->getTagLocation());
 
 			std::string pass = tag->getString("password");
+			if (pass.empty())
+				throw ModuleException("<title:password> is empty at " + tag->getTagLocation());
+
 			std::string hash = tag->getString("hash");
 			std::string host = tag->getString("host", "*@*");
 			std::string title = tag->getString("title");

--- a/src/modules/m_customtitle.cpp
+++ b/src/modules/m_customtitle.cpp
@@ -28,12 +28,39 @@ enum
 	RPL_WHOISSPECIAL = 320
 };
 
+struct CustomTitle
+{
+	const std::string name, password, hash, host, title, vhost;
+
+	CustomTitle(const std::string& n, const std::string& p, const std::string& h, const std::string& hst, const std::string& t, const std::string& v)
+		: name(n), password(p), hash(h), host(hst), title(t), vhost(v)
+	{
+	}
+
+	bool MatchUser(User* user) const
+	{
+		const std::string userHost = user->ident + "@" + user->GetRealHost();
+		const std::string userIP = user->ident + "@" + user->GetIPString();
+		return InspIRCd::MatchMask(host, userHost, userIP);
+	}
+
+	bool CheckPass(User* user, const std::string& pass) const
+	{
+		return ServerInstance->PassCompare(user, password, pass, hash);
+	}
+};
+
+typedef std::multimap<std::string, CustomTitle> CustomVhostMap;
+typedef std::pair<CustomVhostMap::iterator, CustomVhostMap::iterator> MatchingConfigs;
+
 /** Handle /TITLE
  */
 class CommandTitle : public Command
 {
  public:
 	StringExtItem ctitle;
+	CustomVhostMap configs;
+
 	CommandTitle(Module* Creator) : Command(Creator,"TITLE", 2),
 		ctitle("ctitle", ExtensionItem::EXT_USER, Creator)
 	{
@@ -42,30 +69,21 @@ class CommandTitle : public Command
 
 	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE
 	{
-		const std::string userHost = user->ident + "@" + user->GetRealHost();
-		const std::string userIP = user->ident + "@" + user->GetIPString();
+		MatchingConfigs matching = configs.equal_range(parameters[0]);
 
-		ConfigTagList tags = ServerInstance->Config->ConfTags("title");
-		for (ConfigIter i = tags.first; i != tags.second; ++i)
+		for (MatchingConfigs::first_type i = matching.first; i != matching.second; ++i)
 		{
-			std::string Name = i->second->getString("name");
-			std::string pass = i->second->getString("password");
-			std::string hash = i->second->getString("hash");
-			std::string host = i->second->getString("host", "*@*");
-			std::string title = i->second->getString("title");
-			std::string vhost = i->second->getString("vhost");
-
-			if (Name == parameters[0] && ServerInstance->PassCompare(user, pass, parameters[1], hash) &&
-				InspIRCd::MatchMask(host, userHost, userIP) && !title.empty())
+			CustomTitle config = i->second;
+			if (config.MatchUser(user) && config.CheckPass(user, parameters[1]))
 			{
-				ctitle.set(user, title);
+				ctitle.set(user, config.title);
 
-				ServerInstance->PI->SendMetaData(user, "ctitle", title);
+				ServerInstance->PI->SendMetaData(user, "ctitle", config.title);
 
-				if (!vhost.empty())
-					user->ChangeDisplayedHost(vhost);
+				if (!config.vhost.empty())
+					user->ChangeDisplayedHost(config.vhost);
 
-				user->WriteNotice("Custom title set to '" + title + "'");
+				user->WriteNotice("Custom title set to '" + config.title + "'");
 
 				return CMD_SUCCESS;
 			}
@@ -86,6 +104,28 @@ class ModuleCustomTitle : public Module, public Whois::LineEventListener
 		: Whois::LineEventListener(this)
 		, cmd(this)
 	{
+	}
+
+	void ReadConfig(ConfigStatus &status) CXX11_OVERRIDE
+	{
+		ConfigTagList tags = ServerInstance->Config->ConfTags("title");
+		CustomVhostMap newtitles;
+		for (ConfigIter i = tags.first; i != tags.second; ++i)
+		{
+			reference<ConfigTag> tag = i->second;
+			std::string name = tag->getString("name", "", 1);
+			if (name.empty())
+				continue;
+
+			std::string pass = tag->getString("password");
+			std::string hash = tag->getString("hash");
+			std::string host = tag->getString("host", "*@*");
+			std::string title = tag->getString("title");
+			std::string vhost = tag->getString("vhost");
+			CustomTitle config(name, pass, hash, host, title, vhost);
+			newtitles.insert(std::make_pair(name, config));
+		}
+		cmd.configs.swap(newtitles);
 	}
 
 	// :kenny.chatspike.net 320 Brain Azhrarn :is getting paid to play games.

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -514,8 +514,8 @@ class ModuleDCCAllow : public Module
 			bf.action = i->second->getString("action");
 			newbfl.push_back(bf);
 		}
-
 		bfl.swap(newbfl);
+
 		ConfigTag* tag = ServerInstance->Config->ConfValue("dccallow");
 		cmd.maxentries = tag->getUInt("maxentries", 20);
 		cmd.defaultlength = tag->getDuration("length", 0);

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -508,17 +508,20 @@ class ModuleDCCAllow : public Module
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("dccallow");
-		cmd.maxentries = tag->getUInt("maxentries", 20);
+		unsigned long maxentries = tag->getUInt("maxentries", 20);
 
-		bfl.clear();
+		bannedfilelist newbfl;
 		ConfigTagList tags = ServerInstance->Config->ConfTags("banfile");
 		for (ConfigIter i = tags.first; i != tags.second; ++i)
 		{
 			BannedFileList bf;
 			bf.filemask = i->second->getString("pattern");
 			bf.action = i->second->getString("action");
-			bfl.push_back(bf);
+			newbfl.push_back(bf);
 		}
+
+		bfl.swap(newbfl);
+		cmd.maxentries = maxentries;
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -106,6 +106,7 @@ class CommandDccallow : public Command
 
  public:
 	unsigned int maxentries;
+	unsigned long defaultlength;
 	CommandDccallow(Module* parent, DCCAllowExt& Ext)
 		: Command(parent, "DCCALLOW", 0)
 		, ext(Ext)
@@ -206,12 +207,10 @@ class CommandDccallow : public Command
 					}
 
 					std::string mask = target->nick+"!"+target->ident+"@"+target->GetDisplayedHost();
-					std::string default_length = ServerInstance->Config->ConfValue("dccallow")->getString("length");
-
 					unsigned long length;
 					if (parameters.size() < 2)
 					{
-						length = InspIRCd::Duration(default_length);
+						length = defaultlength;
 					}
 					else if (!InspIRCd::IsValidDuration(parameters[1]))
 					{
@@ -520,6 +519,7 @@ class ModuleDCCAllow : public Module
 		bfl.swap(newbfl);
 		ConfigTag* tag = ServerInstance->Config->ConfValue("dccallow");
 		cmd.maxentries = tag->getUInt("maxentries", 20);
+		cmd.defaultlength = tag->getDuration("length", 0);
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -507,9 +507,6 @@ class ModuleDCCAllow : public Module
 
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
-		ConfigTag* tag = ServerInstance->Config->ConfValue("dccallow");
-		unsigned long maxentries = tag->getUInt("maxentries", 20);
-
 		bannedfilelist newbfl;
 		ConfigTagList tags = ServerInstance->Config->ConfTags("banfile");
 		for (ConfigIter i = tags.first; i != tags.second; ++i)
@@ -521,7 +518,8 @@ class ModuleDCCAllow : public Module
 		}
 
 		bfl.swap(newbfl);
-		cmd.maxentries = maxentries;
+		ConfigTag* tag = ServerInstance->Config->ConfValue("dccallow");
+		cmd.maxentries = tag->getUInt("maxentries", 20);
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -292,11 +292,14 @@ class ModuleDCCAllow : public Module
 {
 	DCCAllowExt ext;
 	CommandDccallow cmd;
+	bool blockchat;
+	std::string defaultaction;
 
  public:
 	ModuleDCCAllow()
 		: ext("dccallow", ExtensionItem::EXT_USER, this)
 		, cmd(this, ext)
+		, blockchat(false)
 	{
 	}
 
@@ -355,9 +358,6 @@ class ModuleDCCAllow : public Module
 
 					const std::string type = buf.substr(0, s);
 
-					ConfigTag* conftag = ServerInstance->Config->ConfValue("dccallow");
-					bool blockchat = conftag->getBool("blockchat");
-
 					if (stdalgo::string::equalsci(type, "SEND"))
 					{
 						size_t first;
@@ -383,7 +383,6 @@ class ModuleDCCAllow : public Module
 						if (s == std::string::npos)
 							return MOD_RES_PASSTHRU;
 
-						std::string defaultaction = conftag->getString("action");
 						std::string filename = buf.substr(first, s);
 
 						bool found = false;
@@ -520,6 +519,8 @@ class ModuleDCCAllow : public Module
 		ConfigTag* tag = ServerInstance->Config->ConfValue("dccallow");
 		cmd.maxentries = tag->getUInt("maxentries", 20);
 		cmd.defaultlength = tag->getDuration("length", 0);
+		blockchat = tag->getBool("blockchat");
+		defaultaction = tag->getString("action");
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -228,9 +228,11 @@ class DNSBLResolver : public DNS::Request
 	}
 };
 
+typedef std::vector<reference<DNSBLConfEntry> > DNSBLConfList;
+
 class ModuleDNSBL : public Module, public Stats::EventListener
 {
-	std::vector<reference<DNSBLConfEntry> > DNSBLConfEntries;
+	DNSBLConfList DNSBLConfEntries;
 	dynamic_reference<DNS::Manager> DNS;
 	LocalStringExt nameExt;
 	LocalIntExt countExt;
@@ -276,7 +278,7 @@ class ModuleDNSBL : public Module, public Stats::EventListener
 	 */
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
-		DNSBLConfEntries.clear();
+		DNSBLConfList newentries;
 
 		ConfigTagList dnsbls = ServerInstance->Config->ConfTags("dnsbl");
 		for(ConfigIter i = dnsbls.first; i != dnsbls.second; ++i)
@@ -341,9 +343,11 @@ class ModuleDNSBL : public Module, public Stats::EventListener
 				}
 
 				/* add it, all is ok */
-				DNSBLConfEntries.push_back(e);
+				newentries.push_back(e);
 			}
 		}
+
+		DNSBLConfEntries.swap(newentries);
 	}
 
 	void OnSetUserIP(LocalUser* user) CXX11_OVERRIDE

--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -315,23 +315,19 @@ class ModuleDNSBL : public Module, public Stats::EventListener
 			/* yeah, logic here is a little messy */
 			if ((e->bitmask <= 0) && (DNSBLConfEntry::A_BITMASK == e->type))
 			{
-				std::string location = tag->getTagLocation();
-				ServerInstance->SNO->WriteGlobalSno('d', "DNSBL(%s): invalid bitmask", location.c_str());
+				throw ModuleException("Invalid <dnsbl:bitmask> at " + tag->getTagLocation());
 			}
 			else if (e->name.empty())
 			{
-				std::string location = tag->getTagLocation();
-				ServerInstance->SNO->WriteGlobalSno('d', "DNSBL(%s): Invalid name", location.c_str());
+				throw ModuleException("Empty <dnsbl:name> at " + tag->getTagLocation());
 			}
 			else if (e->domain.empty())
 			{
-				std::string location = tag->getTagLocation();
-				ServerInstance->SNO->WriteGlobalSno('d', "DNSBL(%s): Invalid domain", location.c_str());
+				throw ModuleException("Empty <dnsbl:domain> at " + tag->getTagLocation());
 			}
 			else if (e->banaction == DNSBLConfEntry::I_UNKNOWN)
 			{
-				std::string location = tag->getTagLocation();
-				ServerInstance->SNO->WriteGlobalSno('d', "DNSBL(%s): Invalid banaction", location.c_str());
+				throw ModuleException("Unknown <dnsbl:action> at " + tag->getTagLocation());
 			}
 			else
 			{

--- a/src/modules/m_flashpolicyd.cpp
+++ b/src/modules/m_flashpolicyd.cpp
@@ -97,7 +97,6 @@ class ModuleFlashPD : public Module
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("flashpolicyd");
-		timeout = tag->getDuration("timeout", 5, 1);
 		std::string file = tag->getString("file");
 
 		if (!file.empty())
@@ -113,6 +112,7 @@ class ModuleFlashPD : public Module
 				ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, error_message);
 				ServerInstance->SNO->WriteGlobalSno('a', error_message);
 				policy_reply.clear();
+				throw ModuleException(error_message + " at " + tag->getTagLocation());
 			}
 			return;
 		}
@@ -144,6 +144,7 @@ class ModuleFlashPD : public Module
 <site-control permitted-cross-domain-policies=\"master-only\"/>\
 <allow-access-from domain=\"*\" to-ports=\"" + to_ports + "\" />\
 </cross-domain-policy>";
+		timeout = tag->getDuration("timeout", 5, 1);
 	}
 
 	CullResult cull() CXX11_OVERRIDE

--- a/src/modules/m_flashpolicyd.cpp
+++ b/src/modules/m_flashpolicyd.cpp
@@ -108,11 +108,7 @@ class ModuleFlashPD : public Module
 			}
 			catch (CoreException&)
 			{
-				const std::string error_message = "A file was specified for FlashPD, but it could not be loaded.";
-				ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, error_message);
-				ServerInstance->SNO->WriteGlobalSno('a', error_message);
-				policy_reply.clear();
-				throw ModuleException(error_message + " at " + tag->getTagLocation());
+				throw ModuleException("A file was specified for FlashPD, but it could not be loaded at " + tag->getTagLocation());
 			}
 			return;
 		}

--- a/src/modules/m_helpop.cpp
+++ b/src/modules/m_helpop.cpp
@@ -146,10 +146,9 @@ class ModuleHelpop : public Module, public Whois::EventListener
 				throw ModuleException("m_helpop: Helpop file is missing important entry 'start'. Please check the example conf.");
 			}
 
-			helpop_map.swap(help);
-
 			ConfigTag* tag = ServerInstance->Config->ConfValue("helpmsg");
 			cmd.nohelp = tag->getString("nohelp", "There is no help for the topic you searched for. Please try again.", 1);
+			helpop_map.swap(help);
 		}
 
 		void OnWhois(Whois::Context& whois) CXX11_OVERRIDE

--- a/src/modules/m_helpop.cpp
+++ b/src/modules/m_helpop.cpp
@@ -146,9 +146,10 @@ class ModuleHelpop : public Module, public Whois::EventListener
 				throw ModuleException("m_helpop: Helpop file is missing important entry 'start'. Please check the example conf.");
 			}
 
+			helpop_map.swap(help);
+
 			ConfigTag* tag = ServerInstance->Config->ConfValue("helpmsg");
 			cmd.nohelp = tag->getString("nohelp", "There is no help for the topic you searched for. Please try again.", 1);
-			helpop_map.swap(help);
 		}
 
 		void OnWhois(Whois::Context& whois) CXX11_OVERRIDE

--- a/src/modules/m_hidemode.cpp
+++ b/src/modules/m_hidemode.cpp
@@ -37,7 +37,7 @@ class Settings
 
 	void Load()
 	{
-		rankstosee.clear();
+		RanksToSeeMap newranks;
 
 		ConfigTagList tags = ServerInstance->Config->ConfTags("hidemode");
 		for (ConfigIter i = tags.first; i != tags.second; ++i)
@@ -48,9 +48,10 @@ class Settings
 			if (!modename.empty() && rank)
 			{
 				ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Hiding the %s mode from users below rank %u", modename.c_str(), rank);
-				rankstosee.insert(std::make_pair(modename, rank));
+				newranks.insert(std::make_pair(modename, rank));
 			}
 		}
+		rankstosee.swap(newranks);
 	}
 };
 

--- a/src/modules/m_hidemode.cpp
+++ b/src/modules/m_hidemode.cpp
@@ -51,11 +51,8 @@ class Settings
 			if (rank <= 0)
 				throw ModuleException("<hidemode:rank> must be greater than 0 at " + tag->getTagLocation());
 
-			if (!modename.empty() && rank)
-			{
-				ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Hiding the %s mode from users below rank %u", modename.c_str(), rank);
-				newranks.insert(std::make_pair(modename, rank));
-			}
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Hiding the %s mode from users below rank %u", modename.c_str(), rank);
+			newranks.insert(std::make_pair(modename, rank));
 		}
 		rankstosee.swap(newranks);
 	}

--- a/src/modules/m_hidemode.cpp
+++ b/src/modules/m_hidemode.cpp
@@ -43,12 +43,12 @@ class Settings
 		for (ConfigIter i = tags.first; i != tags.second; ++i)
 		{
 			ConfigTag* tag = i->second;
-			std::string modename = tag->getString("mode");
-			unsigned int rank = tag->getInt("rank", 0, 0);
+			const std::string modename = tag->getString("mode");
 			if (modename.empty())
 				throw ModuleException("<hidemode:mode> is empty at " + tag->getTagLocation());
 
-			if (rank <= 0)
+			unsigned int rank = tag->getUInt("rank", 0);
+			if (!rank)
 				throw ModuleException("<hidemode:rank> must be greater than 0 at " + tag->getTagLocation());
 
 			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Hiding the %s mode from users below rank %u", modename.c_str(), rank);

--- a/src/modules/m_hidemode.cpp
+++ b/src/modules/m_hidemode.cpp
@@ -45,6 +45,12 @@ class Settings
 			ConfigTag* tag = i->second;
 			std::string modename = tag->getString("mode");
 			unsigned int rank = tag->getInt("rank", 0, 0);
+			if (modename.empty())
+				throw ModuleException("<hidemode:mode> is empty at " + tag->getTagLocation());
+
+			if (rank <= 0)
+				throw ModuleException("<hidemode:rank> must be greater than 0 at " + tag->getTagLocation());
+
 			if (!modename.empty() && rank)
 			{
 				ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Hiding the %s mode from users below rank %u", modename.c_str(), rank);

--- a/src/modules/m_httpd_acl.cpp
+++ b/src/modules/m_httpd_acl.cpp
@@ -51,7 +51,7 @@ class ModuleHTTPAccessList : public Module, public HTTPACLEventListener
 
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
-		acl_list.clear();
+		std::vector<HTTPACL> new_acls;
 		ConfigTagList acls = ServerInstance->Config->ConfTags("httpdacl");
 		for (ConfigIter i = acls.first; i != acls.second; i++)
 		{
@@ -89,8 +89,9 @@ class ModuleHTTPAccessList : public Module, public HTTPACLEventListener
 			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Read ACL: path=%s pass=%s whitelist=%s blacklist=%s", path.c_str(),
 					password.c_str(), whitelist.c_str(), blacklist.c_str());
 
-			acl_list.push_back(HTTPACL(path, username, password, whitelist, blacklist));
+			new_acls.push_back(HTTPACL(path, username, password, whitelist, blacklist));
 		}
+		acl_list.swap(new_acls);
 	}
 
 	void BlockAccess(HTTPRequest* http, unsigned int returnval, const std::string &extraheaderkey = "", const std::string &extraheaderval="")

--- a/src/modules/m_inviteexception.cpp
+++ b/src/modules/m_inviteexception.cpp
@@ -82,8 +82,8 @@ public:
 
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
-		invite_bypass_key = ServerInstance->Config->ConfValue("inviteexception")->getBool("bypasskey", true);
 		ie.DoRehash();
+		invite_bypass_key = ServerInstance->Config->ConfValue("inviteexception")->getBool("bypasskey", true);
 	}
 
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/modules/m_pbkdf2.cpp
+++ b/src/modules/m_pbkdf2.cpp
@@ -141,7 +141,8 @@ class PBKDF2Provider : public HashProvider
 
 struct ProviderConfig
 {
-	unsigned long iterations, dkey_length;
+	unsigned long dkey_length;
+	unsigned long iterations;
 };
 
 typedef std::map<std::string, ProviderConfig> ProviderConfigMap;

--- a/src/modules/m_pbkdf2.cpp
+++ b/src/modules/m_pbkdf2.cpp
@@ -187,7 +187,7 @@ class ModulePBKDF2 : public Module
 		{
 			tag = i->second;
 			std::string hash_name = "hash/" + tag->getString("hash");
-			ProviderConfig config;
+			ProviderConfig& config = newconfigs[hash_name];
 
 			config.iterations = tag->getUInt("iterations", newglobal.iterations, 1);
 			config.dkey_length = tag->getUInt("length", newglobal.dkey_length, 1, 1024);

--- a/src/modules/m_restrictchans.cpp
+++ b/src/modules/m_restrictchans.cpp
@@ -35,7 +35,11 @@ class ModuleRestrictChans : public Module
 		ConfigTagList tags = ServerInstance->Config->ConfTags("allowchannel");
 		for(ConfigIter i = tags.first; i != tags.second; ++i)
 		{
-			newallows.insert(i->second->getString("name"));
+			const std::string name = i->second->getString("name");
+			if (name.empty())
+				throw ModuleException("Empty <allowchannel:name> at " + i->second->getTagLocation());
+
+			newallows.insert(name);
 		}
 		allowchans.swap(newallows);
 	}

--- a/src/modules/m_restrictchans.cpp
+++ b/src/modules/m_restrictchans.cpp
@@ -22,21 +22,22 @@
 
 #include "inspircd.h"
 
+typedef insp::flat_set<std::string, irc::insensitive_swo> AllowChans;
+
 class ModuleRestrictChans : public Module
 {
-	insp::flat_set<std::string, irc::insensitive_swo> allowchans;
+	AllowChans allowchans;
 
  public:
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
-		allowchans.clear();
+		AllowChans newallows;
 		ConfigTagList tags = ServerInstance->Config->ConfTags("allowchannel");
 		for(ConfigIter i = tags.first; i != tags.second; ++i)
 		{
-			ConfigTag* tag = i->second;
-			std::string txt = tag->getString("name");
-			allowchans.insert(txt);
+			newallows.insert(i->second->getString("name"));
 		}
+		allowchans.swap(newallows);
 	}
 
 	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE

--- a/src/modules/m_securelist.cpp
+++ b/src/modules/m_securelist.cpp
@@ -22,9 +22,11 @@
 #include "inspircd.h"
 #include "modules/account.h"
 
+typedef std::vector<std::string> AllowList;
+
 class ModuleSecureList : public Module
 {
-	std::vector<std::string> allowlist;
+	AllowList allowlist;
 	bool exemptregistered;
 	unsigned int WaitTime;
 
@@ -36,15 +38,19 @@ class ModuleSecureList : public Module
 
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
-		allowlist.clear();
+		AllowList newallows;
 
 		ConfigTagList tags = ServerInstance->Config->ConfTags("securehost");
 		for (ConfigIter i = tags.first; i != tags.second; ++i)
-			allowlist.push_back(i->second->getString("exception"));
+			newallows.push_back(i->second->getString("exception"));
 
 		ConfigTag* tag = ServerInstance->Config->ConfValue("securelist");
-		exemptregistered = tag->getBool("exemptregistered");
-		WaitTime = tag->getDuration("waittime", 60, 1);
+		bool exreg = tag->getBool("exemptregistered");
+		unsigned long wait = tag->getDuration("waittime", 60, 1);
+
+		exemptregistered = exreg;
+		WaitTime = wait;
+		allowlist.swap(newallows);
 	}
 
 

--- a/src/modules/m_securelist.cpp
+++ b/src/modules/m_securelist.cpp
@@ -45,7 +45,7 @@ class ModuleSecureList : public Module
 		{
 			std::string host = i->second->getString("exception");
 			if (host.empty())
-				throw ModuleException("<securehost:exception> is a requirewd field! at " + i->second->getTagLocation());
+				throw ModuleException("<securehost:exception> is a required field at " + i->second->getTagLocation());
 			newallows.push_back(host);
 		}
 

--- a/src/modules/m_securelist.cpp
+++ b/src/modules/m_securelist.cpp
@@ -42,7 +42,12 @@ class ModuleSecureList : public Module
 
 		ConfigTagList tags = ServerInstance->Config->ConfTags("securehost");
 		for (ConfigIter i = tags.first; i != tags.second; ++i)
-			newallows.push_back(i->second->getString("exception"));
+		{
+			std::string host = i->second->getString("exception");
+			if (host.empty())
+				throw ModuleException("<securehost:exception> is a requirewd field! at " + i->second->getTagLocation());
+			newallows.push_back(host);
+		}
 
 		ConfigTag* tag = ServerInstance->Config->ConfValue("securelist");
 

--- a/src/modules/m_securelist.cpp
+++ b/src/modules/m_securelist.cpp
@@ -45,11 +45,9 @@ class ModuleSecureList : public Module
 			newallows.push_back(i->second->getString("exception"));
 
 		ConfigTag* tag = ServerInstance->Config->ConfValue("securelist");
-		bool exreg = tag->getBool("exemptregistered");
-		unsigned long wait = tag->getDuration("waittime", 60, 1);
 
-		exemptregistered = exreg;
-		WaitTime = wait;
+		exemptregistered = tag->getBool("exemptregistered");
+		WaitTime = tag->getDuration("waittime", 60, 1);
 		allowlist.swap(newallows);
 	}
 

--- a/src/modules/m_vhost.cpp
+++ b/src/modules/m_vhost.cpp
@@ -24,10 +24,16 @@
 
 struct CustomVhost
 {
-	const std::string name, password, hash, vhost;
+	const std::string name;
+	const std::string password;
+	const std::string hash;
+	const std::string vhost;
 
 	CustomVhost(const std::string& n, const std::string& p, const std::string& h, const std::string& v)
-			: name(n), password(p), hash(h), vhost(v)
+		: name(n)
+		, password(p)
+		, hash(h)
+		, vhost(v)
 	{
 	}
 
@@ -47,7 +53,8 @@ class CommandVhost : public Command
  public:
 	CustomVhostMap vhosts;
 
-	CommandVhost(Module* Creator) : Command(Creator, "VHOST", 2)
+	CommandVhost(Module* Creator)
+		: Command(Creator, "VHOST", 2)
 	{
 		syntax = "<username> <password>";
 	}
@@ -77,7 +84,8 @@ class ModuleVHost : public Module
 	CommandVhost cmd;
 
  public:
-	ModuleVHost() : cmd(this)
+	ModuleVHost()
+		: cmd(this)
 	{
 	}
 
@@ -102,7 +110,7 @@ class ModuleVHost : public Module
 
 	Version GetVersion() CXX11_OVERRIDE
 	{
-		return Version("Provides masking of user hostnames via traditional /VHOST command",VF_VENDOR);
+		return Version("Provides masking of user hostnames via traditional /VHOST command", VF_VENDOR);
 	}
 };
 

--- a/src/modules/m_vhost.cpp
+++ b/src/modules/m_vhost.cpp
@@ -96,9 +96,15 @@ class ModuleVHost : public Module
 		for (ConfigIter i = tags.first; i != tags.second; ++i)
 		{
 			ConfigTag* tag = i->second;
-			std::string mask = tag->getString("host", "", 1);
+			std::string mask = tag->getString("host");
+			if (mask.empty())
+				throw ModuleException("<vhost:host> is empty! at " + tag->getTagLocation());
 			std::string username = tag->getString("user");
+			if (username.empty())
+				throw ModuleException("<vhost:user> is empty! at " + tag->getTagLocation());
 			std::string pass = tag->getString("pass");
+			if (pass.empty())
+				throw ModuleException("<vhost:pass> is empty! at " + tag->getTagLocation());
 			std::string hash = tag->getString("hash");
 
 			CustomVhost vhost(username, pass, hash, mask);


### PR DESCRIPTION
Atomic rehashing allows us to ensure that an invalid configuration doesn't get partially applied before erroring or remove existing settings and not add them back, thus causing unexpected behavior.

Mostly minor changes to only apply changes to a module's config if it does not error.

### Major changes
- Refactor of `core_info` including changes to the `CommandDie`/`CommandRestart` structure and functionality

- `m_vhost` and `m_customtitle` got new config objects to allow easier loading of their configs instead of reading them on command execution

- Restructured loading and configuration of `m_pbkdf2` providers to make the rehash atomic, added config data objects

- And various `typedef`s for type reuse throughout

