### PR TITLE
m_spanningtree: Ensure tags are sent in forwarded cmds

### DIFF
--- a/src/modules/m_spanningtree/treesocket2.cpp
+++ b/src/modules/m_spanningtree/treesocket2.cpp
@@ -376,11 +376,11 @@ void TreeSocket::ProcessConnectedLine(std::string& taglist, std::string& prefix,
 	}
 
 	CmdResult res;
+	ClientProtocol::TagMap tags;
 	if (scmd)
 		res = scmd->Handle(who, params);
 	else
 	{
-		ClientProtocol::TagMap tags;
 		std::string tag;
 		irc::sepstream tagstream(taglist, ';');
 		while (tagstream.GetToken(tag))
@@ -391,7 +391,7 @@ void TreeSocket::ProcessConnectedLine(std::string& taglist, std::string& prefix,
 	}
 
 	if (res == CMD_SUCCESS)
-		Utils->RouteCommand(server->GetRoute(), cmdbase, params, who);
+		Utils->RouteCommand(server->GetRoute(), cmdbase, CommandBase::Params(params, tags), who);
 }
 
 void TreeSocket::OnTimeout()


### PR DESCRIPTION
When a user (U1) sends a PRIVMSG to a server (S1), which sends it to S2, which finally
sends it to S3 to send to U2, S2 doesn't send the tags it received on
the command from S1 to S3.