### PR TITLE
Add a function for displaying human-readable durations.

### DIFF
--- a/include/inspircd.h
+++ b/include/inspircd.h
@@ -516,6 +516,12 @@ class CoreExport InspIRCd
 	 */
 	static bool IsValidDuration(const std::string& str);
 
+	/** Return a duration in seconds as a human-readable string.
+	 * @param duration The duration in seconds to convert to a human-readable string.
+	 * @return A string representing the given duration.
+	 */
+	static std::string DurationString(time_t duration);
+
 	/** Attempt to compare a password to a string from the config file.
 	 * This will be passed to handling modules which will compare the data
 	 * against possible hashed equivalents in the input string.

--- a/src/coremods/core_xline/cmd_eline.cpp
+++ b/src/coremods/core_xline/cmd_eline.cpp
@@ -69,14 +69,13 @@ CmdResult CommandEline::Handle(User* user, const Params& parameters)
 		{
 			if (!duration)
 			{
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added permanent E-line for %s: %s", user->nick.c_str(), target.c_str(), parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added permanent E-line for %s: %s", user->nick.c_str(), target.c_str(), parameters[2].c_str());
 			}
 			else
 			{
-				time_t c_requires_crap = duration + ServerInstance->Time();
-				std::string timestr = InspIRCd::TimeString(c_requires_crap);
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added timed E-line for %s, expires on %s: %s",user->nick.c_str(),target.c_str(),
-						timestr.c_str(), parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added timed E-line for %s, expires in %s (on %s): %s",
+					user->nick.c_str(), target.c_str(), InspIRCd::DurationString(duration).c_str(),
+					InspIRCd::TimeString(ServerInstance->Time() + duration).c_str(), parameters[2].c_str());
 			}
 		}
 		else

--- a/src/coremods/core_xline/cmd_gline.cpp
+++ b/src/coremods/core_xline/cmd_gline.cpp
@@ -75,14 +75,13 @@ CmdResult CommandGline::Handle(User* user, const Params& parameters)
 		{
 			if (!duration)
 			{
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added permanent G-line for %s: %s",user->nick.c_str(),target.c_str(), parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added permanent G-line for %s: %s", user->nick.c_str(), target.c_str(), parameters[2].c_str());
 			}
 			else
 			{
-				time_t c_requires_crap = duration + ServerInstance->Time();
-				std::string timestr = InspIRCd::TimeString(c_requires_crap);
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added timed G-line for %s, expires on %s: %s",user->nick.c_str(),target.c_str(),
-						timestr.c_str(), parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added timed G-line for %s, expires in %s (on %s): %s",
+					user->nick.c_str(), target.c_str(), InspIRCd::DurationString(duration).c_str(),
+					InspIRCd::TimeString(ServerInstance->Time() + duration).c_str(), parameters[2].c_str());
 			}
 
 			ServerInstance->XLines->ApplyLines();

--- a/src/coremods/core_xline/cmd_kline.cpp
+++ b/src/coremods/core_xline/cmd_kline.cpp
@@ -75,14 +75,13 @@ CmdResult CommandKline::Handle(User* user, const Params& parameters)
 		{
 			if (!duration)
 			{
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added permanent K-line for %s: %s",user->nick.c_str(),target.c_str(), parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added permanent K-line for %s: %s", user->nick.c_str(), target.c_str(), parameters[2].c_str());
 			}
 			else
 			{
-				time_t c_requires_crap = duration + ServerInstance->Time();
-				std::string timestr = InspIRCd::TimeString(c_requires_crap);
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added timed K-line for %s, expires on %s: %s",user->nick.c_str(),target.c_str(),
-						timestr.c_str(), parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added timed K-line for %s, expires in %s (on %s): %s",
+					user->nick.c_str(), target.c_str(), InspIRCd::DurationString(duration).c_str(),
+					InspIRCd::TimeString(ServerInstance->Time() + duration).c_str(), parameters[2].c_str());
 			}
 
 			ServerInstance->XLines->ApplyLines();

--- a/src/coremods/core_xline/cmd_qline.cpp
+++ b/src/coremods/core_xline/cmd_qline.cpp
@@ -55,14 +55,13 @@ CmdResult CommandQline::Handle(User* user, const Params& parameters)
 		{
 			if (!duration)
 			{
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added permanent Q-line for %s: %s",user->nick.c_str(), parameters[0].c_str(), parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added permanent Q-line for %s: %s", user->nick.c_str(), parameters[0].c_str(), parameters[2].c_str());
 			}
 			else
 			{
-				time_t c_requires_crap = duration + ServerInstance->Time();
-				std::string timestr = InspIRCd::TimeString(c_requires_crap);
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added timed Q-line for %s, expires on %s: %s",user->nick.c_str(),parameters[0].c_str(),
-						timestr.c_str(), parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added timed Q-line for %s, expires in %s (on %s): %s",
+					user->nick.c_str(), parameters[0].c_str(), InspIRCd::DurationString(duration).c_str(),
+					InspIRCd::TimeString(ServerInstance->Time() + duration).c_str(), parameters[2].c_str());
 			}
 			ServerInstance->XLines->ApplyLines();
 		}

--- a/src/coremods/core_xline/cmd_zline.cpp
+++ b/src/coremods/core_xline/cmd_zline.cpp
@@ -73,14 +73,13 @@ CmdResult CommandZline::Handle(User* user, const Params& parameters)
 		{
 			if (!duration)
 			{
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added permanent Z-line for %s: %s", user->nick.c_str(), ipaddr, parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added permanent Z-line for %s: %s", user->nick.c_str(), ipaddr, parameters[2].c_str());
 			}
 			else
 			{
-				time_t c_requires_crap = duration + ServerInstance->Time();
-				std::string timestr = InspIRCd::TimeString(c_requires_crap);
-				ServerInstance->SNO->WriteToSnoMask('x',"%s added timed Z-line for %s, expires on %s: %s",user->nick.c_str(),ipaddr,
-						timestr.c_str(), parameters[2].c_str());
+				ServerInstance->SNO->WriteToSnoMask('x', "%s added timed Z-line for %s, expires in %s (on %s): %s",
+					user->nick.c_str(), ipaddr, InspIRCd::DurationString(duration).c_str(),
+					InspIRCd::TimeString(ServerInstance->Time() + duration).c_str(), parameters[2].c_str());
 			}
 			ServerInstance->XLines->ApplyLines();
 		}

--- a/src/helperfuncs.cpp
+++ b/src/helperfuncs.cpp
@@ -7,6 +7,7 @@
  *   Copyright (C) 2008 Thomas Stagner <aquanight@inspircd.org>
  *   Copyright (C) 2006-2007 Oliver Lupton <oliverlupton@gmail.com>
  *   Copyright (C) 2007 Dennis Friis <peavey@inspircd.org>
+ *   Copyright (C) 2003-2019 Anope Team <team@anope.org>
  *
  * This file is part of InspIRCd.  InspIRCd is free software: you can
  * redistribute it and/or modify it under the terms of the GNU General Public
@@ -427,6 +428,33 @@ bool InspIRCd::IsValidDuration(const std::string& duration)
 			return false;
 	}
 	return true;
+}
+
+std::string InspIRCd::DurationString(time_t duration)
+{
+	time_t years = duration / 31536000;
+	time_t weeks = (duration / 604800) % 52;
+	time_t days = (duration / 86400) % 7;
+	time_t hours = (duration / 3600) % 24;
+	time_t minutes = (duration / 60) % 60;
+	time_t seconds = duration % 60;
+
+	std::string ret;
+
+	if (years)
+		ret = ConvToStr(years) + "y";
+	if (weeks)
+		ret += ConvToStr(weeks) + "w";
+	if (days)
+		ret += ConvToStr(days) + "d";
+	if (hours)
+		ret += ConvToStr(hours) + "h";
+	if (minutes)
+		ret += ConvToStr(minutes) + "m";
+	if (seconds)
+		ret += ConvToStr(seconds) + "s";
+
+	return ret;
 }
 
 std::string InspIRCd::Format(va_list& vaList, const char* formatString)

--- a/src/modules/m_cban.cpp
+++ b/src/modules/m_cban.cpp
@@ -130,9 +130,9 @@ class CommandCBan : public Command
 				}
 				else
 				{
-					time_t c_requires_crap = duration + ServerInstance->Time();
-					std::string timestr = InspIRCd::TimeString(c_requires_crap);
-					ServerInstance->SNO->WriteGlobalSno('x', "%s added timed CBan for %s, expires on %s: %s", user->nick.c_str(), parameters[0].c_str(), timestr.c_str(), reason);
+					ServerInstance->SNO->WriteGlobalSno('x', "%s added timed CBan for %s, expires in %s (on %s): %s",
+						user->nick.c_str(), parameters[0].c_str(), InspIRCd::DurationString(duration).c_str(),
+						InspIRCd::TimeString(ServerInstance->Time() + duration).c_str(), reason);
 				}
 			}
 			else

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -235,7 +235,7 @@ class CommandDccallow : public Command
 
 					if (length > 0)
 					{
-						user->WriteNumeric(RPL_DCCALLOWTIMED, user->nick, InspIRCd::Format("Added %s to DCCALLOW list for %ld seconds", target->nick.c_str(), length));
+						user->WriteNumeric(RPL_DCCALLOWTIMED, user->nick, InspIRCd::Format("Added %s to DCCALLOW list for %s", target->nick.c_str(), InspIRCd::DurationString(length).c_str()));
 					}
 					else
 					{

--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -147,9 +147,9 @@ class DNSBLResolver : public DNS::Request
 							"*", them->GetIPString());
 					if (ServerInstance->XLines->AddLine(kl,NULL))
 					{
-						std::string timestr = InspIRCd::TimeString(kl->expiry);
-						ServerInstance->SNO->WriteGlobalSno('x', "K-line added due to DNSBL match on *@%s to expire on %s: %s",
-							them->GetIPString().c_str(), timestr.c_str(), reason.c_str());
+						ServerInstance->SNO->WriteGlobalSno('x', "K-line added due to DNSBL match on *@%s to expire in %s (on %s): %s",
+							them->GetIPString().c_str(), InspIRCd::DurationString(kl->duration).c_str(),
+							InspIRCd::TimeString(kl->expiry).c_str(), reason.c_str());
 						ServerInstance->XLines->ApplyLines();
 					}
 					else
@@ -165,9 +165,9 @@ class DNSBLResolver : public DNS::Request
 							"*", them->GetIPString());
 					if (ServerInstance->XLines->AddLine(gl,NULL))
 					{
-						std::string timestr = InspIRCd::TimeString(gl->expiry);
-						ServerInstance->SNO->WriteGlobalSno('x', "G-line added due to DNSBL match on *@%s to expire on %s: %s",
-							them->GetIPString().c_str(), timestr.c_str(), reason.c_str());
+						ServerInstance->SNO->WriteGlobalSno('x', "G-line added due to DNSBL match on *@%s to expire in %s (on %s): %s",
+							them->GetIPString().c_str(), InspIRCd::DurationString(gl->duration).c_str(),
+							InspIRCd::TimeString(gl->expiry).c_str(), reason.c_str());
 						ServerInstance->XLines->ApplyLines();
 					}
 					else
@@ -183,9 +183,9 @@ class DNSBLResolver : public DNS::Request
 							them->GetIPString());
 					if (ServerInstance->XLines->AddLine(zl,NULL))
 					{
-						std::string timestr = InspIRCd::TimeString(zl->expiry);
-						ServerInstance->SNO->WriteGlobalSno('x', "Z-line added due to DNSBL match on %s to expire on %s: %s",
-							them->GetIPString().c_str(), timestr.c_str(), reason.c_str());
+						ServerInstance->SNO->WriteGlobalSno('x', "Z-line added due to DNSBL match on %s to expire in %s (on %s): %s",
+							them->GetIPString().c_str(), InspIRCd::DurationString(zl->duration).c_str(),
+							InspIRCd::TimeString(zl->expiry).c_str(), reason.c_str());
 						ServerInstance->XLines->ApplyLines();
 					}
 					else

--- a/src/modules/m_rline.cpp
+++ b/src/modules/m_rline.cpp
@@ -80,9 +80,9 @@ class RLine : public XLine
 			ZLine* zl = new ZLine(ServerInstance->Time(), duration ? expiry - ServerInstance->Time() : 0, ServerInstance->Config->ServerName.c_str(), reason.c_str(), u->GetIPString());
 			if (ServerInstance->XLines->AddLine(zl, NULL))
 			{
-				std::string timestr = InspIRCd::TimeString(zl->expiry);
-				ServerInstance->SNO->WriteToSnoMask('x', "Z-line added due to R-line match on %s%s%s: %s",
-					zl->ipaddr.c_str(), zl->duration ? " to expire on " : "", zl->duration ? timestr.c_str() : "", zl->reason.c_str());
+				std::string expirystr = zl->duration ? InspIRCd::Format(" to expire in %s (on %s)", InspIRCd::DurationString(zl->duration).c_str(), InspIRCd::TimeString(zl->expiry).c_str()) : "";
+				ServerInstance->SNO->WriteToSnoMask('x', "Z-line added due to R-line match on %s%s: %s",
+					zl->ipaddr.c_str(), expirystr.c_str(), zl->reason.c_str());
 				added_zline = true;
 			}
 			else
@@ -174,9 +174,9 @@ class CommandRLine : public Command
 					}
 					else
 					{
-						time_t c_requires_crap = duration + ServerInstance->Time();
-						std::string timestr = InspIRCd::TimeString(c_requires_crap);
-						ServerInstance->SNO->WriteToSnoMask('x', "%s added timed R-line for %s to expire on %s: %s", user->nick.c_str(), parameters[0].c_str(), timestr.c_str(), parameters[2].c_str());
+						ServerInstance->SNO->WriteToSnoMask('x', "%s added timed R-line for %s to expire in %s (on %s): %s",
+							user->nick.c_str(), parameters[0].c_str(), InspIRCd::DurationString(duration).c_str(),
+							InspIRCd::TimeString(ServerInstance->Time() + duration).c_str(), parameters[2].c_str());
 					}
 
 					ServerInstance->XLines->ApplyLines();

--- a/src/modules/m_shun.cpp
+++ b/src/modules/m_shun.cpp
@@ -110,15 +110,14 @@ class CommandShun : public Command
 			{
 				if (!duration)
 				{
-					ServerInstance->SNO->WriteToSnoMask('x',"%s added permanent SHUN for %s: %s",
+					ServerInstance->SNO->WriteToSnoMask('x', "%s added permanent SHUN for %s: %s",
 						user->nick.c_str(), target.c_str(), expr.c_str());
 				}
 				else
 				{
-					time_t c_requires_crap = duration + ServerInstance->Time();
-					std::string timestr = InspIRCd::TimeString(c_requires_crap);
-					ServerInstance->SNO->WriteToSnoMask('x', "%s added timed SHUN for %s to expire on %s: %s",
-						user->nick.c_str(), target.c_str(), timestr.c_str(), expr.c_str());
+					ServerInstance->SNO->WriteToSnoMask('x', "%s added timed SHUN for %s to expire in %s (on %s): %s",
+						user->nick.c_str(), target.c_str(), InspIRCd::DurationString(duration).c_str(),
+						InspIRCd::TimeString(ServerInstance->Time() + duration).c_str(), expr.c_str());
 				}
 			}
 			else

--- a/src/modules/m_spanningtree/addline.cpp
+++ b/src/modules/m_spanningtree/addline.cpp
@@ -50,14 +50,16 @@ CmdResult CommandAddLine::Handle(User* usr, Params& params)
 	{
 		if (xl->duration)
 		{
-			std::string timestr = InspIRCd::TimeString(xl->expiry);
-			ServerInstance->SNO->WriteToSnoMask('X',"%s added %s%s on %s to expire on %s: %s",setter.c_str(),params[0].c_str(),params[0].length() == 1 ? "-line" : "",
-					params[1].c_str(), timestr.c_str(), params[5].c_str());
+			ServerInstance->SNO->WriteToSnoMask('X', "%s added %s%s on %s to expire in %s (on %s): %s",
+				setter.c_str(), params[0].c_str(), params[0].length() == 1 ? "-line" : "",
+				params[1].c_str(), InspIRCd::DurationString(xl->duration).c_str(),
+				InspIRCd::TimeString(xl->expiry).c_str(), params[5].c_str());
 		}
 		else
 		{
-			ServerInstance->SNO->WriteToSnoMask('X',"%s added permanent %s%s on %s: %s",setter.c_str(),params[0].c_str(),params[0].length() == 1 ? "-line" : "",
-					params[1].c_str(),params[5].c_str());
+			ServerInstance->SNO->WriteToSnoMask('X', "%s added permanent %s%s on %s: %s",
+				setter.c_str(), params[0].c_str(), params[0].length() == 1 ? "-line" : "",
+				params[1].c_str(), params[5].c_str());
 		}
 
 		TreeServer* remoteserver = TreeServer::Get(usr);

--- a/src/modules/m_svshold.cpp
+++ b/src/modules/m_svshold.cpp
@@ -58,8 +58,8 @@ public:
 	{
 		if (!silent)
 		{
-			ServerInstance->SNO->WriteToSnoMask('x', "Removing expired SVSHOLD %s (set by %s %ld seconds ago): %s",
-				nickname.c_str(), source.c_str(), (long)(ServerInstance->Time() - set_time), reason.c_str());
+			ServerInstance->SNO->WriteToSnoMask('x', "Removing expired SVSHOLD %s (set by %s %s ago): %s",
+				nickname.c_str(), source.c_str(), InspIRCd::DurationString(ServerInstance->Time() - set_time).c_str(), reason.c_str());
 		}
 	}
 

--- a/src/modules/m_timedbans.cpp
+++ b/src/modules/m_timedbans.cpp
@@ -118,7 +118,7 @@ class CommandTban : public Command
 		T.chan = channel;
 		TimedBanList.push_back(T);
 
-		const std::string addban = user->nick + " added a timed ban on " + mask + " lasting for " + ConvToStr(duration) + " seconds.";
+		const std::string addban = user->nick + " added a timed ban on " + mask + " lasting for " + InspIRCd::DurationString(duration) + ".";
 		// If halfop is loaded, send notice to halfops and above, otherwise send to ops and above
 		PrefixMode* mh = ServerInstance->Modes->FindPrefixMode('h');
 		char pfxchar = (mh && mh->name == "halfop") ? mh->GetPrefix() : '@';

--- a/src/xline.cpp
+++ b/src/xline.cpp
@@ -682,8 +682,8 @@ void ELine::OnAdd()
 void XLine::DisplayExpiry()
 {
 	bool onechar = (type.length() == 1);
-	ServerInstance->SNO->WriteToSnoMask('x', "Removing expired %s%s %s (set by %s %ld seconds ago): %s",
-		type.c_str(), (onechar ? "-line" : ""), Displayable().c_str(), source.c_str(), (long)(ServerInstance->Time() - set_time), reason.c_str());
+	ServerInstance->SNO->WriteToSnoMask('x', "Removing expired %s%s %s (set by %s %s ago): %s",
+		type.c_str(), (onechar ? "-line" : ""), Displayable().c_str(), source.c_str(), InspIRCd::DurationString(ServerInstance->Time() - set_time).c_str(), reason.c_str());
 }
 
 const std::string& ELine::Displayable()


### PR DESCRIPTION
This adds a (helper) function of `InspIRCd::DurationString(time_t)` that returns a string containing the duration in a human-readable format. The format matches that of current InspIRCd duration inputs (ex: 1y20w2d3h5m9s). The function is based off Anope's `Anope::Duration()`, modified to add weeks and output short text format.

Switched to use this function:
* X-line expiries: from `600 seconds ago` to `10m ago`.
* X-line additions: from `expires on <date>` to `expires in 1d12h (on <date>)`.
* Timed ban additions: from `lasting for 600 seconds` to `lasting for 10m`.
* DCC Allow: from `for 600 seconds` to `for 10m`.

Closes #1574.