### PR TITLE
Fix DNSBL lookups for IPv6.

### DIFF
--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -384,6 +384,7 @@ class ModuleDNSBL : public Module, public Stats::EventListener
 				reversedip.push_back(*it);
 				reversedip.push_back('.');
 			}
+			reversedip.erase(reversedip.length() - 1, 1);
 		}
 		else
 			return;


### PR DESCRIPTION
> A '.' gets added to the end of `reversedip` when creating the DNSBL hostname (L399) for the resolver. We need to remove the trailing '.' on the IPv6 form of `reversedip` or the resolver will fail.

##### Pre-commit:
`m_dnsbl: Reversed IP 172.110.28.43 -> 43.28.110.172`
`m_dnsbl: Reversed IP 2604:880:a:6::629 -> 9.2.6.0.0.0.0.0.0.0.0.0.0.0.0.0.6.0.0.0.a.0.0.0.0.8.8.0.4.0.6.2.`
IPv6 lookup throws SNOTICE: `DNSBL: An error occurred whilst checking whether 715AAAAAD!715AAAAAD@2604:880:a:6::629 (2604:880:a:6::629) is on the 'DroneBL' DNS blacklist: Request timed out`

##### Post-commit:
`m_dnsbl: Reversed IP 172.110.28.43 -> 43.28.110.172`
`m_dnsbl: Reversed IP 2604:880:a:6::629 -> 9.2.6.0.0.0.0.0.0.0.0.0.0.0.0.0.6.0.0.0.a.0.0.0.0.8.8.0.4.0.6.2`
and no error on IPv6 lookup.