### PR TITLE
m_haproxy: Initialize address length to 0

### DIFF
--- a/src/modules/m_haproxy.cpp
+++ b/src/modules/m_haproxy.cpp
@@ -367,6 +367,7 @@ class HAProxyHook : public IOHookMiddle
 		: IOHookMiddle(Prov)
 		, sslapi(api)
 		, state(HPS_WAITING_FOR_HEADER)
+		, address_length(0)
 	{
 		sock->AddIOHook(this);
 	}


### PR DESCRIPTION
If the command is LOCAL, the address length isn't set before it is used
in ReadProxyAddress()