### PR TITLE
Improve handling of a link block without a port.

### DIFF
--- a/src/modules/m_spanningtree/main.cpp
+++ b/src/modules/m_spanningtree/main.cpp
@@ -336,6 +336,12 @@ ModResult ModuleSpanningTree::HandleConnect(const CommandBase::Params& parameter
 				return MOD_RES_DENY;
 			}
 
+			if (!x->Port)
+			{
+				user->WriteRemoteNotice(InspIRCd::Format("*** CONNECT: Server \002%s\002 is configured for inbound only (no port defined).", x->Name.c_str()));
+				return MOD_RES_DENY;
+			}
+
 			TreeServer* CheckDupe = Utils->FindServer(x->Name);
 			if (!CheckDupe)
 			{

--- a/src/modules/m_spanningtree/utils.cpp
+++ b/src/modules/m_spanningtree/utils.cpp
@@ -206,12 +206,6 @@ void SpanningTreeUtilities::RefreshIPCache()
 	for (std::vector<reference<Link> >::iterator i = LinkBlocks.begin(); i != LinkBlocks.end(); ++i)
 	{
 		Link* L = *i;
-		if (!L->Port)
-		{
-			ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Ignoring a link block without a port.");
-			/* Invalid link block */
-			continue;
-		}
 
 		ValidIPs.insert(ValidIPs.end(), L->AllowMasks.begin(), L->AllowMasks.end());
 


### PR DESCRIPTION
## Summary
This removes the 'no port' check/skip from the allowed IPs list refresh function. Now a link block with no port defined will have it's `allowmask` values and validated `ipaddr` value added to the allowed IPs list. The 'no port' check is now placed in the /connect command handler to prevent connect attempts from even trying.
### ToDo
- Check/modify autoconnects to ensure they won't try connecting to a no port link either.

## Rationale
- Links like services and some relays only connect to an uplink and don't accept incoming connections. There is no need to define a port or allow /connect to these links.

## Testing Environment
I have tested this pull request on:

**Operating system name and version:** Ubuntu 16.04
**Compiler name and version:** GCC 5.4.0

## Checks
I have ensured that:

  - [ ] I have documented any features added by this pull request.
  - [ ] No issues arise from having '0' used as the port in the ipaddr validation.