### PR TITLE
Improve the handling of config X-lines and filters.

### DIFF
--- a/include/xline.h
+++ b/include/xline.h
@@ -515,8 +515,9 @@ class CoreExport XLineManager
 	/** Expire a line given two iterators which identify it in the main map.
 	 * @param container Iterator to the first level of entries the map
 	 * @param item Iterator to the second level of entries in the map
+	 * @param silent If true, doesn't send an expiry SNOTICE.
 	 */
-	void ExpireLine(ContainerIter container, LookupIter item);
+	void ExpireLine(ContainerIter container, LookupIter item, bool silent = false);
 
 	/** Apply any new lines that are pending to be applied.
 	 * This will only apply lines in the pending_lines list, to save on
@@ -533,6 +534,6 @@ class CoreExport XLineManager
 	 */
 	void InvokeStats(const std::string& type, unsigned int numeric, Stats::Context& stats);
 
-	/** Clears any XLines which were added by the server configuration. */
-	void ClearConfigLines();
+	/** Expire X-lines which were added by the server configuration and have been removed. */
+	void ExpireRemovedConfigLines(const std::string& type, const insp::flat_set<std::string>& configlines);
 };

--- a/src/modules/m_xline_db.cpp
+++ b/src/modules/m_xline_db.cpp
@@ -51,7 +51,8 @@ class ModuleXLineDB : public Module
 	 */
 	void OnAddLine(User* source, XLine* line) CXX11_OVERRIDE
 	{
-		dirty = true;
+		if (!line->from_config)
+			dirty = true;
 	}
 
 	/** Called whenever an xline is deleted.
@@ -61,7 +62,8 @@ class ModuleXLineDB : public Module
 	 */
 	void OnDelLine(User* source, XLine* line) CXX11_OVERRIDE
 	{
-		dirty = true;
+		if (!line->from_config)
+			dirty = true;
 	}
 
 	void OnBackgroundTimer(time_t now) CXX11_OVERRIDE
@@ -113,6 +115,9 @@ class ModuleXLineDB : public Module
 			for (LookupIter i = lookup->begin(); i != lookup->end(); ++i)
 			{
 				XLine* line = i->second;
+				if (line->from_config)
+					continue;
+
 				stream << "LINE " << line->type << " " << line->Displayable() << " "
 					<< line->source << " " << line->set_time << " "
 					<< line->duration << " :" << line->reason << std::endl;


### PR DESCRIPTION
#### X-lines:
* Prevent xline_db from saving config X-lines as this is unnecessary and can cause weirdness or 'almost' duplicated X-lines to exist.
- On Rehash:
  * Allow a config X-line to replace an existing X-line if:
    * The existing X-line is not a config line, or
    * The existing X-line is a config line but the reason changed.
  * Compare the existing X-lines to a list of the newly read config X-lines and only expire those that are no longer configured.  

This prevents the extra noise during a rehash by only expiring the `badhost, badip, badnick, and exception` tags that were actually removed. If any of the aforementioned tags have a changed `reason`, the existing X-line will be expired and the new one added (mimicking behavior of the forced removal). Also allow the replacement (expire and add new) of an existing, non-config, X-line with a newly defined config X-line.

#### Filters:
* Change the addition of a config filter to use the existing AddFilter() function. This prevents being able to configure multiple filters with the same patterns. AddFilter() now takes an additional parameter (`bool config`) to set the appropriate flag for `from_config`.

- On Rehash:
  * Continue to remove all config defined filters, as various parameters to each pattern may have been changed.
  * Keep a list of the removed filters, erasing a pattern if it has been successfully added as a filter again.
  * Send an SNOTICE for each of the remaining filter patterns that were actually removed.  

This again prevents the extra noise during a rehash as all config filters are removed and re-added, by only sending notices for the actually removed filters. Also fix a possible bug of defining multiple filters with the same pattern in the config.

Resolves #1577.