### PR TITLE
Add the ability to disable console colors in stdout logging

### DIFF
--- a/include/consolecolors.h
+++ b/include/consolecolors.h
@@ -19,7 +19,46 @@
 
 #include <ostream>
 
-#ifdef _WIN32
+inline std::ostream& con_green(std::ostream &s);
+inline std::ostream& con_red(std::ostream &s);
+inline std::ostream& con_white(std::ostream &s);
+inline std::ostream& con_white_bright(std::ostream &s);
+inline std::ostream& con_bright(std::ostream &s);
+inline std::ostream& con_reset(std::ostream &s);
+
+#ifdef INSPIRCD_DISABLE_COLORS
+
+inline std::ostream& con_green(std::ostream &s)
+{
+	return s;
+}
+
+inline std::ostream& con_red(std::ostream &s)
+{
+	return s;
+}
+
+inline std::ostream& con_white(std::ostream &s)
+{
+	return s;
+}
+
+inline std::ostream& con_white_bright(std::ostream &s)
+{
+	return s;
+}
+
+inline std::ostream& con_bright(std::ostream &s)
+{
+	return s;
+}
+
+inline std::ostream& con_reset(std::ostream &s)
+{
+	return s;
+}
+
+#elif defined _WIN32
 
 #include <windows.h>
 

--- a/include/consolecolors.h
+++ b/include/consolecolors.h
@@ -65,33 +65,53 @@ inline std::ostream& con_reset(std::ostream &s)
 
 #else
 
+#include <unistd.h>   // for isatty()
+#include <stdio.h>    // for fileno()
+
+static inline bool IsRunningInteractive()
+{
+	return isatty(fileno(stdout));
+}
+
 inline std::ostream& con_green(std::ostream &s)
 {
+	if (!IsRunningInteractive())
+		return s;
 	return s << "\033[1;32m";
 }
 
 inline std::ostream& con_red(std::ostream &s)
 {
+	if (!IsRunningInteractive())
+		return s;
 	return s << "\033[1;31m";
 }
 
 inline std::ostream& con_white(std::ostream &s)
 {
+	if (!IsRunningInteractive())
+		return s;
 	return s << "\033[0m";
 }
 
 inline std::ostream& con_white_bright(std::ostream &s)
 {
+	if (!IsRunningInteractive())
+		return s;
 	return s << "\033[1m";
 }
 
 inline std::ostream& con_bright(std::ostream &s)
 {
+	if (!IsRunningInteractive())
+		return s;
 	return s << "\033[1m";
 }
 
 inline std::ostream& con_reset(std::ostream &s)
 {
+	if (!IsRunningInteractive())
+		return s;
 	return s << "\033[0m";
 }
 

--- a/include/consolecolors.h
+++ b/include/consolecolors.h
@@ -18,6 +18,16 @@
 #pragma once
 
 #include <ostream>
+#include <stdio.h> // for fileno()
+
+#ifdef _WIN32
+#include <io.h>
+
+#define isatty(x) _isatty((x))
+#define fileno(x) _fileno((x))
+#else
+#include <unistd.h>   // for isatty()
+#endif
 
 inline std::ostream& con_green(std::ostream &s);
 inline std::ostream& con_red(std::ostream &s);
@@ -26,39 +36,19 @@ inline std::ostream& con_white_bright(std::ostream &s);
 inline std::ostream& con_bright(std::ostream &s);
 inline std::ostream& con_reset(std::ostream &s);
 
