### PR TITLE
 Fix issue where m_pbkdf2 was not aware of services loaded before it.

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -1050,6 +1050,7 @@ class CoreExport Module : public classbase, public usecountbase
 class CoreExport ModuleManager : public fakederef<ModuleManager>
 {
  public:
+	typedef std::multimap<std::string, ServiceProvider*, irc::insensitive_swo> DataProviderMap;
 	typedef std::vector<ServiceProvider*> ServiceList;
 
  private:
@@ -1092,7 +1093,7 @@ class CoreExport ModuleManager : public fakederef<ModuleManager>
 	Module::List EventHandlers[I_END];
 
 	/** List of data services keyed by name */
-	std::multimap<std::string, ServiceProvider*, irc::insensitive_swo> DataProviders;
+	DataProviderMap DataProviders;
 
 	/** A list of ServiceProviders waiting to be registered.
 	 * Non-NULL when constructing a Module, NULL otherwise.

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -425,9 +425,9 @@ void ModuleManager::DoSafeUnload(Module* mod)
 		user->doUnhookExtensions(items);
 	}
 
-	for(std::multimap<std::string, ServiceProvider*>::iterator i = DataProviders.begin(); i != DataProviders.end(); )
+	for (DataProviderMap::iterator i = DataProviders.begin(); i != DataProviders.end(); )
 	{
-		std::multimap<std::string, ServiceProvider*>::iterator curr = i++;
+		DataProviderMap::iterator curr = i++;
 		if (curr->second->creator == mod)
 		{
 			DataProviders.erase(curr);
@@ -642,7 +642,7 @@ ServiceProvider* ModuleManager::FindService(ServiceType type, const std::string&
 		case SERVICE_DATA:
 		case SERVICE_IOHOOK:
 		{
-			std::multimap<std::string, ServiceProvider*>::iterator i = DataProviders.find(name);
+			DataProviderMap::iterator i = DataProviders.find(name);
 			if (i != DataProviders.end() && i->second->service == type)
 				return i->second;
 			return NULL;
@@ -696,7 +696,7 @@ void dynamic_reference_base::resolve()
 {
 	// Because find() may return any element with a matching key in case count(key) > 1 use lower_bound()
 	// to ensure a dynref with the same name as another one resolves to the same object
-	std::multimap<std::string, ServiceProvider*>::iterator i = ServerInstance->Modules.DataProviders.lower_bound(name);
+	ModuleManager::DataProviderMap::iterator i = ServerInstance->Modules.DataProviders.lower_bound(name);
 	if ((i != ServerInstance->Modules.DataProviders.end()) && (i->first == this->name))
 	{
 		ServiceProvider* newvalue = i->second;
@@ -729,7 +729,7 @@ void ModuleManager::AddReferent(const std::string& name, ServiceProvider* servic
 
 void ModuleManager::DelReferent(ServiceProvider* service)
 {
-	for (std::multimap<std::string, ServiceProvider*>::iterator i = DataProviders.begin(); i != DataProviders.end(); )
+	for (DataProviderMap::iterator i = DataProviders.begin(); i != DataProviders.end(); )
 	{
 		ServiceProvider* curr = i->second;
 		if (curr == service)

--- a/src/modules/m_pbkdf2.cpp
+++ b/src/modules/m_pbkdf2.cpp
@@ -209,6 +209,14 @@ class ModulePBKDF2 : public Module
 		stdalgo::delete_all(providers);
 	}
 
+	void init() CXX11_OVERRIDE
+	{
+		// Let ourself know about any existing services.
+		const ModuleManager::DataProviderMap& dataproviders = ServerInstance->Modules->DataProviders;
+		for (ModuleManager::DataProviderMap::const_iterator it = dataproviders.begin(); it != dataproviders.end(); ++it)
+			OnServiceAdd(*it->second);
+	}
+
 	void OnServiceAdd(ServiceProvider& provider) CXX11_OVERRIDE
 	{
 		// Check if it's a hash provider


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary
* Make sure m_pbkdf2 knows about services already existing when it is loaded.

<!--
Briefly describe what this pull request changes.
-->

## Rationale

<!--
Describe why you have made this change.
-->
Get rid of bug #1818

## Testing Environment
Followed procedure outlined in #1818 before and after fix.

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** <!-- e.g. Linux 3.11 -->
WSL 4.4.0-19041-Microsoft
**Compiler name and version:** <!-- e.g. GCC 4.2.0 -->
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [X] This pull request does not introduce any incompatible API changes.
  - [X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [X] I have documented any features added by this pull request.
