### PR TITLE
Check the ident when checking against IP in ldapoper

### DIFF
--- a/src/modules/m_ldapoper.cpp
+++ b/src/modules/m_ldapoper.cpp
@@ -222,9 +222,7 @@ class ModuleLDAPOper : public Module
 				return MOD_RES_PASSTHRU;
 
 			std::string acceptedhosts = tag->getString("host");
-			std::string userHost = user->ident + "@" + user->GetRealHost();
-			std::string userIP = user->ident + "@" + user->GetIPString();
-			if (!InspIRCd::MatchMask(acceptedhosts, userHost, userIP))
+			if (!InspIRCd::MatchMask(acceptedhosts, user->MakeHost(), user->MakeHostIP()))
 				return MOD_RES_PASSTHRU;
 
 			if (!LDAP)

--- a/src/modules/m_ldapoper.cpp
+++ b/src/modules/m_ldapoper.cpp
@@ -222,8 +222,9 @@ class ModuleLDAPOper : public Module
 				return MOD_RES_PASSTHRU;
 
 			std::string acceptedhosts = tag->getString("host");
-			std::string hostname = user->ident + "@" + user->GetRealHost();
-			if (!InspIRCd::MatchMask(acceptedhosts, hostname, user->GetIPString()))
+			std::string userHost = user->ident + "@" + user->GetRealHost();
+			std::string userIP = user->ident + "@" + user->GetIPString();
+			if (!InspIRCd::MatchMask(acceptedhosts, userHost, userIP))
 				return MOD_RES_PASSTHRU;
 
 			if (!LDAP)


### PR DESCRIPTION
## Summary

Currently m_ldapoper doesn't add the user's ident when checking whether user's IP is in the oper hosts. This pull request copies the wait that cmd_oper does:

https://github.com/inspircd/inspircd/blob/7a02052130721d83b43a349dc9b0650ad798fc08/src/coremods/core_oper/cmd_oper.cpp#L53

## Rationale

The ldapoper fails the matching host is the user's IP and not host.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Linux 5.4.0
**Compiler name and version:** GCC 9.3.0 with musl 1.1.24 (docker)

## Checks

I have ensured that:

  - [X] This pull request does not introduce any incompatible API changes.
  - [X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [] I have documented any features added by this pull request.
