### PR TITLE
Correct a module name typo.

### DIFF
--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -846,7 +846,7 @@ using their cloak when they quit.
  w            Receives wallops messages.
  x            Gives a cloaked hostname (requires the cloaking module).
  z            Only allow private messages from SSL users (requires the
-              sslmode module).
+              sslmodes module).
  B            Marks as a bot (requires the botmode module).
  D            Privdeaf mode. User will not receive any private messages
               or notices from users (requires the deaf module).


### PR DESCRIPTION
## Summary
Minor typo of a module name - `sslmode` -> `sslmodes`.

## Rationale
Typos are bad.

## Testing Environment
I have tested this pull request on:

**Operating system name and version:** Ubuntu 18.04
**Compiler name and version:** GCC 7.5.0