### PR TITLE
Re-order the includes to fix C++03 builds.

### DIFF
--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -24,9 +24,9 @@
  */
 
 
-#include <iostream>
 #include "inspircd.h"
 #include "exitcodes.h"
+#include <iostream>
 
 #ifndef _WIN32
 	#include <dirent.h>

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -20,9 +20,9 @@
  */
 
 
-#include <signal.h>
-#include "exitcodes.h"
 #include "inspircd.h"
+#include "exitcodes.h"
+#include <signal.h>
 
 void InspIRCd::SignalHandler(int signal)
 {


### PR DESCRIPTION
inspircd.h defines __STDC_LIMIT_MACROS to ensure that C99 int type limits are defined, however, if <stdint.h> is included implicitly before inspircd.h, the build fails due to the C99 integer type limits being undefined.