### PR TITLE
Check perms for removal of oper-only channel modes.

### DIFF
--- a/src/mode.cpp
+++ b/src/mode.cpp
@@ -312,18 +312,18 @@ ModeAction ModeParser::TryMode(User* user, User* targetuser, Channel* chan, Mode
 		}
 	}
 
-	if ((adding) && (IS_LOCAL(user)) && (mh->NeedsOper()) && (!user->HasModePermission(mh)))
+	if ((chan || (!chan && adding)) && IS_LOCAL(user) && mh->NeedsOper() && !user->HasModePermission(mh))
 	{
 		/* It's an oper only mode, and they don't have access to it. */
 		if (user->IsOper())
 		{
-			user->WriteNumeric(ERR_NOPRIVILEGES, InspIRCd::Format("Permission Denied - Oper type %s does not have access to set %s mode %c",
-					user->oper->name.c_str(), type == MODETYPE_CHANNEL ? "channel" : "user", modechar));
+			user->WriteNumeric(ERR_NOPRIVILEGES, InspIRCd::Format("Permission Denied - Oper type %s does not have access to %sset %s mode %c",
+					user->oper->name.c_str(), adding ? "" : "un", type == MODETYPE_CHANNEL ? "channel" : "user", modechar));
 		}
 		else
 		{
-			user->WriteNumeric(ERR_NOPRIVILEGES, InspIRCd::Format("Permission Denied - Only operators may set %s mode %c",
-					type == MODETYPE_CHANNEL ? "channel" : "user", modechar));
+			user->WriteNumeric(ERR_NOPRIVILEGES, InspIRCd::Format("Permission Denied - Only operators may %sset %s mode %c",
+					adding ? "" : "un", type == MODETYPE_CHANNEL ? "channel" : "user", modechar));
 		}
 		return MODEACTION_DENY;
 	}


### PR DESCRIPTION
> Oper-only channel modes are currently unsettable by any channel op, oper or not. Correct this by checking both directions of an oper-only channel mode and continue only checking the setting of
an oper-only user mode. As anyone should be able to unset their own user modes and UnOper() removes all oper-only user modes automatically.

This keeps proper removal of oper-only user modes during UnOper() and prevents non-opers or opers without the given channel mode permission from removing said channel modes.