### PR TITLE
Add translation for m_override mode name

### DIFF
--- a/src/modules/m_spanningtree/capab.cpp
+++ b/src/modules/m_spanningtree/capab.cpp
@@ -99,7 +99,13 @@ std::string TreeSocket::BuildModeList(ModeType mtype)
 			else
 				mdesc.append("simple:");
 		}
-		mdesc.append(mh->name);
+		// In the 2.0 inspircd-extras module m_override_umode
+		// it is called permitoverride
+		if (mh->creator->ModuleSourceFile == "m_override.so" && mh->name == "override" && proto_version == 1202)
+			mdesc.append("permitoverride");
+		else
+			mdesc.append(mh->name);
+
 		mdesc.push_back('=');
 		if (pm)
 		{


### PR DESCRIPTION
In the 2.0 extras module it's called permitoverride, in 3.0 it's just
override