### PR TITLE
Improve logging for the m_ldap and m_ldapauth modules

### DIFF
--- a/src/modules/extra/m_ldap.cpp
+++ b/src/modules/extra/m_ldap.cpp
@@ -403,7 +403,7 @@ class LDAPService : public LDAPProvider, public SocketThread
 
 		if (res != LDAP_SUCCESS)
 		{
-			ldap_result->error = std::string(ldap_err2string(res)) + " (" + req->info() + ")";
+			ldap_result->error = InspIRCd::Format("%s (%s)", ldap_err2string(res), req->info().c_str());
 			return;
 		}
 

--- a/src/modules/extra/m_ldap.cpp
+++ b/src/modules/extra/m_ldap.cpp
@@ -78,6 +78,7 @@ class LDAPRequest
 	}
 
 	virtual int run() = 0;
+	virtual std::string info() = 0;
 };
 
 class LDAPBind : public LDAPRequest
@@ -94,6 +95,7 @@ class LDAPBind : public LDAPRequest
 	}
 
 	int run() CXX11_OVERRIDE;
+	std::string info() CXX11_OVERRIDE;
 };
 
 class LDAPSearch : public LDAPRequest
@@ -113,6 +115,7 @@ class LDAPSearch : public LDAPRequest
 	}
 
 	int run() CXX11_OVERRIDE;
+	std::string info() CXX11_OVERRIDE;
 };
 
 class LDAPAdd : public LDAPRequest
@@ -130,6 +133,7 @@ class LDAPAdd : public LDAPRequest
 	}
 
 	int run() CXX11_OVERRIDE;
+	std::string info() CXX11_OVERRIDE;
 };
 
 class LDAPDel : public LDAPRequest
@@ -145,6 +149,7 @@ class LDAPDel : public LDAPRequest
 	}
 
 	int run() CXX11_OVERRIDE;
+	std::string info() CXX11_OVERRIDE;
 };
 
 class LDAPModify : public LDAPRequest
@@ -162,6 +167,7 @@ class LDAPModify : public LDAPRequest
 	}
 
 	int run() CXX11_OVERRIDE;
+	std::string info() CXX11_OVERRIDE;
 };
 
 class LDAPCompare : public LDAPRequest
@@ -179,6 +185,7 @@ class LDAPCompare : public LDAPRequest
 	}
 
 	int run() CXX11_OVERRIDE;
+	std::string info() CXX11_OVERRIDE;
 };
 
 class LDAPService : public LDAPProvider, public SocketThread
@@ -396,7 +403,7 @@ class LDAPService : public LDAPProvider, public SocketThread
 
 		if (res != LDAP_SUCCESS)
 		{
-			ldap_result->error = ldap_err2string(res);
+			ldap_result->error = std::string(ldap_err2string(res)) + " (" + req->info() + ")";
 			return;
 		}
 
@@ -646,9 +653,19 @@ int LDAPBind::run()
 	return i;
 }
 
+std::string LDAPBind::info()
+{
+	return "bind dn=" + who;
+}
+
 int LDAPSearch::run()
 {
 	return ldap_search_ext_s(service->GetConnection(), base.c_str(), searchscope, filter.c_str(), NULL, 0, NULL, NULL, &tv, 0, &message);
+}
+
+std::string LDAPSearch::info()
+{
+	return "search base=" + base + " filter=" + filter;
 }
 
 int LDAPAdd::run()
@@ -659,9 +676,19 @@ int LDAPAdd::run()
 	return i;
 }
 
+std::string LDAPAdd::info()
+{
+	return "add dn=" + dn;
+}
+
 int LDAPDel::run()
 {
 	return ldap_delete_ext_s(service->GetConnection(), dn.c_str(), NULL, NULL);
+}
+
+std::string LDAPDel::info()
+{
+	return "del dn=" + dn;
 }
 
 int LDAPModify::run()
@@ -670,6 +697,11 @@ int LDAPModify::run()
 	int i = ldap_modify_ext_s(service->GetConnection(), base.c_str(), mods, NULL, NULL);
 	LDAPService::FreeMods(mods);
 	return i;
+}
+
+std::string LDAPModify::info()
+{
+	return "modify base=" + base;
 }
 
 int LDAPCompare::run()
@@ -683,7 +715,11 @@ int LDAPCompare::run()
 	free(cred.bv_val);
 
 	return ret;
+}
 
+std::string LDAPCompare::info()
+{
+	return "compare dn=" + dn + " attr=" + attr;
 }
 
 MODULE_INIT(ModuleLDAP)

--- a/src/modules/m_ldapauth.cpp
+++ b/src/modules/m_ldapauth.cpp
@@ -118,6 +118,9 @@ class BindInterface : public LDAPInterface
 
 		if (!checkingAttributes && requiredattributes.empty())
 		{
+			if (verbose)
+				ServerInstance->SNO->WriteToSnoMask('c', "Successful connection from %s (dn=%s)", user->GetFullRealHost().c_str(), DN.c_str());
+
 			// We're done, there are no attributes to check
 			SetVHost(user, DN);
 			authed->set(user, 1);
@@ -133,6 +136,9 @@ class BindInterface : public LDAPInterface
 			{
 				// Only one has to pass
 				passed = true;
+
+				if (verbose)
+					ServerInstance->SNO->WriteToSnoMask('c', "Successful connection from %s (dn=%s)", user->GetFullRealHost().c_str(), DN.c_str());
 
 				SetVHost(user, DN);
 				authed->set(user, 1);
@@ -171,7 +177,7 @@ class BindInterface : public LDAPInterface
 		if (!attrCount)
 		{
 			if (verbose)
-				ServerInstance->SNO->WriteToSnoMask('c', "Forbidden connection from %s (unable to validate attributes)", user->GetFullRealHost().c_str());
+				ServerInstance->SNO->WriteToSnoMask('c', "Forbidden connection from %s (dn=%s) (unable to validate attributes)", user->GetFullRealHost().c_str(), DN.c_str());
 			ServerInstance->Users->QuitUser(user, killreason);
 			delete this;
 		}


### PR DESCRIPTION
Currently, it is difficult to diagnose LDAP authentication failures,
since the logs do not provide sufficient information about what is
actually being queried and what actually failed.

This increases logging details so that information about the LDAP query
is included, for example:

  Fri Mar 06 2020 08:02:59 ANNOUNCEMENT: Error binding as manager to LDAP
  server: Invalid credentials (bind dn=cn=adminz,dc=nodomain)

Rather than:

  Fri Mar 06 2020 08:02:59 ANNOUNCEMENT: Error binding as manager to LDAP
  server: Invalid credentials

Same with connection logging:

  Fri Mar 06 2020 07:59:53 CONNECT: Forbidden connection from
  jsing!jsing@192.168.200.1 (Invalid credentials (bind
  dn=uid=jsing,dc=nodomain))

  Fri Mar 06 2020 08:01:19 CONNECT: Successful connection from
  jsing!jsing@192.168.200.1 (dn=uid=jsing,dc=nodomain)
