### PR TITLE
Fix a couple of issues with m_nationalchars and casemapping.

### DIFF
--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -368,7 +368,8 @@ void ServerConfig::Fill()
 			throw CoreException("You must restart to change the server id");
 
 		std::string casemapping = options->getString("casemapping");
-		if (!casemapping.empty() && casemapping != CaseMapping)
+		// Ignore this value if CaseMapping is set to something the core doesn't provide (i.e., m_nationalchars).
+		if (!casemapping.empty() && casemapping != CaseMapping && (CaseMapping == "ascii" || CaseMapping == "rfc1459"))
 			throw CoreException("You must restart to change the server casemapping");
 
 	}

--- a/src/modules/m_nationalchars.cpp
+++ b/src/modules/m_nationalchars.cpp
@@ -222,6 +222,7 @@ class ModuleNationalChars : public Module
 	TR1NS::function<bool(const std::string&)> rememberer;
 	bool forcequit;
 	const unsigned char * lowermap_rememberer;
+	std::string casemapping_rememberer;
 	unsigned char prev_map[256];
 
 	template <typename T>
@@ -248,7 +249,9 @@ class ModuleNationalChars : public Module
 
  public:
 	ModuleNationalChars()
-		: rememberer(ServerInstance->IsNick), lowermap_rememberer(national_case_insensitive_map)
+		: rememberer(ServerInstance->IsNick)
+		, lowermap_rememberer(national_case_insensitive_map)
+		, casemapping_rememberer(ServerInstance->Config->CaseMapping)
 	{
 		memcpy(prev_map, national_case_insensitive_map, sizeof(prev_map));
 	}
@@ -305,6 +308,9 @@ class ModuleNationalChars : public Module
 	{
 		ServerInstance->IsNick = rememberer;
 		national_case_insensitive_map = lowermap_rememberer;
+		ServerInstance->Config->CaseMapping = casemapping_rememberer;
+		// The core rebuilds ISupport on module unload, but before the dtor.
+		ServerInstance->ISupport.Build();
 		CheckForceQuit("National characters module unloaded");
 		CheckRehash();
 	}


### PR DESCRIPTION
## Summary
* Allow `options:casemapping` to remain defined and not cause rehash errors when another module is providing the current casemapping (i.e., m_nationalchars).
* m_nationalchars: Save the current CaseMapping value when loading and set it back when unloading, also rebuilding the ISupport numeric.

## Rationale
`options:casemapping` is defined in the example config and will cause a rehash to error out if m_nationalchars is loaded (CaseMapping is set different than the core expects). This is misleading and incorrect as the error implies you are trying to change the casemapping on rehash. The example config also claims it will be ignored if m_nationalchars is loaded, which is only half-true currently.
Setting the CaseMapping back when the module unloads is correct behavior and was just missed throughout changes with the Config variable being added and ISupport method.

## Testing Environment
I have tested this pull request on:

**Operating system name and version:** Ubuntu 16.04
**Compiler name and version:** GCC 5.4.0

## Checks
I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] This pull request has been tested thoroughly.
