### PR TITLE
Allow opers with 'channels/auspex' to see a secret channel topic.

### DIFF
--- a/src/coremods/core_channel/cmd_topic.cpp
+++ b/src/coremods/core_channel/cmd_topic.cpp
@@ -44,7 +44,7 @@ CmdResult CommandTopic::HandleLocal(LocalUser* user, const Params& parameters)
 
 	if (parameters.size() == 1)
 	{
-		if ((c->IsModeSet(secretmode)) && (!c->HasUser(user)))
+		if ((c->IsModeSet(secretmode)) && (!c->HasUser(user) && !user->HasPrivPermission("channels/auspex")))
 		{
 			user->WriteNumeric(Numerics::NoSuchChannel(c->name));
 			return CMD_FAILURE;


### PR DESCRIPTION
Currently an oper cannot see the topic of a secret channel they aren't in using TOPIC. This was reported on IRC by @KoraggKnightWolf. The priv 'channels/auspex' would imply they should be able to, as LIST will show the topic of such a channel.
Add a check to TOPIC to match the behavior of LIST and meet the expectation.