### PR TITLE
Add repeat to the list of possible restriction types to exempt in helpop.conf.example.

### DIFF
--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -1000,6 +1000,7 @@ using their cloak when they quit.">
  nonick              Channel mode +N
  nonotice            Channel mode +T
  regmoderated        Channel mode +M
+ repeat              Channel mode +E
  stripcolor          Channel mode +S
  topiclock           Channel mode +t
 


### PR DESCRIPTION
## Summary
Add repeat to the list of possible restriction types to exempt in helpop.conf.example.
Fixes #1714.

## Rationale
It was missing from the list of possible restriction types to exempt.

## Testing Environment
Not applicable

I have tested this pull request on:
Not applicable

## Checks
I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented INSPIRCD_VERSION_API.
  - [x] I have documented any features added by this pull request.