### PR TITLE
Fix a minor typo in ssl.h

### DIFF
--- a/include/modules/ssl.h
+++ b/include/modules/ssl.h
@@ -206,7 +206,7 @@ class SSLIOHook : public IOHook
 	std::string GetFingerprint() const
 	{
 		ssl_cert* cert = GetCertificate();
-		if (cert && certificate->IsUsable())
+		if (cert && cert->IsUsable())
 			return cert->GetFingerprint();
 		return "";
 	}


### PR DESCRIPTION
This fixes a minor typo created when the IsUsable check was moved to GetFingerprint. certificate is not defined-- rather, the variable here is cert.