### PR TITLE
Update modules.conf.example

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1773,7 +1773,7 @@
 #               less CPU usage. Increasing this beyond 512 doesn't have
 #               any effect, as the maximum length of a message on IRC
 #               cannot exceed that.
-#<repeat maxbacklog="20" maxdistance="50 maxlines="20" maxtime="0" size="512">
+#<repeat maxbacklog="20" maxdistance="50" maxlines="20" maxtime="0" size="512">
 #<module name="repeat">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#


### PR DESCRIPTION
Fixed missing `"` that leads IRCd not to start after un-commenting the `repeat` module options