### PR TITLE
Merge extras/m_privdeaf into m_deaf and update documentation.

### DIFF
--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -853,6 +853,8 @@ using their cloak when they quit.">
  z            Only allow private messages from SSL users (requires the
               sslmode module).
  B            Marks as a bot (requires the botmode module).
+ D            Privdeaf mode. User will not receive any private messages
+              or notices from users (requires the deaf module).
  G            Censors messages sent to the user based on filters
               configured for the network (requires the censor module).
  H            Hides an oper's oper status from WHOIS (requires the

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -719,9 +719,24 @@
 #<banfile pattern="*.txt" action="allow">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# Deaf module: Adds support for the usermode +d - deaf to channel
-# messages and channel notices.
+# Deaf module: Adds support for the usermodes +dD:
+# d - deaf to channel messages and notices.
+# D - deaf to user messages and notices.
+# The +D user mode is not enabled by default to enable link compatibility
+# with 2.0 servers.
 #<module name="deaf">
+#
+#-#-#-#-#-#-#-#-#-#-#-#-  DEAF CONFIGURATION   -#-#-#-#-#-#-#-#-#-#-#-#
+#  bypasschars       - Characters that bypass deaf to a regular user.
+#  bypasscharsuline  - Characters that bypass deaf to a U-lined user (services).
+#                      Both of these take a list of characters that must match
+#                      the starting character of a message.
+#                      If 'bypasscharsuline' is empty, then 'bypasschars' will
+#                      match for both regular and U-lined users.
+#  enableprivdeaf    - Whether to enable usermode +D (privdeaf).
+#  privdeafuline     - Whether U-lined users bypass usermode +D (privdeaf).A
+#
+#<deaf bypasschars="" bypasscharsuline="!" enableprivdeaf="no" privdeafuline="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Delay join module: Adds the channel mode +D which delays all JOIN

--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -36,6 +36,7 @@
      #   - users/callerid-override: allows opers with this priv to message people using callerid without being on their callerid list.
      #   - users/ignore-commonchans: allows opers with this priv to send a message to a +c user without sharing common channels.
      #   - users/ignore-noctcp: allows opers with this priv to send a CTCP to a +T user.
+     #   - users/privdeaf-override: allows opers with this priv to message users with +D set.
      #   - users/sajoin-others: allows opers with this priv to /SAJOIN users other than themselves.
      #   - servers/use-disabled-commands: allows opers with this priv to use disabled commands.
      #   - servers/use-disabled-modes: allows opers with this priv to use disabled modes.

--- a/src/modules/m_deaf.cpp
+++ b/src/modules/m_deaf.cpp
@@ -4,6 +4,7 @@
  *   Copyright (C) 2006, 2008 Craig Edwards <craigedwards@brainbox.cc>
  *   Copyright (C) 2007 Robin Burchell <robin+git@viroteck.net>
  *   Copyright (C) 2006-2007 Dennis Friis <peavey@inspircd.org>
+ *   Copyright (C) 2012 satmd <satmd@satmd.dyndns.org>
  *
  * This file is part of InspIRCd.  InspIRCd is free software: you can
  * redistribute it and/or modify it under the terms of the GNU General Public
@@ -21,12 +22,11 @@
 
 #include "inspircd.h"
 
-/** User mode +d - filter out channel messages and channel notices
- */
-class User_d : public ModeHandler
+// User mode +d - filter out channel messages and channel notices
+class DeafMode : public ModeHandler
 {
  public:
-	User_d(Module* Creator) : ModeHandler(Creator, "deaf", 'd', PARAM_NONE, MODETYPE_USER) { }
+	DeafMode(Module* Creator) : ModeHandler(Creator, "deaf", 'd', PARAM_NONE, MODETYPE_USER) { }
 
 	ModeAction OnModeChange(User* source, User* dest, Channel* channel, std::string& parameter, bool adding) CXX11_OVERRIDE
 	{
@@ -41,15 +41,41 @@ class User_d : public ModeHandler
 	}
 };
 
