### PR TITLE
Add m_samove module

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1916,6 +1916,13 @@
 #<module name="samode">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
+# SAMOVE module: Adds the /SAMOVE command which forcibly parts a user
+# from a channel, and joins the user in another channel.
+# This module is oper-only.
+# To use, SAMOVE must be in one of your oper class blocks.
+#<module name="samove">
+
+#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # SANICK module: Adds the /SANICK command which allows opers to change
 # users' nicks.
 # This module is oper-only.

--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -54,7 +54,7 @@
      # snomasks: The snomasks that opers with this class can use.
      snomasks="*">
 
-<class name="SACommands" commands="SAJOIN SAPART SANICK SAQUIT SATOPIC SAKICK SAMODE OJOIN">
+<class name="SACommands" commands="SAJOIN SAPART SANICK SAQUIT SATOPIC SAKICK SAMODE OJOIN SAMOVE">
 <class name="ServerLink" commands="CONNECT SQUIT RCONNECT RSQUIT MKPASSWD ALLTIME SWHOIS LOCKSERV UNLOCKSERV" usermodes="*" chanmodes="*" privs="servers/auspex" snomasks="Cc">
 <class name="BanControl" commands="KILL GLINE KLINE ZLINE QLINE ELINE TLINE RLINE CHECK NICKLOCK NICKUNLOCK SHUN CLONES CBAN" usermodes="*" chanmodes="*" snomasks="Xx">
 <class name="OperChat" commands="WALLOPS GLOBOPS" usermodes="*" chanmodes="*" privs="users/mass-message" snomasks="Gg">

--- a/src/modules/m_samove.cpp
+++ b/src/modules/m_samove.cpp
@@ -1,0 +1,160 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2013, 2018-2019 Sadie Powell <sadie@witchery.services>
+ *   Copyright (C) 2013 Daniel Vassdal <shutter@canternet.org>
+ *   Copyright (C) 2012-2014, 2016 Attila Molnar <attilamolnar@hush.com>
+ *   Copyright (C) 2012, 2019 Robby <robby@chatbelgie.be>
+ *   Copyright (C) 2009 Daniel De Graaf <danieldg@inspircd.org>
+ *   Copyright (C) 2007, 2010 Craig Edwards <brain@inspircd.org>
+ *   Copyright (C) 2007 Robin Burchell <robin+git@viroteck.net>
+ *   Copyright (C) 2007 Dennis Friis <peavey@inspircd.org>
+ *   Copyright (C) 2006 jamie <jamie@e03df62e-2008-0410-955e-edbf42e46eb7>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+
+/** Handle /SAMOVE
+ *
+ * Basically it's a SAPART + SAJOIN in 1 command
+ */
+class CommandSamove : public Command
+{
+ public:
+	CommandSamove(Module* Creator) : Command(Creator,"SAMOVE", 1)
+	{
+		allow_empty_last_param = false;
+		flags_needed = 'o';
+		syntax = "<nick> <fromchannel> <tochannel>";
+		TRANSLATE3(TR_NICK, TR_TEXT, TR_TEXT);		
+	}
+
+	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE				
+	{
+		if (parameters.size() != 3) 
+		{
+			return CMD_FAILURE;			
+		}
+
+		const std::string& nickname = parameters[0];
+		const std::string& from_channel = parameters[1];
+		const std::string& to_channel = parameters[2];
+		std::string msg = std::string();
+
+		User* dest = ServerInstance->FindNick(nickname);
+		if ((dest) && (dest->registered == REG_ALL))
+		{
+
+			if (dest->server->IsULine())
+			{
+				user->WriteNumeric(ERR_NOPRIVILEGES, "Cannot use an SA command on a U-lined client");
+				return CMD_FAILURE;
+			}
+			if (IS_LOCAL(user) && !ServerInstance->IsChannel(from_channel))
+			{
+				/* we didn't need to check this for each character ;) */
+				user->WriteNotice("*** Invalid characters in 'from channel' name or name too long");
+				return CMD_FAILURE;
+			}
+			if (IS_LOCAL(user) && !ServerInstance->IsChannel(to_channel))
+			{
+				/* we didn't need to check this for each character ;) */
+				user->WriteNotice("*** Invalid characters in 'to channel' name or name too long");
+				return CMD_FAILURE;
+			}
+			Channel* from_chan = ServerInstance->FindChan(from_channel);
+			if (!(from_chan))
+			{
+				user->WriteRemoteNotice("*** invalid 'from channel '" + from_channel);
+				return CMD_FAILURE;
+			}
+			Channel* to_chan = ServerInstance->FindChan(to_channel);
+			if (!(to_chan))
+			{
+				user->WriteRemoteNotice("*** invalid 'to channel '" + to_channel);
+				return CMD_FAILURE;
+			}
+
+			
+
+
+
+			/* For local users, we call Channel::JoinUser which may create a channel and set its TS, also PART them directly
+			 * For non-local users, we just return CMD_SUCCESS, knowing this will propagate it where it needs to be
+			 * and then that server will handle the command.
+			 */
+			LocalUser* localuser = IS_LOCAL(dest);
+			if (localuser)
+			{
+				/*
+				 * 
+				 */
+
+				if ((from_chan) && (from_chan->HasUser(dest))) 
+				{
+					from_chan->PartUser(dest, msg);
+				}
+
+				if ((to_chan) && (!to_chan->HasUser(dest))) 
+				{
+					Channel* chan = Channel::JoinUser(localuser, to_channel, true);
+					if (!chan)
+					{
+						user->WriteNotice("*** Could not join "+dest->nick+" to "+to_channel);
+						return CMD_FAILURE;
+					}
+
+				}
+
+
+				ServerInstance->SNO->WriteGlobalSno('a', user->nick+" used SAMOVE to move "+dest->nick+" from "+from_channel+" to "+to_channel);
+				return CMD_SUCCESS;
+
+			}
+			else
+			{
+				return CMD_SUCCESS;
+			}
+		}
+		else
+		{
+			user->WriteNotice("*** No such nickname: '" + nickname + "'");
+			return CMD_FAILURE;
+		}
+	}
+
+	RouteDescriptor GetRouting(User* user, const Params& parameters) CXX11_OVERRIDE
+	{
+		return ROUTE_OPT_UCAST(parameters[0]);
+	}
+};
+
+class ModuleSamove : public Module
+{
+	CommandSamove cmd;
+ public:
+	ModuleSamove()
+		: cmd(this)
+	{
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Adds the /SAMOVE command which allows server operators to force move users from one channel to another.", VF_OPTCOMMON | VF_VENDOR);
+	}
+};
+
+MODULE_INIT(ModuleSamove)


### PR DESCRIPTION
## Summary

Implements a module for moving a user from one channel to another

## Rationale

Although it is possible for moving a user from one channel to another with SAPART + SAJOIN the intention is not clear in the Server Notices when doing so. 



## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

Linux 4.9.0
GCC 6.3.0

## Checks


I have ensured that:

  - [X ] This pull request does not introduce any incompatible API changes.
  - [X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [X] I have documented any features added by this pull request.
