### PR TITLE
m_geo_maxmind: Skip UNIX sockets in GetLocation().

### DIFF
--- a/src/modules/extra/m_geo_maxmind.cpp
+++ b/src/modules/extra/m_geo_maxmind.cpp
@@ -97,6 +97,10 @@ class GeolocationAPIImpl : public Geolocation::APIBase
 
 	Geolocation::Location* GetLocation(irc::sockets::sockaddrs& sa) CXX11_OVERRIDE
 	{
+		// Skip trying to look up a UNIX socket.
+		if (sa.family() != AF_INET && sa.family() != AF_INET6)
+			return NULL;
+
 		// Attempt to look up the socket address.
 		int result;
 		MMDB_lookup_result_s lookup = MMDB_lookup_sockaddr(&mmdb, &sa.sa, &result);


### PR DESCRIPTION
I was showing as connecting from Japan while connected via a UNIX socket. Now it shows the expected "unknown".