### PR TITLE
Updating CBAN to allow requesting list

### DIFF
--- a/src/modules/m_cban.cpp
+++ b/src/modules/m_cban.cpp
@@ -92,9 +92,9 @@ class CBanFactory : public XLineFactory
 class CommandCBan : public Command
 {
  public:
-	CommandCBan(Module* Creator) : Command(Creator, "CBAN", 1, 3)
+	CommandCBan(Module* Creator) : Command(Creator, "CBAN", 0, 3)
 	{
-		flags_needed = 'o'; this->syntax = "<channel> [<duration> [:<reason>]]";
+		flags_needed = 'o'; this->syntax = "[<channel> [<duration> [:<reason>]]]";
 	}
 
 	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE
@@ -102,7 +102,31 @@ class CommandCBan : public Command
 		/* syntax: CBAN #channel time :reason goes here */
 		/* 'time' is a human-readable timestring, like 2d3h2s. */
 
-		if (parameters.size() == 1)
+		if (parameters.size() == 0)
+		{
+			XLineLookup* lookup = ServerInstance->XLines->GetAll("CBAN");
+			if (!lookup)
+			{
+				user->WriteNotice("*** There are not CBan in the list.");
+			}
+			else
+			{
+				user->WriteNotice("List of CBan:");
+				for (LookupIter i = lookup->begin(); i != lookup->end(); ++i)
+				{
+					XLine* line = i->second;
+					std::string msg;
+					if (line->duration == 0) {
+						msg = "    "+line->Displayable()+" by "+line->source+". Reason: "+line->reason;
+					} else {
+						msg = "    "+line->Displayable()+" by "+line->source+" until "+InspIRCd::TimeString(line->expiry)+". Reason: "+line->reason;
+					}
+					user->WriteNotice(msg);
+				}
+				user->WriteNotice("End of list.");
+			}
+		}
+		else if (parameters.size() == 1)
 		{
 			std::string reason;
 


### PR DESCRIPTION
## Summary

It allows CBAN command without parameters. If it is used without parameters, it shows the list of XLines of type CBAN.

## Rationale

It can be useful for an operator to see the full list.

## Testing Environment

I've tested locally with latest insp3 branch:
/quote CBAN #forbidden 1d :With time
/quote CBAN - we see the list with 1 entry
/quote CBAN #forbidden2 0 :Without time
/quote CBAN - we see the list with 2 entries
/quote CBAN #forbidden
/quote CBAN - we see the list again with 1 entry
/quote CBAN #forbidden2
/quote CBAN - we get an emty list message

I have tested this pull request on:

**Operating system name and version:** Debian Buster 10.4
**Compiler name and version:** gcc 8.3.0

## Checks

I have ensured that:

  - [ x ] This pull request does not introduce any incompatible API changes.
  - [ x ] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [ x ] I have documented any features added by this pull request.
