### PR TITLE
configure: When not generating certs, warn if certs exist in source directory that will overwrite output

### DIFF
--- a/configure
+++ b/configure
@@ -394,6 +394,13 @@ EOQ
 if (<$RealDir/src/modules/m_ssl_*.cpp>) {
 	if (prompt_bool $interactive, $question, $interactive) {
 		system './tools/genssl', 'auto';
+	} elsif (<$RealDir/*.pem>) {
+		# Answered "no", and (likely self-signed) certs already exist
+		print_warning <<"EOW";
+InspIRCd will use the existing generated certificates in the root of
+the source directory.  If this is not intended, remove the .pem files before
+running make.
+EOW
 	}
 } else {
 	print_warning <<"EOM";


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

When running `./configure` and not enabling certificate generation, warn if certificates exist in the root of the source directory which will overwrite any certificates in the build output.

<!--
Briefly describe what this pull request changes.
-->

## Rationale

This helps avoid the issue where someone initially generates self-signed certificates for testing, then later replaces the certs in
the output directory without removing them from the source directory.  Previously, it wasn't clear why the certificates were being replaced despite answering "no".

<!--
Describe why you have made this change.
-->

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Kubuntu 20.04 LTS
**Compiler name and version:** GCC (`Ubuntu 9.3.0-10ubuntu2`) `9.3.0`
**Perl version:** Perl `v5.30.0`

The output after having previously run `./configure` and generating self-signed certs looks like this…

```
[...]
Would you like to generate a self-signed SSL certificate now? This certificate
can be used for testing but should not be used on a production network.

Note: you can get a free CA-signed certificate from Let's Encrypt. See
https://letsencrypt.org/getting-started/ for more details.

[yes] => no

Warning: InspIRCd will use the existing generated certificates in the root of
the source directory.  If this is not intended, remove the .pem files before
running make.

Writing .configure/cache.cfg ...
[...]
```

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
