### PR TITLE
SSL modules: send SNOTICE upon successful rehash.

### DIFF
--- a/src/modules/extra/m_ssl_gnutls.cpp
+++ b/src/modules/extra/m_ssl_gnutls.cpp
@@ -1365,6 +1365,7 @@ class ModuleSSLGnuTLS : public Module
 		try
 		{
 			ReadProfiles();
+			ServerInstance->SNO->WriteToSnoMask('a', "SSL module %s rehashed.", MODNAME);
 		}
 		catch (ModuleException& ex)
 		{

--- a/src/modules/extra/m_ssl_mbedtls.cpp
+++ b/src/modules/extra/m_ssl_mbedtls.cpp
@@ -932,6 +932,7 @@ class ModuleSSLmbedTLS : public Module
 		try
 		{
 			ReadProfiles();
+			ServerInstance->SNO->WriteToSnoMask('a', "SSL module %s rehashed.", MODNAME);
 		}
 		catch (ModuleException& ex)
 		{

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -1055,6 +1055,7 @@ class ModuleSSLOpenSSL : public Module
 		try
 		{
 			ReadProfiles();
+			ServerInstance->SNO->WriteToSnoMask('a', "SSL module %s rehashed.", MODNAME);
 		}
 		catch (ModuleException& ex)
 		{


### PR DESCRIPTION
## Summary
Send a server notice of a successful SSL module rehash.

## Rationale
SSL modules only rehash when specifically told to with `/rehash [-]ssl` or via signal using m_sslrehashsignal. Currently there is no confirmation of anything happening when called from IRC and only a notice of the rehash being called when done via signal. Confirmation of success (and just in general from IRC) has been requested a few times in #inspircd and is nice to have.

## Testing Environment
I have tested this pull request on:

**Operating system name and version:** Ubuntu 16.04
**Compiler name and version:** GCC 5.4.0

## Checks
I have ensured that:

  - [x] this compiles and functions as intended with the correct information.