+namespace
+{
+	inline bool IsRunningInteractive()
+	{
 #ifdef INSPIRCD_DISABLE_COLORS
-
-inline std::ostream& con_green(std::ostream &s)
-{
-	return s;
+		return false;
+#else
+		return isatty(fileno(stdout));
+#endif
+	}
 }
 
-inline std::ostream& con_red(std::ostream &s)
-{
-	return s;
-}
-
-inline std::ostream& con_white(std::ostream &s)
-{
-	return s;
-}
-
-inline std::ostream& con_white_bright(std::ostream &s)
-{
-	return s;
-}
-
-inline std::ostream& con_bright(std::ostream &s)
-{
-	return s;
-}
-
-inline std::ostream& con_reset(std::ostream &s)
-{
-	return s;
-}
-
-#elif defined _WIN32
+#ifdef _WIN32
 
 #include <windows.h>
 
@@ -68,52 +58,47 @@ extern HANDLE g_hStdout;
 
 inline std::ostream& con_green(std::ostream &s)
 {
-	SetConsoleTextAttribute(g_hStdout, FOREGROUND_GREEN|FOREGROUND_INTENSITY|g_wBackgroundColor);
+	if (IsRunningInteractive())
+		SetConsoleTextAttribute(g_hStdout, FOREGROUND_GREEN|FOREGROUND_INTENSITY|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_red(std::ostream &s)
 {
-	SetConsoleTextAttribute(g_hStdout, FOREGROUND_RED|FOREGROUND_INTENSITY|g_wBackgroundColor);
+	if (IsRunningInteractive())
+		SetConsoleTextAttribute(g_hStdout, FOREGROUND_RED|FOREGROUND_INTENSITY|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_white(std::ostream &s)
 {
-	SetConsoleTextAttribute(g_hStdout, FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN|g_wBackgroundColor);
+	if (IsRunningInteractive())
+		SetConsoleTextAttribute(g_hStdout, FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_white_bright(std::ostream &s)
 {
-	SetConsoleTextAttribute(g_hStdout, FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_INTENSITY|g_wBackgroundColor);
+	if (IsRunningInteractive())
+		SetConsoleTextAttribute(g_hStdout, FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_INTENSITY|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_bright(std::ostream &s)
 {
-	SetConsoleTextAttribute(g_hStdout, FOREGROUND_INTENSITY|g_wBackgroundColor);
+	if (IsRunningInteractive())
+		SetConsoleTextAttribute(g_hStdout, FOREGROUND_INTENSITY|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_reset(std::ostream &s)
 {
-	SetConsoleTextAttribute(g_hStdout, g_wOriginalColors);
+	if (IsRunningInteractive())
+		SetConsoleTextAttribute(g_hStdout, g_wOriginalColors);
 	return s;
 }
 
 #else
-
-#include <unistd.h>   // for isatty()
-#include <stdio.h>    // for fileno()
-
-namespace
-{
-	inline bool IsRunningInteractive()
-	{
-		return isatty(fileno(stdout));
-	}
-}
 
 inline std::ostream& con_green(std::ostream &s)
 {

--- a/include/consolecolors.h
+++ b/include/consolecolors.h
@@ -18,27 +18,19 @@
 #pragma once
 
 #include <ostream>
-#include <stdio.h> // for fileno()
+#include <stdio.h>
 
 #ifdef _WIN32
-#include <io.h>
-
-#define isatty(x) _isatty((x))
-#define fileno(x) _fileno((x))
+# include <io.h>
+# define isatty(x) _isatty((x))
+# define fileno(x) _fileno((x))
 #else
-#include <unistd.h>   // for isatty()
+# include <unistd.h>
 #endif
-
-inline std::ostream& con_green(std::ostream &s);
-inline std::ostream& con_red(std::ostream &s);
-inline std::ostream& con_white(std::ostream &s);
-inline std::ostream& con_white_bright(std::ostream &s);
-inline std::ostream& con_bright(std::ostream &s);
-inline std::ostream& con_reset(std::ostream &s);
 
 namespace
 {
-	inline bool IsRunningInteractive()
+	inline bool CanUseColors()
 	{
 #ifdef INSPIRCD_DISABLE_COLORS
 		return false;
@@ -58,42 +50,42 @@ extern HANDLE g_hStdout;
 
 inline std::ostream& con_green(std::ostream &s)
 {
-	if (IsRunningInteractive())
+	if (CanUseColors())
 		SetConsoleTextAttribute(g_hStdout, FOREGROUND_GREEN|FOREGROUND_INTENSITY|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_red(std::ostream &s)
 {
-	if (IsRunningInteractive())
+	if (CanUseColors())
 		SetConsoleTextAttribute(g_hStdout, FOREGROUND_RED|FOREGROUND_INTENSITY|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_white(std::ostream &s)
 {
-	if (IsRunningInteractive())
+	if (CanUseColors())
 		SetConsoleTextAttribute(g_hStdout, FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_white_bright(std::ostream &s)
 {
-	if (IsRunningInteractive())
+	if (CanUseColors())
 		SetConsoleTextAttribute(g_hStdout, FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN|FOREGROUND_INTENSITY|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_bright(std::ostream &s)
 {
-	if (IsRunningInteractive())
+	if (CanUseColors())
 		SetConsoleTextAttribute(g_hStdout, FOREGROUND_INTENSITY|g_wBackgroundColor);
 	return s;
 }
 
 inline std::ostream& con_reset(std::ostream &s)
 {
-	if (IsRunningInteractive())
+	if (CanUseColors())
 		SetConsoleTextAttribute(g_hStdout, g_wOriginalColors);
 	return s;
 }
@@ -102,42 +94,42 @@ inline std::ostream& con_reset(std::ostream &s)
 
 inline std::ostream& con_green(std::ostream &s)
 {
-	if (!IsRunningInteractive())
+	if (!CanUseColors())
 		return s;
 	return s << "\033[1;32m";
 }
 
 inline std::ostream& con_red(std::ostream &s)
 {
-	if (!IsRunningInteractive())
+	if (!CanUseColors())
 		return s;
 	return s << "\033[1;31m";
 }
 
 inline std::ostream& con_white(std::ostream &s)
 {
-	if (!IsRunningInteractive())
+	if (!CanUseColors())
 		return s;
 	return s << "\033[0m";
 }
 
 inline std::ostream& con_white_bright(std::ostream &s)
 {
-	if (!IsRunningInteractive())
+	if (!CanUseColors())
 		return s;
 	return s << "\033[1m";
 }
 
 inline std::ostream& con_bright(std::ostream &s)
 {
-	if (!IsRunningInteractive())
+	if (!CanUseColors())
 		return s;
 	return s << "\033[1m";
 }
 
 inline std::ostream& con_reset(std::ostream &s)
 {
-	if (!IsRunningInteractive())
+	if (!CanUseColors())
 		return s;
 	return s << "\033[0m";
 }

--- a/include/consolecolors.h
+++ b/include/consolecolors.h
@@ -107,9 +107,12 @@ inline std::ostream& con_reset(std::ostream &s)
 #include <unistd.h>   // for isatty()
 #include <stdio.h>    // for fileno()
 
-static inline bool IsRunningInteractive()
+namespace
 {
-	return isatty(fileno(stdout));
+	inline bool IsRunningInteractive()
+	{
+		return isatty(fileno(stdout));
+	}
 }
 
 inline std::ostream& con_green(std::ostream &s)


### PR DESCRIPTION
- Disables console colors when not attached to a TTY
- Add a preprocessor option to disable console colors completely