### PR TITLE
Move UNIX socket removal to ListenSocket ctor.

### DIFF
--- a/src/listensocket.cpp
+++ b/src/listensocket.cpp
@@ -29,6 +29,15 @@ ListenSocket::ListenSocket(ConfigTag* tag, const irc::sockets::sockaddrs& bind_t
 	: bind_tag(tag)
 	, bind_sa(bind_to)
 {
+	// Are we creating a UNIX socket?
+	if (bind_to.family() == AF_UNIX)
+	{
+		// Is 'replace' enabled?
+		const bool replace = tag->getBool("replace");
+		if (replace && irc::sockets::isunix(bind_to.str()))
+			unlink(bind_to.str().c_str());
+	}
+
 	fd = socket(bind_to.family(), SOCK_STREAM, 0);
 
 	if (this->fd == -1)

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -118,10 +118,6 @@ int InspIRCd::BindPorts(FailedPortList& failed_ports)
 				continue;
 			}
 
-			const bool replace = tag->getBool("replace");
-			if (replace && irc::sockets::isunix(fullpath))
-				remove(fullpath.c_str());
-
 			irc::sockets::untosa(fullpath, bindspec);
 			if (!BindPort(tag, bindspec, old_ports))
 				failed_ports.push_back(std::make_pair(bindspec, errno));


### PR DESCRIPTION
Doing the removal in BindPorts() would remove the socket during a rehash and not recreate it. Now it's only removed if it's about to be created.

Resolves #1681.