### PR TITLE
Reset diag pragmas after including external headers

### DIFF
--- a/src/modules/extra/m_ldap.cpp
+++ b/src/modules/extra/m_ldap.cpp
@@ -26,12 +26,20 @@
 #include "inspircd.h"
 #include "modules/ldap.h"
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+#endif
+
 // Ignore OpenLDAP deprecation warnings on OS X Yosemite and newer.
 #if defined __APPLE__
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 #include <ldap.h>
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 #ifdef _WIN32
 # pragma comment(lib, "libldap_r.lib")

--- a/src/modules/extra/m_ldap.cpp
+++ b/src/modules/extra/m_ldap.cpp
@@ -26,18 +26,15 @@
 #include "inspircd.h"
 #include "modules/ldap.h"
 
-#ifdef __GNUC__
-# pragma GCC diagnostic push
-#endif
-
 // Ignore OpenLDAP deprecation warnings on OS X Yosemite and newer.
 #if defined __APPLE__
+# pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 #include <ldap.h>
 
-#ifdef __GNUC__
+#ifdef __APPLE__
 # pragma GCC diagnostic pop
 #endif
 

--- a/src/modules/extra/m_mysql.cpp
+++ b/src/modules/extra/m_mysql.cpp
@@ -28,6 +28,9 @@
 /// $PackageInfo: require_system("debian") libmysqlclient-dev
 /// $PackageInfo: require_system("ubuntu") libmysqlclient-dev
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+#endif
 
 // Fix warnings about the use of `long long` on C++03.
 #if defined __clang__
@@ -39,6 +42,10 @@
 #include "inspircd.h"
 #include <mysql.h>
 #include "modules/sql.h"
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 #ifdef _WIN32
 # pragma comment(lib, "libmysql.lib")

--- a/src/modules/extra/m_regex_re2.cpp
+++ b/src/modules/extra/m_regex_re2.cpp
@@ -28,6 +28,10 @@
 #include "inspircd.h"
 #include "modules/regex.h"
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+#endif
+
 // Fix warnings about the use of `long long` on C++03 and
 // shadowing on GCC.
 #if defined __clang__
@@ -38,6 +42,10 @@
 #endif
 
 #include <re2/re2.h>
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 class RE2Regex : public Regex
 {

--- a/src/modules/extra/m_sqlite3.cpp
+++ b/src/modules/extra/m_sqlite3.cpp
@@ -30,6 +30,10 @@
 #include "inspircd.h"
 #include "modules/sql.h"
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+#endif
+
 // Fix warnings about the use of `long long` on C++03.
 #if defined __clang__
 # pragma clang diagnostic ignored "-Wc++11-long-long"
@@ -38,6 +42,10 @@
 #endif
 
 #include <sqlite3.h>
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 #ifdef _WIN32
 # pragma comment(lib, "sqlite3.lib")

--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -37,6 +37,10 @@
 #include "modules/ssl.h"
 #include <memory>
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+#endif
+
 // Fix warnings about the use of commas at end of enumerator lists on C++03.
 #if defined __clang__
 # pragma clang diagnostic ignored "-Wc++11-extensions"
@@ -53,6 +57,10 @@
 
 #include <gnutls/gnutls.h>
 #include <gnutls/x509.h>
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 #ifndef GNUTLS_VERSION_NUMBER
 #define GNUTLS_VERSION_NUMBER LIBGNUTLS_VERSION_NUMBER

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -34,6 +34,10 @@
 #include "iohook.h"
 #include "modules/ssl.h"
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+#endif
+
 // Ignore OpenSSL deprecation warnings on OS X Lion and newer.
 #if defined __APPLE__
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -49,6 +53,10 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/dh.h>
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 #ifdef _WIN32
 # pragma comment(lib, "ssleay32.lib")

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -28,14 +28,16 @@
 #include "iohook.h"
 #include "modules/httpd.h"
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+#endif
+
 // Fix warnings about the use of commas at end of enumerator lists and long long
 // on C++03.
 #if defined __clang__
-# pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wc++11-extensions"
 # pragma clang diagnostic ignored "-Wc++11-long-long"
 #elif defined __GNUC__
-# pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wlong-long"
 # if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8))
 #  pragma GCC diagnostic ignored "-Wpedantic"
@@ -51,9 +53,7 @@
 
 #include <http_parser.c>
 
-#if defined __clang__
-# pragma clang diagnostic pop
-#elif defined __GNUC__
+#ifdef __GNUC__
 # pragma GCC diagnostic pop
 #endif
 

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -31,9 +31,11 @@
 // Fix warnings about the use of commas at end of enumerator lists and long long
 // on C++03.
 #if defined __clang__
+# pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wc++11-extensions"
 # pragma clang diagnostic ignored "-Wc++11-long-long"
 #elif defined __GNUC__
+# pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wlong-long"
 # if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8))
 #  pragma GCC diagnostic ignored "-Wpedantic"
@@ -44,10 +46,16 @@
 
 // Fix warnings about shadowing in http_parser.
 #ifdef __GNUC__
-//# pragma GCC diagnostic ignored "-Wshadow"
+# pragma GCC diagnostic ignored "-Wshadow"
 #endif
 
 #include <http_parser.c>
+
+#if defined __clang__
+# pragma clang diagnostic pop
+#elif defined __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 class ModuleHttpServer;
 

--- a/src/modules/m_sha256.cpp
+++ b/src/modules/m_sha256.cpp
@@ -22,6 +22,9 @@
 /// $CompilerFlags: -Ivendor_directory("sha2")
 /// $CompilerFlags: require_compiler("GCC") -Wno-long-long
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+#endif
 
 // Fix warnings about the use of `long long` on C++03.
 #if defined __clang__
@@ -34,6 +37,10 @@
 #include "modules/hash.h"
 
 #include <sha2.c>
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 class HashSHA256 : public HashProvider
 {


### PR DESCRIPTION
This allows the disabled warnings to still be applied to the rest of the source code while ignoring the vendored `http_parser.c`.