### PR TITLE
DurationString(): Fix years being offset from weeks.

### DIFF
--- a/src/helperfuncs.cpp
+++ b/src/helperfuncs.cpp
@@ -432,7 +432,7 @@ bool InspIRCd::IsValidDuration(const std::string& duration)
 
 std::string InspIRCd::DurationString(time_t duration)
 {
-	time_t years = duration / 31536000;
+	time_t years = duration / 31449600;
 	time_t weeks = (duration / 604800) % 52;
 	time_t days = (duration / 86400) % 7;
 	time_t hours = (duration / 3600) % 24;


### PR DESCRIPTION
Currently a duration of 52w will return a blank string.
When I added weeks to the calculations, I failed to update the number of seconds to a year. As 365 days and 52 weeks aren't the same, but the calculation needs to be consistent.