### PR TITLE
Document that exemptions configured in <options:exemptchanops> can be negated, and change the <badnick> ChanServ example

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -685,8 +685,9 @@
          #  - stripcolor      Channel mode +S - strips formatting codes from
          #                    messages (requires the stripcolor module).
          #  - topiclock       Channel mode +t - limits changing the topic to (half)ops
-         # You can also configure this on a per-channel basis with a channel mode.
-         # See m_exemptchanops in modules.conf.example for more details.
+         # You can also configure this on a per-channel basis with a channel mode and
+         # even negate the configured exemptions below.
+         # See exemptchanops in modules.conf.example for more details.
          exemptchanops="censor:o filter:o nickflood:o nonick:v regmoderated:o"
 
          # invitebypassmodes: This allows /INVITE to bypass other channel modes.
@@ -962,10 +963,10 @@
 
 <badnick
          # nick: Nick to disallow. Wildcards are supported.
-         nick="ChanServ"
+         nick="Tr0ll123"
 
          # reason: Reason to display on /NICK.
-         reason="Reserved for a network service">
+         reason="Don't use this nick.">
 
 <badhost
          # host: ident@hostname to ban.

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -883,6 +883,8 @@
 # See <options:exemptchanops> in inspircd.conf.example for a more     #
 # detailed list of the restriction modes that can be exempted.        #
 # These are settable using: /MODE #chan +X <restriction>:<status>     #
+# Furthermore, the exemptions configured in <options:exemptchanops>   #
+# can also be negated by using: /MODE #chan +X <restriction>:*        #
 #<module name="exemptchanops">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#


### PR DESCRIPTION
## Summary

- Document that exemptions configured in \<options:exemptchanops\> can be negated.
- Change the \<badnick\> example in inspircd.conf.example to another nick, since ChanServ is already covered by examples/services/generic.conf.example.

## Rationale

Because.

## Testing Environment

Not applicable.

I have tested this pull request on:

**Operating system name and version:** Not applicable.
**Compiler name and version:** Not applicable.

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.