### PR TITLE
Fix sending large pages in m_httpd

### DIFF
--- a/include/inspsocket.h
+++ b/include/inspsocket.h
@@ -230,6 +230,8 @@ class CoreExport StreamSocket : public EventHandler
 	/** Whether this socket should close once its sendq is empty */
 	bool closeonempty;
 
+	bool closing;
+
 	/** The IOHook that handles raw I/O for this socket, or NULL */
 	IOHook* iohook;
 
@@ -277,6 +279,7 @@ class CoreExport StreamSocket : public EventHandler
 	const Type type;
 	StreamSocket(Type sstype = SS_UNKNOWN)
 		: closeonempty(false)
+		, closing(false)
 		, iohook(NULL)
 		, type(sstype)
 	{

--- a/include/inspsocket.h
+++ b/include/inspsocket.h
@@ -342,10 +342,8 @@ class CoreExport StreamSocket : public EventHandler
 	 */
 	virtual void Close();
 
-	/**
-	 * Queue the socket to close once all data has been written
-	 */
-	virtual void WriteAllClose();
+	/** If writeblock == True, only close the socket if all data has been sent */
+	void Close(bool writeblock);
 
 	/** This ensures that close is called prior to destructor */
 	CullResult cull() CXX11_OVERRIDE;

--- a/include/inspsocket.h
+++ b/include/inspsocket.h
@@ -342,7 +342,7 @@ class CoreExport StreamSocket : public EventHandler
 	 */
 	virtual void Close();
 
-	/** If writeblock == True, only close the socket if all data has been sent */
+	/** If writeblock is true then only close the socket if all data has been sent. Otherwise, close immediately. */
 	void Close(bool writeblock);
 
 	/** This ensures that close is called prior to destructor */

--- a/include/inspsocket.h
+++ b/include/inspsocket.h
@@ -230,6 +230,7 @@ class CoreExport StreamSocket : public EventHandler
 	/** Whether this socket should close once its sendq is empty */
 	bool closeonempty;
 
+	/** Whether the socket is currently closing or not, used to avoid repeatedly closing a closed socket */
 	bool closing;
 
 	/** The IOHook that handles raw I/O for this socket, or NULL */

--- a/include/inspsocket.h
+++ b/include/inspsocket.h
@@ -227,6 +227,9 @@ class CoreExport StreamSocket : public EventHandler
 	};
 
  private:
+	/** Whether this socket should close once its sendq is empty */
+	bool closeonempty;
+
 	/** The IOHook that handles raw I/O for this socket, or NULL */
 	IOHook* iohook;
 
@@ -273,7 +276,8 @@ class CoreExport StreamSocket : public EventHandler
  public:
 	const Type type;
 	StreamSocket(Type sstype = SS_UNKNOWN)
-		: iohook(NULL)
+		: closeonempty(false)
+		, iohook(NULL)
 		, type(sstype)
 	{
 	}
@@ -334,6 +338,12 @@ class CoreExport StreamSocket : public EventHandler
 	 * Close the socket, remove from socket engine, etc
 	 */
 	virtual void Close();
+
+	/**
+	 * Queue the socket to close once all data has been written
+	 */
+	virtual void WriteAllClose();
+
 	/** This ensures that close is called prior to destructor */
 	CullResult cull() CXX11_OVERRIDE;
 

--- a/src/inspsocket.cpp
+++ b/src/inspsocket.cpp
@@ -206,7 +206,12 @@ static const int MYIOV_MAX = IOV_MAX < 128 ? IOV_MAX : 128;
 void StreamSocket::DoWrite()
 {
 	if (getSendQSize() == 0)
+	{
+		if (closeonempty)
+			Close();
+
 		return;
+	}
 	if (!error.empty() || fd < 0)
 	{
 		ServerInstance->Logs->Log("SOCKET", LOG_DEBUG, "DoWrite on errored or closed socket");
@@ -242,6 +247,9 @@ void StreamSocket::DoWrite()
 
 	if (psendq)
 		FlushSendQ(*psendq);
+
+	if (getSendQSize() == 0 && closeonempty)
+		Close();
 }
 
 void StreamSocket::FlushSendQ(SendQueue& sq)
@@ -520,4 +528,12 @@ size_t StreamSocket::getSendQSize() const
 		curr = iohm->GetNextHook();
 	}
 	return ret;
