### PR TITLE
m_cban: Implement support for channel masks

### DIFF
--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -572,9 +572,9 @@ the network.
 Sends a message to all users with the +g snomask.
 ">
 
-<helpop key="cban" title="/CBAN <channel> [<duration> [:<reason>]]" value="
-Sets or removes a global channel ban. You must specify all three parameters
-to add a ban, and one parameter to remove a ban (just the channel).
+<helpop key="cban" title="/CBAN <channelmask> [<duration> [:<reason>]]" value="
+Sets or removes a global channel based ban. You must specify all three parameters
+to add a ban, and one parameter to remove a ban (just the channelmask).
 
 The duration may be specified in seconds, or in the format
 1y2w3d4h5m6s - meaning one year, two weeks, three days, four hours,

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -338,6 +338,9 @@
 # This module is oper-only and provides /CBAN.
 # To use, CBAN must be in one of your oper class blocks.
 #<module name="cban">
+# CBAN does not allow glob channelmasks by default for compatibility
+# reasons. You can enable glob support by uncommenting the next line.
+#<cban glob="true">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Censor module: Adds channel and user mode +G which block phrases that

--- a/src/modules/m_cban.cpp
+++ b/src/modules/m_cban.cpp
@@ -58,7 +58,7 @@ public:
 
 	bool Matches(const std::string& s) CXX11_OVERRIDE
 	{
-		return irc::equals(matchtext, s);
+		return InspIRCd::Match(s, matchtext);
 	}
 
 	const std::string& Displayable() CXX11_OVERRIDE
@@ -94,7 +94,8 @@ class CommandCBan : public Command
  public:
 	CommandCBan(Module* Creator) : Command(Creator, "CBAN", 1, 3)
 	{
-		flags_needed = 'o'; this->syntax = "<channel> [<duration> [:<reason>]]";
+		flags_needed = 'o';
+		this->syntax = "<channelmask> [<duration> [:<reason>]]";
 	}
 
 	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE


### PR DESCRIPTION
## Summary

This PR updates m_cban to use InspIRCd::Match to enable glob matching.

## Rationale

The existing logic does not actually account for a globbed channel name.

## Testing Environment

Tested on the insp3 git as of commit d0c1741.

I have tested this pull request on:

**Operating system name and version:** Linux 5.8.16
**Compiler name and version:** Clang 10.0.1

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
