### PR TITLE
Give m_setname its own snomask

### DIFF
--- a/src/modules/m_setname.cpp
+++ b/src/modules/m_setname.cpp
@@ -45,7 +45,7 @@ class CommandSetname : public Command
 
 		if (user->ChangeName(parameters[0].c_str()))
 		{
-			ServerInstance->SNO->WriteGlobalSno('a', "%s used SETNAME to change their GECOS to '%s'", user->nick.c_str(), parameters[0].c_str());
+			ServerInstance->SNO->WriteGlobalSno('s', "%s used SETNAME to change their GECOS to '%s'", user->nick.c_str(), parameters[0].c_str());
 		}
 
 		return CMD_SUCCESS;


### PR DESCRIPTION
This pull request gives m_setname its own snomask char, s, as it is not used on InspIRCd 2.x. The reason is so that opers can be informed about users using /SETNAME yet it does not get propogated to the announcement snomask a. This could lead to important messages "drowning". 
The reason for this pull request instead of simply disabling m_setname or making it oper only, is that features should not have to be disabled just because they could be abused as in the end, any command could be abused.

Regards,

Koragg