### PR TITLE
DurationString(): Return "0" for a duration of 0.

### DIFF
--- a/src/helperfuncs.cpp
+++ b/src/helperfuncs.cpp
@@ -433,7 +433,7 @@ bool InspIRCd::IsValidDuration(const std::string& duration)
 std::string InspIRCd::DurationString(time_t duration)
 {
 	if (duration == 0)
-		return "0";
+		return "0s";
 
 	time_t years = duration / 31449600;
 	time_t weeks = (duration / 604800) % 52;

--- a/src/helperfuncs.cpp
+++ b/src/helperfuncs.cpp
@@ -432,6 +432,9 @@ bool InspIRCd::IsValidDuration(const std::string& duration)
 
 std::string InspIRCd::DurationString(time_t duration)
 {
+	if (duration == 0)
+		return "0";
+
 	time_t years = duration / 31449600;
 	time_t weeks = (duration / 604800) % 52;
 	time_t days = (duration / 86400) % 7;


### PR DESCRIPTION
Usually a duration of 0 is not allowed or handled separately, but it can also be used as a 'no set time' without separation.
Case in point: m_chanhistory calls DurationString() to convert the max time seconds back to a human readable string for the mode serializer. Returning a blank string is bad here.