+}
+
+void StreamSocket::WriteAllClose()
+{
+	if (getSendQSize() == 0)
+		Close();
+	else
+		closeonempty = true;
 }

--- a/src/inspsocket.cpp
+++ b/src/inspsocket.cpp
@@ -95,6 +95,10 @@ BufferedSocketError BufferedSocket::BeginConnect(const irc::sockets::sockaddrs& 
 
 void StreamSocket::Close()
 {
+	if (closing)
+		return;
+
+	closing = true;
 	if (this->fd > -1)
 	{
 		// final chance, dump as much of the sendq as we can

--- a/src/inspsocket.cpp
+++ b/src/inspsocket.cpp
@@ -118,6 +118,14 @@ void StreamSocket::Close()
 	}
 }
 
+void StreamSocket::Close(bool writeblock)
+{
+	if (getSendQSize() != 0 && writeblock)
+		closeonempty = true;
+	else
+		Close();
+}
+
 CullResult StreamSocket::cull()
 {
 	Close();
@@ -532,12 +540,4 @@ size_t StreamSocket::getSendQSize() const
 		curr = iohm->GetNextHook();
 	}
 	return ret;
-}
-
-void StreamSocket::WriteAllClose()
-{
-	if (getSendQSize() == 0)
-		Close();
-	else
-		closeonempty = true;
 }

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -296,7 +296,7 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 	{
 		SendHeaders(s.length(), response, *hheaders);
 		WriteData(s);
-		WriteAllClose();
+		Close(true);
 	}
 
 	void Page(std::stringstream* n, unsigned int response, HTTPHeaders* hheaders)

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -236,9 +236,7 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 			"<html><head></head><body>Server error %u: %s<br>"
 			"<small>Powered by <a href='https://www.inspircd.org'>InspIRCd</a></small></body></html>", response, http_status_str((http_status)response));
 
-		SendHeaders(data.length(), response, empty);
-		WriteData(data);
-		Close();
+		Page(data, response, &empty);
 	}
 
 	void SendHeaders(unsigned long size, unsigned int response, HTTPHeaders &rheaders)
@@ -291,11 +289,16 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 		}
 	}
 
+	void Page(const std::string& s, unsigned int response, HTTPHeaders* hheaders)
+	{
+		SendHeaders(s.length(), response, *hheaders);
+		WriteData(s);
+		Close();
+	}
+
 	void Page(std::stringstream* n, unsigned int response, HTTPHeaders* hheaders)
 	{
-		SendHeaders(n->str().length(), response, *hheaders);
-		WriteData(n->str());
-		Close();
+		return Page(n->str(), response, hheaders);
 	}
 
 	void AddToCull()

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -293,7 +293,7 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 	{
 		SendHeaders(s.length(), response, *hheaders);
 		WriteData(s);
-		Close();
+		WriteAllClose();
 	}
 
 	void Page(std::stringstream* n, unsigned int response, HTTPHeaders* hheaders)

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -72,10 +72,13 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 	/** True if this object is in the cull list
 	 */
 	bool waitingcull;
+	bool messagecomplete;
 
 	bool Tick(time_t currtime) CXX11_OVERRIDE
 	{
-		AddToCull();
+		if (!messagecomplete)
+			AddToCull();
+
 		return false;
 	}
 
@@ -186,6 +189,7 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 
 	int OnMessageComplete()
 	{
+		messagecomplete = true;
 		ServeData();
 		return 0;
 	}
@@ -197,6 +201,7 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 		, ip(IP)
 		, status_code(0)
 		, waitingcull(false)
+		, messagecomplete(false)
 	{
 		if ((!via->iohookprovs.empty()) && (via->iohookprovs.back()))
 		{

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -77,9 +77,12 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 	bool Tick(time_t currtime) CXX11_OVERRIDE
 	{
 		if (!messagecomplete)
+		{
 			AddToCull();
+			return false;
+		}
 
-		return false;
+		return true;
 	}
 
 	template<int (HttpServerSocket::*f)()>
@@ -298,7 +301,7 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 
 	void Page(std::stringstream* n, unsigned int response, HTTPHeaders* hheaders)
 	{
-		return Page(n->str(), response, hheaders);
+		Page(n->str(), response, hheaders);
 	}
 
 	void AddToCull()


### PR DESCRIPTION
Currently m_httpd writes one buffer's worth of data before closing the socket, this fix makes it write the entire buffer and only close once it finishes.