### PR TITLE
Add option to make a connect block not match users with an account

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -336,6 +336,16 @@
          port="6697,9999">
 
 <connect
+         name="loggedin"
+         parent="main"
+
+         # account: Control how the class matches users with an account (requires m_services_account)
+         #  allow: Allow a user with an account to connect, not requiring an account though (default)
+         #  deny: Only allow a user that isn't logged in to match this connect class
+         #  require: Only match a user with an account
+         account="require">
+
+<connect
          # name: Name to use for this connect block. Mainly used for
          # connect class inheriting.
          name="main"

--- a/src/modules/m_services_account.cpp
+++ b/src/modules/m_services_account.cpp
@@ -290,11 +290,26 @@ class ModuleServicesAccount : public Module, public Whois::EventListener
 
 	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* myclass) CXX11_OVERRIDE
 	{
-		if (myclass->config->getBool("requireaccount") && !accountname.get(user))
+		bool hasacct = accountname.get(user);
+		if (myclass->config->getBool("requireaccount") && !hasacct)
 			return MOD_RES_DENY;
 
-		if (myclass->config->getBool("requirenoaccount") && accountname.get(user))
-			return MOD_RES_DENY;
+		std::string acct = myclass->config->getString("account", "allow", 1);
+		if (stdalgo::string::equalsci(acct, "allow"))
+		{
+			// Allow anyone
+			return MOD_RES_PASSTHRU;
+		}
+		else if (stdalgo::string::equalsci(acct, "deny"))
+		{
+			if (hasacct)
+				return MOD_RES_DENY;
+		}
+		else if (stdalgo::string::equalsci(acct, "require"))
+		{
+			if (!hasacct)
+				return MOD_RES_DENY;
+		}
 
 		return MOD_RES_PASSTHRU;
 	}

--- a/src/modules/m_services_account.cpp
+++ b/src/modules/m_services_account.cpp
@@ -292,6 +292,10 @@ class ModuleServicesAccount : public Module, public Whois::EventListener
 	{
 		if (myclass->config->getBool("requireaccount") && !accountname.get(user))
 			return MOD_RES_DENY;
+
+		if (myclass->config->getBool("requirenoaccount") && accountname.get(user))
+			return MOD_RES_DENY;
+
 		return MOD_RES_PASSTHRU;
 	}
 


### PR DESCRIPTION
Allows setting a connect class which will only match a user who has not
logged in