+// User mode +D - filter out user messages and user notices
+class PrivDeafMode : public ModeHandler
+{
+ public:
+	PrivDeafMode(Module* Creator) : ModeHandler(Creator, "privdeaf", 'D', PARAM_NONE, MODETYPE_USER)
+	{
+		if (!ServerInstance->Config->ConfValue("deaf")->getBool("enableprivdeaf"))
+			DisableAutoRegister();
+	}
+
+	ModeAction OnModeChange(User* source, User* dest, Channel* channel, std::string& parameter, bool adding) CXX11_OVERRIDE
+	{
+		if (adding == dest->IsModeSet(this))
+			return MODEACTION_DENY;
+
+		if (adding)
+			dest->WriteNotice("*** You have enabled usermode +D, private deaf mode. This mode means you WILL NOT receive any messages and notices from any nicks. If you did NOT mean to do this, use /mode " + dest->nick + " -D.");
+
+		dest->SetMode(this, adding);
+		return MODEACTION_ALLOW;
+	}
+};
+
 class ModuleDeaf : public Module
 {
-	User_d m1;
+	DeafMode deafmode;
+	PrivDeafMode privdeafmode;
 	std::string deaf_bypasschars;
 	std::string deaf_bypasschars_uline;
+	bool privdeafuline;
 
  public:
 	ModuleDeaf()
-		: m1(this)
+		: deafmode(this)
+		, privdeafmode(this)
 	{
 	}
 
@@ -58,44 +84,55 @@ class ModuleDeaf : public Module
 		ConfigTag* tag = ServerInstance->Config->ConfValue("deaf");
 		deaf_bypasschars = tag->getString("bypasschars");
 		deaf_bypasschars_uline = tag->getString("bypasscharsuline");
+		privdeafuline = tag->getBool("privdeafuline", true);
 	}
 
 	ModResult OnUserPreMessage(User* user, const MessageTarget& target, MessageDetails& details) CXX11_OVERRIDE
 	{
-		if (target.type != MessageTarget::TYPE_CHANNEL)
-			return MOD_RES_PASSTHRU;
-
-		Channel* chan = target.Get<Channel>();
-		bool is_bypasschar = (deaf_bypasschars.find(details.text[0]) != std::string::npos);
-		bool is_bypasschar_uline = (deaf_bypasschars_uline.find(details.text[0]) != std::string::npos);
-
-		/*
-		 * If we have no bypasschars_uline in config, and this is a bypasschar (regular)
-		 * Than it is obviously going to get through +d, no build required
-		 */
-		if (deaf_bypasschars_uline.empty() && is_bypasschar)
-			return MOD_RES_PASSTHRU;
-
-		const Channel::MemberMap& ulist = chan->GetUsers();
-		for (Channel::MemberMap::const_iterator i = ulist.begin(); i != ulist.end(); ++i)
+		if (target.type == MessageTarget::TYPE_CHANNEL)
 		{
-			/* not +d ? */
-			if (!i->first->IsModeSet(m1))
-				continue; /* deliver message */
-			/* matched both U-line only and regular bypasses */
+			Channel* chan = target.Get<Channel>();
+			bool is_bypasschar = (deaf_bypasschars.find(details.text[0]) != std::string::npos);
+			bool is_bypasschar_uline = (deaf_bypasschars_uline.find(details.text[0]) != std::string::npos);
+
+			// If we have no bypasschars_uline in config, and this is a bypasschar (regular)
+			// Then it is obviously going to get through +d, no exemption list required
+			if (deaf_bypasschars_uline.empty() && is_bypasschar)
+				return MOD_RES_PASSTHRU;
+			// If it matches both bypasschar and bypasschar_uline, it will get through.
 			if (is_bypasschar && is_bypasschar_uline)
-				continue; /* deliver message */
+				return MOD_RES_PASSTHRU;
 
-			bool is_a_uline = i->first->server->IsULine();
-			/* matched a U-line only bypass */
-			if (is_bypasschar_uline && is_a_uline)
-				continue; /* deliver message */
-			/* matched a regular bypass */
-			if (is_bypasschar && !is_a_uline)
-				continue; /* deliver message */
+			const Channel::MemberMap& ulist = chan->GetUsers();
+			for (Channel::MemberMap::const_iterator i = ulist.begin(); i != ulist.end(); ++i)
+			{
+				// not +d
+				if (!i->first->IsModeSet(deafmode))
+					continue;
 
-			/* don't deliver message! */
-			details.exemptions.insert(i->first);
+				bool is_a_uline = i->first->server->IsULine();
+				// matched a U-line only bypass
+				if (is_bypasschar_uline && is_a_uline)
+					continue;
+				// matched a regular bypass
+				if (is_bypasschar && !is_a_uline)
+					continue;
+
+				// don't deliver message!
+				details.exemptions.insert(i->first);
+			}
+		}
+		else if (target.type == MessageTarget::TYPE_USER)
+		{
+			User* targ = target.Get<User>();
+			if (!targ->IsModeSet(privdeafmode))
+				return MOD_RES_PASSTHRU;
+
+			if (!privdeafuline && user->server->IsULine())
+				return MOD_RES_DENY;
+
+			if (!user->HasPrivPermission("users/privdeaf-override"))
+				return MOD_RES_DENY;
 		}
 
 		return MOD_RES_PASSTHRU;
@@ -103,7 +140,7 @@ class ModuleDeaf : public Module
 
 	Version GetVersion() CXX11_OVERRIDE
 	{
-		return Version("Provides usermode +d to block channel messages and channel notices", VF_VENDOR);
+		return Version("Provides usermodes +dD to block channel and/or user messages and notices", VF_VENDOR);
 	}
 };
 


### PR DESCRIPTION
This merges the 2.0 extras module `m_privdeaf` (usermode +D for deaf to user messages and notices) as they have a similar purpose. Also improve some logic in the original deaf code and tidy up comments.
Updated the documentation with the previously undocumented configuration to deaf and the new privdeaf configuration.