### PR TITLE
Add translation for casemapping between 2.0/3.0

### DIFF
--- a/src/modules/m_spanningtree/capab.cpp
+++ b/src/modules/m_spanningtree/capab.cpp
@@ -76,6 +76,15 @@ std::string TreeSocket::MyModules(int filter)
 			capabilities.append(v.link_data);
 		}
 	}
+
+	// If we are linked in a 2.0 server and have an ascii casemapping
+	// advertise it as m_ascii.so from inspircd-extras
+	if ((filter & VF_COMMON) && ServerInstance->Config->CaseMapping == "ascii" && proto_version == 1202)
+	{
+		if (!capabilities.empty())
+			capabilities += "m_ascii.so";
+	}
+
 	return capabilities;
 }
 


### PR DESCRIPTION
If the casemapping is set to ascii, advertise the m_ascii module to 2.0
to allow use of the m_ascii extras module for 2.0