### PR TITLE
[3.0] Fix space separation for CAPAB module list

### DIFF
--- a/src/modules/m_spanningtree/capab.cpp
+++ b/src/modules/m_spanningtree/capab.cpp
@@ -67,8 +67,7 @@ std::string TreeSocket::MyModules(int filter)
 		if ((!do_compat_include) && (!(v.Flags & filter)))
 			continue;
 
-		if (i != modlist.begin())
-			capabilities.push_back(' ');
+		capabilities.push_back(' ');
 		capabilities.append(i->first);
 		if (!v.link_data.empty())
 		{
@@ -80,12 +79,12 @@ std::string TreeSocket::MyModules(int filter)
 	// If we are linked in a 2.0 server and have an ascii casemapping
 	// advertise it as m_ascii.so from inspircd-extras
 	if ((filter & VF_COMMON) && ServerInstance->Config->CaseMapping == "ascii" && proto_version == PROTO_INSPIRCD_20)
-	{
-		if (!capabilities.empty())
-			capabilities += "m_ascii.so";
-	}
+		capabilities.append(" m_ascii.so");
 
-	return capabilities;
+	if (capabilities.empty())
+		return capabilities;
+
+	return capabilities.substr(1);
 }
 
 std::string TreeSocket::BuildModeList(ModeType mtype)


### PR DESCRIPTION
If the first module in `modlist` is skipped by the initial checks, `i` will never be `modlist.begin()` so there will be an extra space at the beginning of the line. The addition of `m_ascii.so` doesn't handle a space at all. This fixes both issues by always adding a space at the beginning and then just trimming it off at the end.