### PR TITLE
Add oper exemption to hidemode.

### DIFF
--- a/src/modules/m_hidemode.cpp
+++ b/src/modules/m_hidemode.cpp
@@ -130,6 +130,9 @@ class ModeHook : public ClientProtocol::EventHook
 		if (!chan)
 			return MOD_RES_PASSTHRU;
 
+		if (user->HasPrivPermission("channels/auspex"))
+			return MOD_RES_PASSTHRU;
+
 		Membership* const memb = chan->GetUser(user);
 		if (!memb)
 			return MOD_RES_PASSTHRU;


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this
template will be closed without warning.
-->

## Summary

Adds the oper privilege of `channels/auspex` as an exemption to m_hidemode. So opers with that privilege will see hidden modes.

## Rationale

Resolves #1716.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Ubuntu 16.04
**Compiler name and version:** GCC 5.4.0

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] ~~If ABI changes have been made I have incremented INSPIRCD_VERSION_API.~~
  - [x] I have documented any features added by this pull request.
  - The documentation for `channels/auspex` generically covers this scenario.
