### PR TITLE
Fix default linker flags in libargon2

### DIFF
--- a/src/modules/extra/m_argon2.cpp
+++ b/src/modules/extra/m_argon2.cpp
@@ -18,7 +18,7 @@
 
 /// $CompilerFlags: find_compiler_flags("libargon2" "")
 
-/// $LinkerFlags: find_linker_flags("libargon2" "-llibargon2")
+/// $LinkerFlags: find_linker_flags("libargon2" "-largon2")
 
 /// $PackageInfo: require_system("arch") argon2 pkgconf
 /// $PackageInfo: require_system("darwin") argon2 pkg-config


### PR DESCRIPTION
It's `-largon2`, not `-llibargon2`. I've experienced build failures due to this.

## Summary

Changes the default linker flags in libargon2 to `-libargon2` instead of `-llibargon2`

## Rationale

`-llibargon2` is not the proper default way to link to the library and breaks the build where `pkg-config`` isn't being used.

## Testing Environment

Multiple Linux systems, one running debian oldstable, one running Adelie Linux

I have tested this pull request on:
* Debian oldstable GCC 6.3.0
* Adelie Linux GCC 8.3.0

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [N/A] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [N/A] I have documented any features added by this pull request.
