### PR TITLE
Fix the signed-ness within ConvToNum char overloads.

### DIFF
--- a/include/convto.h
+++ b/include/convto.h
@@ -104,14 +104,14 @@ template<> inline char ConvToNum<char>(const std::string& in)
 {
 	// We specialise ConvToNum for char to avoid istringstream treating
 	// the input as a character literal.
-	uint16_t num = ConvToNum<uint16_t>(in);
-	return num <= UINT8_MAX ? num : 0;
+	int16_t num = ConvToNum<int16_t>(in);
+	return num >= INT8_MIN && num <= INT8_MAX ? num : 0;
 }
 
 template<> inline unsigned char ConvToNum<unsigned char>(const std::string& in)
 {
 	// We specialise ConvToNum for unsigned char to avoid istringstream
 	// treating the input as a character literal.
-	int16_t num = ConvToNum<int16_t>(in);
-	return num >= INT8_MIN && num <= INT8_MAX ? num : 0;
+	uint16_t num = ConvToNum<uint16_t>(in);
+	return num <= UINT8_MAX ? num : 0;
 }


### PR DESCRIPTION
## Summary
Fixes the incorrect conversion in the `ConvToNum` (un)signed char function overloads.

## Rationale
It should be matching - signed int with signed char and unsigned int with unsigned char.

## Testing Environment
I have tested this pull request on:

**Operating system name and version:** Ubuntu 18.04
**Compiler name and version:** GCC 7.5.0

## Checks
I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.

So far, the only place either of these overloads is used is in socket.cpp for the CIDR mask. I have tested this using `TLINE` and an IPv6 CIDR of /128. Before, it would match all IPv6 addresses as the conversion function return `0`. After, it matches correctly to just the /128 of the address. Along with testing other ranges (/0, /1, /64, etc) to verify they are still correct.
This **might** fix #1648 - at least the part where a /128 Z-line hits more then it should.