### PR TITLE
Add the reason to X-line removal notices.

### DIFF
--- a/include/xline.h
+++ b/include/xline.h
@@ -467,11 +467,12 @@ class CoreExport XLineManager
 	/** Delete an XLine
 	 * @param hostmask The xline-specific string identifying the line, e.g. "*@foo"
 	 * @param type The type of xline
+	 * @param reason The xline reason, if it is being removed successfully
 	 * @param user The user removing the line or NULL if its the local server
 	 * @param simulate If this is true, don't actually remove the line, just return
 	 * @return True if the line was deleted successfully
 	 */
-	bool DelLine(const char* hostmask, const std::string &type, User* user, bool simulate = false);
+	bool DelLine(const char* hostmask, const std::string& type, std::string& reason, User* user, bool simulate = false);
 
 	/** Registers an xline factory.
 	 * An xline factory is a class which when given a particular xline type,

--- a/src/coremods/core_xline/cmd_eline.cpp
+++ b/src/coremods/core_xline/cmd_eline.cpp
@@ -87,9 +87,11 @@ CmdResult CommandEline::Handle(User* user, const Params& parameters)
 	}
 	else
 	{
-		if (ServerInstance->XLines->DelLine(target.c_str(), "E", user))
+		std::string reason;
+
+		if (ServerInstance->XLines->DelLine(target.c_str(), "E", reason, user))
 		{
-			ServerInstance->SNO->WriteToSnoMask('x',"%s removed E-line on %s",user->nick.c_str(),target.c_str());
+			ServerInstance->SNO->WriteToSnoMask('x', "%s removed E-line on %s: %s", user->nick.c_str(), target.c_str(), reason.c_str());
 		}
 		else
 		{

--- a/src/coremods/core_xline/cmd_gline.cpp
+++ b/src/coremods/core_xline/cmd_gline.cpp
@@ -96,9 +96,11 @@ CmdResult CommandGline::Handle(User* user, const Params& parameters)
 	}
 	else
 	{
-		if (ServerInstance->XLines->DelLine(target.c_str(),"G",user))
+		std::string reason;
+
+		if (ServerInstance->XLines->DelLine(target.c_str(), "G", reason, user))
 		{
-			ServerInstance->SNO->WriteToSnoMask('x',"%s removed G-line on %s",user->nick.c_str(),target.c_str());
+			ServerInstance->SNO->WriteToSnoMask('x', "%s removed G-line on %s: %s", user->nick.c_str(), target.c_str(), reason.c_str());
 		}
 		else
 		{

--- a/src/coremods/core_xline/cmd_kline.cpp
+++ b/src/coremods/core_xline/cmd_kline.cpp
@@ -95,9 +95,11 @@ CmdResult CommandKline::Handle(User* user, const Params& parameters)
 	}
 	else
 	{
-		if (ServerInstance->XLines->DelLine(target.c_str(),"K",user))
+		std::string reason;
+
+		if (ServerInstance->XLines->DelLine(target.c_str(), "K", reason, user))
 		{
-			ServerInstance->SNO->WriteToSnoMask('x',"%s removed K-line on %s",user->nick.c_str(),target.c_str());
+			ServerInstance->SNO->WriteToSnoMask('x', "%s removed K-line on %s: %s", user->nick.c_str(), target.c_str(), reason.c_str());
 		}
 		else
 		{

--- a/src/coremods/core_xline/cmd_qline.cpp
+++ b/src/coremods/core_xline/cmd_qline.cpp
@@ -74,9 +74,11 @@ CmdResult CommandQline::Handle(User* user, const Params& parameters)
 	}
 	else
 	{
-		if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "Q", user))
+		std::string reason;
+
+		if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "Q", reason, user))
 		{
-			ServerInstance->SNO->WriteToSnoMask('x',"%s removed Q-line on %s",user->nick.c_str(),parameters[0].c_str());
+			ServerInstance->SNO->WriteToSnoMask('x', "%s removed Q-line on %s: %s", user->nick.c_str(), parameters[0].c_str(), reason.c_str());
 		}
 		else
 		{

--- a/src/coremods/core_xline/cmd_zline.cpp
+++ b/src/coremods/core_xline/cmd_zline.cpp
@@ -92,9 +92,11 @@ CmdResult CommandZline::Handle(User* user, const Params& parameters)
 	}
 	else
 	{
-		if (ServerInstance->XLines->DelLine(target.c_str(),"Z",user))
+		std::string reason;
+
+		if (ServerInstance->XLines->DelLine(target.c_str(), "Z", reason, user))
 		{
-			ServerInstance->SNO->WriteToSnoMask('x',"%s removed Z-line on %s",user->nick.c_str(),target.c_str());
+			ServerInstance->SNO->WriteToSnoMask('x', "%s removed Z-line on %s: %s", user->nick.c_str(), target.c_str(), reason.c_str());
 		}
 		else
 		{

--- a/src/modules/m_cban.cpp
+++ b/src/modules/m_cban.cpp
@@ -98,9 +98,11 @@ class CommandCBan : public Command
 
 		if (parameters.size() == 1)
 		{
-			if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "CBAN", user))
+			std::string reason;
+
+			if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "CBAN", reason, user))
 			{
-				ServerInstance->SNO->WriteGlobalSno('x', "%s removed CBan on %s.",user->nick.c_str(),parameters[0].c_str());
+				ServerInstance->SNO->WriteGlobalSno('x', "%s removed CBan on %s: %s", user->nick.c_str(), parameters[0].c_str(), reason.c_str());
 			}
 			else
 			{

--- a/src/modules/m_rline.cpp
+++ b/src/modules/m_rline.cpp
@@ -190,9 +190,11 @@ class CommandRLine : public Command
 		}
 		else
 		{
-			if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "R", user))
+			std::string reason;
+
+			if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "R", reason, user))
 			{
-				ServerInstance->SNO->WriteToSnoMask('x',"%s removed R-line on %s",user->nick.c_str(),parameters[0].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s removed R-line on %s: %s", user->nick.c_str(), parameters[0].c_str(), reason.c_str());
 			}
 			else
 			{

--- a/src/modules/m_shun.cpp
+++ b/src/modules/m_shun.cpp
@@ -69,13 +69,15 @@ class CommandShun : public Command
 
 		if (parameters.size() == 1)
 		{
-			if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "SHUN", user))
+			std::string reason;
+
+			if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "SHUN", reason, user))
 			{
-				ServerInstance->SNO->WriteToSnoMask('x', "%s removed SHUN on %s", user->nick.c_str(), parameters[0].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s removed SHUN on %s: %s", user->nick.c_str(), parameters[0].c_str(), reason.c_str());
 			}
-			else if (ServerInstance->XLines->DelLine(target.c_str(), "SHUN", user))
+			else if (ServerInstance->XLines->DelLine(target.c_str(), "SHUN", reason, user))
 			{
-				ServerInstance->SNO->WriteToSnoMask('x',"%s removed SHUN on %s", user->nick.c_str(), target.c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s removed SHUN on %s: %s", user->nick.c_str(), target.c_str(), reason.c_str());
 			}
 			else
 			{

--- a/src/modules/m_spanningtree/delline.cpp
+++ b/src/modules/m_spanningtree/delline.cpp
@@ -25,12 +25,13 @@
 CmdResult CommandDelLine::Handle(User* user, Params& params)
 {
 	const std::string& setter = user->nick;
+	std::string reason;
 
 	// XLineManager::DelLine() returns true if the xline existed, false if it didn't
-	if (ServerInstance->XLines->DelLine(params[1].c_str(), params[0], user))
+	if (ServerInstance->XLines->DelLine(params[1].c_str(), params[0], reason, user))
 	{
-		ServerInstance->SNO->WriteToSnoMask('X',"%s removed %s%s on %s", setter.c_str(),
-				params[0].c_str(), params[0].length() == 1 ? "-line" : "", params[1].c_str());
+		ServerInstance->SNO->WriteToSnoMask('X', "%s removed %s%s on %s: %s", setter.c_str(),
+				params[0].c_str(), params[0].length() == 1 ? "-line" : "", params[1].c_str(), reason.c_str());
 		return CMD_SUCCESS;
 	}
 	return CMD_FAILURE;

--- a/src/modules/m_svshold.cpp
+++ b/src/modules/m_svshold.cpp
@@ -112,10 +112,12 @@ class CommandSvshold : public Command
 
 		if (parameters.size() == 1)
 		{
-			if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "SVSHOLD", user))
+			std::string reason;
+
+			if (ServerInstance->XLines->DelLine(parameters[0].c_str(), "SVSHOLD", reason, user))
 			{
 				if (!silent)
-					ServerInstance->SNO->WriteToSnoMask('x',"%s removed SVSHOLD on %s",user->nick.c_str(),parameters[0].c_str());
+					ServerInstance->SNO->WriteToSnoMask('x', "%s removed SVSHOLD on %s: %s", user->nick.c_str(), parameters[0].c_str(), reason.c_str());
 			}
 			else
 			{

--- a/src/xline.cpp
+++ b/src/xline.cpp
@@ -294,7 +294,7 @@ bool XLineManager::AddLine(XLine* line, User* user)
 
 // deletes a line, returns true if the line existed and was removed
 
-bool XLineManager::DelLine(const char* hostmask, const std::string &type, User* user, bool simulate)
+bool XLineManager::DelLine(const char* hostmask, const std::string& type, std::string& reason, User* user, bool simulate)
 {
 	ContainerIter x = lookup_lines.find(type);
 
@@ -305,6 +305,8 @@ bool XLineManager::DelLine(const char* hostmask, const std::string &type, User* 
 
 	if (y == x->second.end())
 		return false;
+
+	reason.assign(y->second->reason);
 
 	if (simulate)
 		return true;


### PR DESCRIPTION
Add the X-line reason to the removal `SNOTICE`, matching the newer behavior of the expiry `SNOTICE`. This modifies `XLineManager::DelLine()` to require a string reference (`reason`) passed to it, which it assigns the X-line reason to if it is found and being removed.  
I had considered doing something like `DisplayExpiry()` in the core, but as removals are command based not core based (as expiring is) that seemed incorrect.

Idea/Request by @Robby-.