### PR TITLE
Only send a local X-line SNOTICE.

### DIFF
--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -158,7 +158,7 @@ class DNSBLResolver : public DNS::Request
 							"*", them->GetIPString());
 					if (ServerInstance->XLines->AddLine(kl,NULL))
 					{
-						ServerInstance->SNO->WriteGlobalSno('x', "K-line added due to DNSBL match on *@%s to expire in %s (on %s): %s",
+						ServerInstance->SNO->WriteToSnoMask('x', "K-line added due to DNSBL match on *@%s to expire in %s (on %s): %s",
 							them->GetIPString().c_str(), InspIRCd::DurationString(kl->duration).c_str(),
 							InspIRCd::TimeString(kl->expiry).c_str(), reason.c_str());
 						ServerInstance->XLines->ApplyLines();
@@ -176,7 +176,7 @@ class DNSBLResolver : public DNS::Request
 							"*", them->GetIPString());
 					if (ServerInstance->XLines->AddLine(gl,NULL))
 					{
-						ServerInstance->SNO->WriteGlobalSno('x', "G-line added due to DNSBL match on *@%s to expire in %s (on %s): %s",
+						ServerInstance->SNO->WriteToSnoMask('x', "G-line added due to DNSBL match on *@%s to expire in %s (on %s): %s",
 							them->GetIPString().c_str(), InspIRCd::DurationString(gl->duration).c_str(),
 							InspIRCd::TimeString(gl->expiry).c_str(), reason.c_str());
 						ServerInstance->XLines->ApplyLines();
@@ -194,7 +194,7 @@ class DNSBLResolver : public DNS::Request
 							them->GetIPString());
 					if (ServerInstance->XLines->AddLine(zl,NULL))
 					{
-						ServerInstance->SNO->WriteGlobalSno('x', "Z-line added due to DNSBL match on %s to expire in %s (on %s): %s",
+						ServerInstance->SNO->WriteToSnoMask('x', "Z-line added due to DNSBL match on %s to expire in %s (on %s): %s",
 							them->GetIPString().c_str(), InspIRCd::DurationString(zl->duration).c_str(),
 							InspIRCd::TimeString(zl->expiry).c_str(), reason.c_str());
 						ServerInstance->XLines->ApplyLines();


### PR DESCRIPTION
## Summary
Only send the DNSBL X-line addition SNOTICE locally.

## Rationale
`m_spanningtree` will send an SNOTICE to 'X' when adding a line. This results in two messages (albeit slightly different wording) for the same thing on remote servers (from where the DNSBL hit happened).
**Before:**
```
[ServerB] *** REMOTEXLINE: ServerA added timed Z-line for 173.244.44.78, expires in 1h (on Mon Mar 23 2020 04:16:10): Your host is listed in the DroneBL. For more information, please visit https://dronebl.org/lookup_branded?ip=173.244.44.78
[ServerB] *** REMOTEXLINE: From ServerA: Z-line added due to DNSBL match on 173.244.44.78 to expire in 1h (on Mon Mar 23 2020 04:16:10): Your host is listed in the DroneBL. For more information, please visit https://dronebl.org/lookup_branded?ip=173.244.44.78
```
**After:**
```
[ServerB] *** REMOTEXLINE: ServerA added timed Z-line for 173.244.44.78, expires in 1h (on Mon Mar 23 2020 04:13:19): Your host is listed in the DroneBL. For more information, please visit https://dronebl.org/lookup_branded?ip=173.244.44.78
```
If any user really wishes to get the distinct DNSBL match type of message on remote servers, they can use 'D' to receive remote DNSBL SNOTICES.

## Testing Environment
I have tested this pull request on:

**Operating system name and version:** Ubuntu 18.04
**Compiler name and version:** GCC 7.5.0

## Checks
I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.