### PR TITLE
Fix compatibility issues between sqloper and postgres

### DIFF
--- a/docs/sql/sqloper.pgsql.sql
+++ b/docs/sql/sqloper.pgsql.sql
@@ -6,8 +6,8 @@ CREATE TABLE ircd_opers (
     "host" text NOT NULL,
     "type" text NOT NULL,
     "fingerprint" text,
-    "autologin" boolean NOT NULL DEFAULT 0,
-    "active" boolean NOT NULL DEFAULT 1
+    "autologin" smallint NOT NULL DEFAULT 0,
+    "active" smallint NOT NULL DEFAULT 1
 );
 ALTER TABLE ONLY ircd_opers
     ADD CONSTRAINT ircd_opers_pkey PRIMARY KEY (id);

--- a/src/modules/m_sqloper.cpp
+++ b/src/modules/m_sqloper.cpp
@@ -96,6 +96,7 @@ class OperQuery : public SQL::Query
 			ifo->class_blocks.assign(tblk->second->class_blocks.begin(), tblk->second->class_blocks.end());
 			oper_blocks[name] = ifo;
 			my_blocks.push_back(name);
+			row.clear();
 		}
 
 		// If this was done as a result of /OPER and not a config read


### PR DESCRIPTION
This PR fixes PostgreSQL compatibility with m_sqloper in InspIRCd 3.0. There were two issues:

First, the PostgreSQL module treats GetRow differently, and as such the row data needed to be cleared at the end of adding an OPER block in sloper.

Second, 1/0 are not synonymous with true/false in PostgreSQL boolean language.