### PR TITLE
Added option in timedbans conf to disable channel operator notices when ban is set/unset

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -2286,7 +2286,7 @@
 #<module name="timedbans">
 # By default, it sends a notice to channel operators when timed ban is
 # set and when it is removed by server.
-#<timedbans sendnotice="true">
+#<timedbans sendnotice="yes">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Test line module: Adds the /TLINE command, used to test how many

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -2284,6 +2284,9 @@
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Timed bans module: Adds timed channel bans with the /TBAN command.
 #<module name="timedbans">
+# By default, it sends a notice to channel operators when timed ban is
+# set and when it is removed by server.
+#<timedbans send_notice="true">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Test line module: Adds the /TLINE command, used to test how many

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -2286,7 +2286,7 @@
 #<module name="timedbans">
 # By default, it sends a notice to channel operators when timed ban is
 # set and when it is removed by server.
-#<timedbans send_notice="true">
+#<timedbans sendnotice="true">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Test line module: Adds the /TLINE command, used to test how many

--- a/src/modules/m_timedbans.cpp
+++ b/src/modules/m_timedbans.cpp
@@ -133,7 +133,8 @@ class CommandTban : public Command
 		T.chan = channel;
 		TimedBanList.push_back(T);
 
-		if (sendnotice) {
+		if (sendnotice)
+		{
 		    const std::string message = InspIRCd::Format("Timed ban %s added by %s on %s lasting for %s.",
 			mask.c_str(), user->nick.c_str(), channel->name.c_str(), InspIRCd::DurationString(duration).c_str());
 		    // If halfop is loaded, send notice to halfops and above, otherwise send to ops and above
@@ -233,7 +234,8 @@ class ModuleTimedBans : public Module
 			const std::string mask = i->mask;
 			Channel* cr = i->chan;
 
-			if (cmd.sendnotice) {
+			if (cmd.sendnotice)
+			{
 			    const std::string message = InspIRCd::Format("Timed ban %s set by %s on %s has expired.",
 				mask.c_str(), i->setter.c_str(), cr->name.c_str());
 			    // If halfop is loaded, send notice to halfops and above, otherwise send to ops and above


### PR DESCRIPTION
## Summary

This allow to disable channel operator notices when a timed ban is set or unset.

## Rationale

In big channels with a lot of activity can be noisy, specially for clients that do not allow to ignore it.

## Testing Environment

1. Forked latest insp3 branch
2. Compiled with patch and launched with a simple config enabling m_timedbans.
3. Connected a user.
4. Executed TBAN. Channel operator notices are sent.
5. Updated modules config with:

`<timedbans send_notice="false">`

6. Executed TBAN again. Channel operator notices are not sent.

- By default, send_notice is enabled (current behaviour).
- Updated modules conf example to explain the new config tab to enable/disable notices.

I have tested this pull request on:

**Operating system name and version:** Ubuntu Eoan
**Compiler name and version:** gcc (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008

## Checks

I have ensured that:

  - [ x ] This pull request does not introduce any incompatible API changes.
  - [ x ] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [ x ] I have documented any features added by this pull request.
