### PR TITLE
Clarify the require* connect block options and document the sslinfo module operonly option.

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -305,14 +305,24 @@
          # module be loaded as well.
          modes="+x"
 
-         # requireident, requiressl, requireaccount: require that users of this
-         # block have a valid ident response, use SSL, or have authenticated.
-         # Requires ident, sslinfo, or the services_account module, respectively.
-         requiressl="on"
-         # NOTE: For requireaccount, you must complete the signon prior to full
-         # connection. Currently, this is only possible by using SASL
-         # authentication; passforward and PRIVMSG NickServ happen after
-         # your final connect block has been found.
+         # requireident: Require that users of this block have a valid ident response.
+         # Requires the ident module to be loaded.
+         #requireident="yes"
+
+         # requiressl: Require that users of this block use an SSL connection.
+         # This can also be set to "trusted", as to only accept certificates
+         # issued by a certificate authority that you can configure in the
+         # settings of the SSL module that you're using.
+         # Requires the sslinfo module to be loaded.
+         #requiressl="yes"
+
+         # requireaccount: Require that users of this block have authenticated to a
+         # services account.
+         # NOTE: You must complete the signon prior to full connection. Currently,
+         # this is only possible by using SASL authentication; passforward
+         # and PRIVMSG NickServ happen after your final connect block has been found.
+         # Requires the services_account module to be loaded.
+         #requireaccount="yes"
 
          # Alternate MOTD file for this connect class. The contents of this file are
          # specified using <files secretmotd="filename"> or <execfiles ...>

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -2075,7 +2075,7 @@
 #<module name="sslrehashsignal">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# GnuTLS SSL module: Adds support for SSL connections using GnuTLS,
+# GnuTLS SSL module: Adds support for SSL/TLS connections using GnuTLS,
 # if enabled. You must answer 'yes' in ./configure when asked or
 # manually symlink the source for this module from the directory
 # src/modules/extra, if you want to enable this, or it will not load.
@@ -2088,25 +2088,35 @@
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # SSL info module: Allows users to retrieve information about other
-# users' peer SSL certificates and keys. This can be used by client
-# scripts to validate users. For this to work, one of ssl_gnutls
-# or ssl_openssl must be loaded. This module also adds the
-# "* <user> is using a secure connection" whois line, the ability for
-# opers to use SSL cert fingerprints to verify their identity and the
-# ability to force opers to use SSL connections in order to oper up.
-# It is highly recommended to load this module if you use SSL on your
-# network.
-# For how to use the oper features, please see the first example <oper> tag
-# in opers.conf.example.
+# users' peer SSL certificates and keys via the SSLINFO command.
+# This can be used by client scripts to validate users. For this to
+# work, one of ssl_gnutls, ssl_mbedtls or ssl_openssl must be loaded.
+# This module also adds the "<user> is using a secure connection"
+# and "<user> has client certificate fingerprint <fingerprint>"
+# WHOIS lines, the ability for opers to use SSL cert fingerprints to
+# verify their identity and the ability to force opers to use SSL
+# connections in order to oper up. It is highly recommended to load
+# this module if you use SSL on your network.
+# For how to use the oper features, please see the first
+# example <oper> tag in opers.conf.example.
 #
 #<module name="sslinfo">
+#
+# If you want to prevent users from viewing SSL certificate information
+# and fingerprints of other users, set operonly to yes.
+#<sslinfo operonly="no">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # mbedTLS SSL module: Adds support for SSL/TLS connections using mbedTLS.
 #<module name="ssl_mbedtls">
+#
+#-#-#-#-#-#-#-#-#-#-#- MBEDTLS CONFIGURATION   -#-#-#-#-#-#-#-#-#-#-#-#
+#                                                                     #
+# ssl_mbedtls is too complex to describe here, see the docs:          #
+# https://docs.inspircd.org/3/modules/ssl_mbedtls                     #
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
-# OpenSSL SSL module: Adds support for SSL connections using OpenSSL,
+# OpenSSL SSL module: Adds support for SSL/TLS connections using OpenSSL,
 # if enabled. You must answer 'yes' in ./configure when asked or symlink
 # the source for this module from the directory src/modules/extra, if
 # you want to enable this, or it will not load.
@@ -2179,7 +2189,7 @@
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # StartTLS module: Implements STARTTLS, which allows clients          #
 # connected to non SSL enabled ports to enable SSL, if a proper SSL   #
-# module is loaded (either ssl_gnutls or ssl_openssl).                #
+# module is loaded (either ssl_gnutls, ssl_mbedtls or ssl_openssl).   #
 #<module name="starttls">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#


### PR DESCRIPTION
This closes #600.