### PR TITLE
m_timedbans: Minor improvements

### DIFF
--- a/src/modules/m_timedbans.cpp
+++ b/src/modules/m_timedbans.cpp
@@ -214,21 +214,20 @@ class ModuleTimedBans : public Module
 		{
 			const std::string mask = i->mask;
 			Channel* cr = i->chan;
-			{
-				const std::string message = InspIRCd::Format("Timed ban %s set by %s on %s has expired.",
-					mask.c_str(), i->setter.c_str(), cr->name.c_str());
-				// If halfop is loaded, send notice to halfops and above, otherwise send to ops and above
-				PrefixMode* mh = ServerInstance->Modes->FindPrefixMode('h');
-				char pfxchar = (mh && mh->name == "halfop") ? mh->GetPrefix() : '@';
 
-				ClientProtocol::Messages::Privmsg notice(ClientProtocol::Messages::Privmsg::nocopy, ServerInstance->FakeClient, cr, message, MSG_NOTICE);
-				cr->Write(ServerInstance->GetRFCEvents().privmsg, notice, pfxchar);
-				ServerInstance->PI->SendChannelNotice(cr, pfxchar, message);
+			const std::string message = InspIRCd::Format("Timed ban %s set by %s on %s has expired.",
+				mask.c_str(), i->setter.c_str(), cr->name.c_str());
+			// If halfop is loaded, send notice to halfops and above, otherwise send to ops and above
+			PrefixMode* mh = ServerInstance->Modes->FindPrefixMode('h');
+			char pfxchar = (mh && mh->name == "halfop") ? mh->GetPrefix() : '@';
 
-				Modes::ChangeList setban;
-				setban.push_remove(ServerInstance->Modes->FindMode('b', MODETYPE_CHANNEL), mask);
-				ServerInstance->Modes->Process(ServerInstance->FakeClient, cr, NULL, setban);
-			}
+			ClientProtocol::Messages::Privmsg notice(ClientProtocol::Messages::Privmsg::nocopy, ServerInstance->FakeClient, cr, message, MSG_NOTICE);
+			cr->Write(ServerInstance->GetRFCEvents().privmsg, notice, pfxchar);
+			ServerInstance->PI->SendChannelNotice(cr, pfxchar, message);
+
+			Modes::ChangeList setban;
+			setban.push_remove(ServerInstance->Modes->FindMode('b', MODETYPE_CHANNEL), mask);
+			ServerInstance->Modes->Process(ServerInstance->FakeClient, cr, NULL, setban);
 		}
 	}
 

--- a/src/modules/m_timedbans.cpp
+++ b/src/modules/m_timedbans.cpp
@@ -23,8 +23,7 @@
 #include "inspircd.h"
 #include "listmode.h"
 
-/** Holds a timed ban
- */
+// Holds a timed ban
 class TimedBan
 {
  public:
@@ -37,8 +36,7 @@ class TimedBan
 typedef std::vector<TimedBan> timedbans;
 timedbans TimedBanList;
 
-/** Handle /TBAN
- */
+// Handle /TBAN
 class CommandTban : public Command
 {
 	ChanModeReference banmode;
@@ -48,6 +46,7 @@ class CommandTban : public Command
 		ListModeBase* banlm = static_cast<ListModeBase*>(*banmode);
 		if (!banlm)
 			return false;
+
 		const ListModeBase::ModeList* bans = banlm->GetList(chan);
 		if (bans)
 		{
@@ -63,7 +62,8 @@ class CommandTban : public Command
 	}
 
  public:
-	CommandTban(Module* Creator) : Command(Creator,"TBAN", 3)
+	CommandTban(Module* Creator)
+		: Command(Creator,"TBAN", 3)
 		, banmode(Creator, "ban")
 	{
 		syntax = "<channel> <duration> <banmask>";
@@ -77,6 +77,7 @@ class CommandTban : public Command
 			user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
 			return CMD_FAILURE;
 		}
+
 		unsigned int cm = channel->GetPrefixValue(user);
 		if (cm < HALFOP_VALUE)
 		{
@@ -92,6 +93,7 @@ class CommandTban : public Command
 			return CMD_FAILURE;
 		}
 		unsigned long expire = duration + ServerInstance->Time();
+
 		std::string mask = parameters[2];
 		bool isextban = ((mask.size() > 2) && (mask[1] == ':'));
 		if (!isextban && !InspIRCd::IsValidMask(mask))


### PR DESCRIPTION
## Summary

Modify the messages sent for the setting and expiry of timed bans to be more informative and similar to each other. Some clients can be terrible with (channel) notices and/or users can choose to have all notices sent to a specific/active window. In these cases, a more informative message is very helpful.
##### Before:
```
Mode #chan +b a!*@c by @nick
[server.name] nick added a timed ban on a!*@c lasting for 15s.
[server.name] *** Timed ban on #chan expired.
Mode #chan -b a!*@c by server.name
```
##### After:
```
Mode #chan +b a!*@c by @nick
[server.name] Timed ban a!*@c added by nick on #chan lasting for 15s.
[server.name] Timed ban a!*@c set by nick on #chan has expired.
Mode #chan -b a!*@c by server.name
```

Also cleaned up some formatting and comments.

## Rationale

Resolves #1639.  
Bring code and comment formatting up to current standard.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Ubuntu 16.04
**Compiler name and version:** GCC 5.4.0

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] Function test of setting and expiry.