### PR TITLE
Don't allow spaces in UNIX listener paths

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -107,6 +107,14 @@ int InspIRCd::BindPorts(FailedPortList& failed_ports)
 				continue;
 			}
 
+			// Check for characters which are problematic in the IRC message format.
+			if (path.find_first_of("\n\r\t!@: ") != std::string::npos)
+			{
+				this->Logs->Log("SOCKET", LOG_DEFAULT, "UNIX listener on %s at %s specified a path containing invalid characters!",
+					path.c_str(), tag->getTagLocation().c_str());
+				continue;
+			}
+
 			// Create the bindspec manually (aptosa doesn't work with AF_UNIX yet).
 			memset(&bindspec, 0, sizeof(bindspec));
 			bindspec.un.sun_family = AF_UNIX;


### PR DESCRIPTION
Allowing spaces here can cause a whole host of issues as the user's host would contain a space unless set otherwise by webirc, haproxy, or similar.