### PR TITLE
Adding bool options notify and notify_onlyops

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1232,8 +1232,13 @@
 # Closes the channel for N seconds if X users join in Y seconds.
 #<module name="joinflood">
 #
-# The number of seconds to close the channel for:
-#<joinflood duration="1m">
+# This tag takes the following attributes:
+#
+# notify         - If enabled, it will send a notice to channel when
+#                  protection is triggered.
+# notify_onlyops - If enabled, only notify to channel operators.
+#
+#<joinflood duration="1m" notify="true" notify_onlyops="false">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Anti auto rejoin: Adds support for prevention of auto-rejoin (+J).

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1234,7 +1234,7 @@
 #
 # This tag takes the following attributes:
 #
-# duration       - The number of seconds to close the channel.
+# duration       - Time to close the channel when protection is triggered.
 # notify         - If enabled, it will send a notice to channel when
 #                  protection is triggered.
 # notify_onlyops - If enabled, only notify to channel operators.

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1234,6 +1234,7 @@
 #
 # This tag takes the following attributes:
 #
+# duration       - The number of seconds to close the channel.
 # notify         - If enabled, it will send a notice to channel when
 #                  protection is triggered.
 # notify_onlyops - If enabled, only notify to channel operators.

--- a/src/modules/m_joinflood.cpp
+++ b/src/modules/m_joinflood.cpp
@@ -186,10 +186,7 @@ class ModuleJoinFlood : public Module
 				f->clear();
 				f->lock();
 				if (notify) {
-					std::string message = InspIRCd::Format("This channel has been closed to new users for %u seconds because there have been more than %d joins in %d seconds.", duration, f->joins, f->secs);
-					ClientProtocol::Messages::Privmsg privmsg(ClientProtocol::Messages::Privmsg::nocopy, ServerInstance->FakeClient, memb->chan, message, MSG_NOTICE);
-					memb->chan->Write(ServerInstance->GetRFCEvents().privmsg, privmsg, notify_onlyops ? '@' : 0);
-					ServerInstance->PI->SendMessage(memb->chan, notify_onlyops ? '@' : 0, message, MSG_NOTICE);
+					memb->chan->WriteNotice(InspIRCd::Format("This channel has been closed to new users for %u seconds because there have been more than %d joins in %d seconds.", duration, f->joins, f->secs), notify_onlyops ? '@' : 0);
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Adding boolean options notify and notify_onlyops to m_joinflood to setup how it is notified to channel when protection is triggered.

Option notify enables or disables notification. Option notify_onlyops only sends to channel operators (@)  if enabled.

## Rationale

This is done to allow avoiding normal users to see it as it can be annoying when having a network with more than few servers.

## Testing Environment

Used branch insp3, connected 2 users to a channel (only one with op) and tested with 3 options:

- notify="false":  no one receives channel notice
- notify="true" and notify_onlyops="false": everyone receives channel notice
- notify="true" and notify_onlyops="true": only the user with op receives channel notice

I have tested this pull request on:

**Operating system name and version:** 5.3.0-26-generic
**Compiler name and version:** GCC 9.2.1

## Checks

I have ensured that:

  - [ x ] This pull request does not introduce any incompatible API changes.
  - [ x ] If ABI changes have been made I have incremented INSPIRCD_VERSION_API.
  - [ x ] I have documented any features added by this pull request.
