### PR TITLE
Acting extbans: Split the channel mode and extban replies.

### DIFF
--- a/src/modules/m_blockcolor.cpp
+++ b/src/modules/m_blockcolor.cpp
@@ -46,19 +46,21 @@ class ModuleBlockColor : public Module
 		if ((target.type == MessageTarget::TYPE_CHANNEL) && (IS_LOCAL(user)))
 		{
 			Channel* c = target.Get<Channel>();
-			ModResult res = CheckExemption::Call(exemptionprov, user, c, "blockcolor");
 
+			ModResult res = CheckExemption::Call(exemptionprov, user, c, "blockcolor");
 			if (res == MOD_RES_ALLOW)
 				return MOD_RES_PASSTHRU;
 
-			if (!c->GetExtBanStatus(user, 'c').check(!c->IsModeSet(bc)))
+			bool modeset = c->IsModeSet(bc);
+			if (!c->GetExtBanStatus(user, 'c').check(!modeset))
 			{
 				for (std::string::iterator i = details.text.begin(); i != details.text.end(); i++)
 				{
 					// Block all control codes except \001 for CTCP
 					if ((*i >= 0) && (*i < 32) && (*i != 1))
 					{
-						user->WriteNumeric(ERR_CANNOTSENDTOCHAN, c->name, "Can't send colors to channel (+c is set)");
+						user->WriteNumeric(ERR_CANNOTSENDTOCHAN, c->name, InspIRCd::Format("Can't send colors to channel (%s)",
+							modeset ? "+c is set" : "you're extbanned"));
 						return MOD_RES_DENY;
 					}
 				}

--- a/src/modules/m_noctcp.cpp
+++ b/src/modules/m_noctcp.cpp
@@ -81,9 +81,11 @@ class ModuleNoCTCP : public Module
 				if (res == MOD_RES_ALLOW)
 					return MOD_RES_PASSTHRU;
 
-				if (!c->GetExtBanStatus(user, 'C').check(!c->IsModeSet(nc)))
+				bool modeset = c->IsModeSet(nc);
+				if (!c->GetExtBanStatus(user, 'C').check(!modeset))
 				{
-					user->WriteNumeric(ERR_CANNOTSENDTOCHAN, c->name, "Can't send CTCP to channel (+C is set)");
+					user->WriteNumeric(ERR_CANNOTSENDTOCHAN, c->name, InspIRCd::Format("Can't send CTCP to channel (%s)",
+						modeset ? "+C is set" : "you're extbanned"));
 					return MOD_RES_DENY;
 				}
 				break;

--- a/src/modules/m_nokicks.cpp
+++ b/src/modules/m_nokicks.cpp
@@ -39,10 +39,12 @@ class ModuleNoKicks : public Module
 
 	ModResult OnUserPreKick(User* source, Membership* memb, const std::string &reason) CXX11_OVERRIDE
 	{
-		if (!memb->chan->GetExtBanStatus(source, 'Q').check(!memb->chan->IsModeSet(nk)))
+		bool modeset = memb->chan->IsModeSet(nk);
+		if (!memb->chan->GetExtBanStatus(source, 'Q').check(!modeset))
 		{
 			// Can't kick with Q in place, not even opers with override, and founders
-			source->WriteNumeric(ERR_CHANOPRIVSNEEDED, memb->chan->name, InspIRCd::Format("Can't kick user %s from channel (+Q is set)", memb->user->nick.c_str()));
+			source->WriteNumeric(ERR_CHANOPRIVSNEEDED, memb->chan->name, InspIRCd::Format("Can't kick user %s from channel (%s)",
+				memb->user->nick.c_str(), modeset ? "+Q is set" : "you're extbanned"));
 			return MOD_RES_DENY;
 		}
 		return MOD_RES_PASSTHRU;

--- a/src/modules/m_nonicks.cpp
+++ b/src/modules/m_nonicks.cpp
@@ -50,17 +50,17 @@ class ModuleNoNickChange : public Module
 			Channel* curr = (*i)->chan;
 
 			ModResult res = CheckExemption::Call(exemptionprov, user, curr, "nonick");
-
 			if (res == MOD_RES_ALLOW)
 				continue;
 
 			if (user->HasPrivPermission("channels/ignore-nonicks"))
 				continue;
 
-			if (!curr->GetExtBanStatus(user, 'N').check(!curr->IsModeSet(nn)))
+			bool modeset = curr->IsModeSet(nn);
+			if (!curr->GetExtBanStatus(user, 'N').check(!modeset))
 			{
-				user->WriteNumeric(ERR_CANTCHANGENICK, InspIRCd::Format("Cannot change nickname while on %s (+N is set)",
-					curr->name.c_str()));
+				user->WriteNumeric(ERR_CANTCHANGENICK, InspIRCd::Format("Can't change nickname while on %s (%s)",
+					curr->name.c_str(), modeset ? "+N is set" : "you're extbanned"));
 				return MOD_RES_DENY;
 			}
 		}

--- a/src/modules/m_nonotice.cpp
+++ b/src/modules/m_nonotice.cpp
@@ -41,20 +41,20 @@ class ModuleNoNotice : public Module
 
 	ModResult OnUserPreMessage(User* user, const MessageTarget& target, MessageDetails& details) CXX11_OVERRIDE
 	{
-		ModResult res;
 		if ((details.type == MSG_NOTICE) && (target.type == MessageTarget::TYPE_CHANNEL) && (IS_LOCAL(user)))
 		{
 			Channel* c = target.Get<Channel>();
-			if (!c->GetExtBanStatus(user, 'T').check(!c->IsModeSet(nt)))
+
+			ModResult res = CheckExemption::Call(exemptionprov, user, c, "nonotice");
+			if (res == MOD_RES_ALLOW)
+				return MOD_RES_PASSTHRU;
+
+			bool modeset = c->IsModeSet(nt);
+			if (!c->GetExtBanStatus(user, 'T').check(!modeset))
 			{
-				res = CheckExemption::Call(exemptionprov, user, c, "nonotice");
-				if (res == MOD_RES_ALLOW)
-					return MOD_RES_PASSTHRU;
-				else
-				{
-					user->WriteNumeric(ERR_CANNOTSENDTOCHAN, c->name, "Can't send NOTICE to channel (+T is set)");
-					return MOD_RES_DENY;
-				}
+				user->WriteNumeric(ERR_CANNOTSENDTOCHAN, c->name, InspIRCd::Format("Can't send NOTICE to channel (%s)",
+					modeset ? "+T is set" : "you're extbanned"));
+				return MOD_RES_DENY;
 			}
 		}
 		return MOD_RES_PASSTHRU;


### PR DESCRIPTION
## Summary
- Tell the user when they are extbanned rather than incorrectly say that the channel mode is set.
- Changed "Cannot" to "Can't" in m_nonicks to match the others.
- Refactored the logic in m_nonotice to match that of the others.

## Rationale
For the acting extbans that send a reply to the user, the implication that the channel mode is set can cause a lot of confusion. By switching up the message when they are extbanned (and the channel mode is **not** set), we can remedy the possible confusion.

## Testing Environment
I have tested this pull request on:

**Operating system name and version:** Ubuntu 16.04
**Compiler name and version:** GCC 5.4.0

## Checks
I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] All modified extbans and channel modes still function as intended.
