### PR TITLE
Update examples directory when paths are changed interactively.

### DIFF
--- a/configure
+++ b/configure
@@ -323,6 +323,7 @@ if (prompt_bool $interactive, $question, 0) {
 	$config{MANUAL_DIR} = prompt_dir $interactive, 'In what directory are manual pages to be placed?',        $config{MANUAL_DIR};
 	$config{MODULE_DIR} = prompt_dir $interactive, 'In what directory are modules to be placed?',             $config{MODULE_DIR};
 	$config{SCRIPT_DIR} = prompt_dir $interactive, 'In what directory are scripts to be placed?',             $config{SCRIPT_DIR};
+	$config{EXAMPLE_DIR} = $config{CONFIG_DIR} . '/examples';
 }
 
 # Configure module settings.


### PR DESCRIPTION
Currently when you change the install paths interactively in ./configure, the example path remains set to the default. This results in the example files "hiding" in the wrong place. Since this option is more for system maintainers and scripted setups, I've just added a line to update the examples directory during the interactive path changes rather than give the option to define it there.
A quick test on Ubuntu 16.04 showed successful.

Reported by damian on IRC.