### PR TITLE
m_override: Improve wording

### DIFF
--- a/src/modules/m_override.cpp
+++ b/src/modules/m_override.cpp
@@ -170,7 +170,7 @@ class ModuleOverride : public Module
 
 		if (CanOverride(source, "MODE"))
 		{
-			std::string msg = source->nick + " overriding modes: ";
+			std::string msg = source->nick + " used oper override to set modes on " + channel->name + ": ";
 
 			// Construct a MODE string in the old format for sending it as a snotice
 			std::string params;


### PR DESCRIPTION
## Summary

Improve  the wording of m_override's MODE handler 

## Rationale

The wording omits the channel and the wording may be misleading
## Testing Environment

None

## Checks

I have ensured that:

  - [X] This pull request does not introduce any incompatible API changes.
  - [X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [X] I have documented any features added by this pull request.
