### PR TITLE
Fix BanCache entries existing after X-line expiry.

### DIFF
--- a/src/xline.cpp
+++ b/src/xline.cpp
@@ -541,7 +541,7 @@ void XLine::DefaultApply(User* u, const std::string &line, bool bancache)
 	{
 		ServerInstance->Logs->Log("BANCACHE", DEBUG, "BanCache: Adding positive hit (" + line + ") for " + u->GetIPString());
 		if (this->duration > 0)
-			ServerInstance->BanCache->AddHit(u->GetIPString(), this->type, line + "-Lined: " + this->reason, this->duration);
+			ServerInstance->BanCache->AddHit(u->GetIPString(), this->type, line + "-Lined: " + this->reason, (this->expiry - ServerInstance->Time()));
 		else
 			ServerInstance->BanCache->AddHit(u->GetIPString(), this->type, line + "-Lined: " + this->reason);
 	}


### PR DESCRIPTION
> When DefaultApply() adds a hit to the BanCache it uses the X-line duration to set a duration on the entry. This can result in an entry lasting longer than the X-line itself. Fix this by setting the entry duration to the time left on the X-line.

Example: G-line `*@xxx.*` for 5m. Wait 4m, connect a matching client, attempt registration and get banned. Try connecting again and note the instant block, as BanCache is working. Wait roughly 1m (expiry of G-line) and run /stats g to force expiry. Try connecting again, the BanCache entry still exists and will for another 4m, blocking connection.