### PR TITLE
noctcp: Bugfix and add oper privs to allow overriding.

### DIFF
--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -27,12 +27,14 @@
      #   - users/mass-message: allows opers with this priv to PRIVMSG and NOTICE to a server mask (e.g. NOTICE $*).
      #   - users/samode-usermodes: allows opers with this priv to change the user modes of any other user using /SAMODE.
      # PERMISSIONS:
+     #   - channels/ignore-noctcp: allows opers with this priv to send a CTCP to a +C channel.
      #   - channels/ignore-nonicks: allows opers with this priv to change their nick when on a +N channel.
      #   - channels/restricted-create: allows opers with this priv to create channels if the restrictchans module is loaded.
      #   - users/flood/no-fakelag: prevents opers from being penalized with fake lag for flooding (*NOTE).
      #   - users/flood/no-throttle: allows opers with this priv to send commands without being throttled (*NOTE).
      #   - users/flood/increased-buffers: allows opers with this priv to send and receive data without worrying about being disconnected for exceeding limits (*NOTE).
      #   - users/callerid-override: allows opers with this priv to message people using callerid without being on their callerid list.
+     #   - users/ignore-noctcp: allows opers with this priv to send a CTCP to a +T user.
      #   - users/sajoin-others: allows opers with this priv to /SAJOIN users other than themselves.
      #   - servers/use-disabled-commands: allows opers with this priv to use disabled commands.
      #   - servers/use-disabled-modes: allows opers with this priv to use disabled modes.

--- a/src/modules/m_noctcp.cpp
+++ b/src/modules/m_noctcp.cpp
@@ -80,7 +80,7 @@ class ModuleNoCTCP : public Module
 			if (u->IsModeSet(ncu))
 			{
 				user->WriteNumeric(ERR_CANTSENDTOUSER, u->nick, "Can't send CTCP to user (+T set)");
-				return MOD_RES_PASSTHRU;
+				return MOD_RES_DENY;
 			}
 		}
 		return MOD_RES_PASSTHRU;

--- a/src/modules/m_noctcp.cpp
+++ b/src/modules/m_noctcp.cpp
@@ -63,6 +63,9 @@ class ModuleNoCTCP : public Module
 
 		if (target.type == MessageTarget::TYPE_CHANNEL)
 		{
+			if (user->HasPrivPermission("channels/ignore-noctcp"))
+				return MOD_RES_PASSTHRU;
+
 			Channel* c = target.Get<Channel>();
 			ModResult res = CheckExemption::Call(exemptionprov, user, c, "noctcp");
 			if (res == MOD_RES_ALLOW)
@@ -76,6 +79,9 @@ class ModuleNoCTCP : public Module
 		}
 		else if (target.type == MessageTarget::TYPE_USER)
 		{
+			if (user->HasPrivPermission("users/ignore-noctcp"))
+				return MOD_RES_PASSTHRU;
+
 			User* u = target.Get<User>();
 			if (u->IsModeSet(ncu))
 			{


### PR DESCRIPTION
Found an incorrect ModResult return when adding the oper privs, allowing the CTCP to still go through when "blocked" to a user target. This corrects that and adds the oper privs for both channel and user targets.

Resolves #1591.