### PR TITLE
Fixing MatchCIDR call when checking proxy range

### DIFF
--- a/src/modules/m_websocket.cpp
+++ b/src/modules/m_websocket.cpp
@@ -363,10 +363,10 @@ class WebSocketHook : public IOHookMiddle
 
 			for (WebSocketConfig::ProxyRanges::const_iterator iter = config.proxyranges.begin(); iter != config.proxyranges.end(); ++iter)
 			{
-				if (InspIRCd::MatchCIDR(*iter, luser->GetIPString(), ascii_case_insensitive_map))
+				if (InspIRCd::MatchCIDR(luser->GetIPString(), *iter, ascii_case_insensitive_map))
 				{
 					// Give the user their real IP address.
-					if (realsa == luser->client_sa)
+					if (realsa != luser->client_sa)
 						luser->SetClientIP(realsa);
 					break;
 				}


### PR DESCRIPTION
## Summary

When checking the CIDR to see if IP is in proxy ranges, the call is done in wrong order. First item must be the user IP, then the range and finally the character map.

Also, the SetClientIP call is done if IP in proxy header is the same as proxy IP, and this should be the opposite.

## Rationale

To get the real user IP when websocket is behing a proxy.

## Testing Environment

I've setup a virtual machine with HAProxy:

```
global
  log /dev/log  local0
  log /dev/log  local1 notice
  chroot /var/lib/haproxy
  user haproxy
  group haproxy
  daemon

defaults
  mode http
  log global
  option httplog
  option  http-server-close
  option  dontlognull
  option  redispatch
  option  contstats
  retries 3
  backlog 10000
  timeout client          25s
  timeout connect          5s
  timeout server          25s
  timeout tunnel        3600s
  timeout http-keep-alive  1s
  timeout http-request    15s
  timeout queue           30s
  timeout tarpit          60s
  default-server inter 3s rise 2 fall 3
  option forwardfor

frontend ircd
  bind *:7000 name http
  default_backend  be-ircd

backend be-ircd
  balance roundrobin
  option forwardfor if-none
  server srv1 127.0.0.1:7002 maxconn 10000 weight 10 cookie srv1 check
```

Theese lines on inspircd.conf:

```
<bind address="0.0.0.0" port="6668" type="clients">
<bind address="127.0.0.1" port="7002" type="clients" hook="websocket">
```

Then connecting a user with an irc client to port 6668 and a user through a KiwiIRC webchat configured to connect directly to virtual machine IP and port 7000.

I have tested this pull request on:

**Operating system name and version:** 4.9.0-11-amd64 Debian 9.11
**Compiler name and version:** gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516

## Checks

I have ensured that:

  - [ x ] This pull request does not introduce any incompatible API changes.
  - [ x ] If ABI changes have been made I have incremented INSPIRCD_VERSION_API.
  - [ x ] I have documented any features added by this pull request.
