### PR TITLE
chanhistory: Mention bot mode opt-out if enabled

### DIFF
--- a/src/modules/m_chanhistory.cpp
+++ b/src/modules/m_chanhistory.cpp
@@ -240,6 +240,8 @@ class ModuleChanHistory
 			std::string message("Replaying up to " + ConvToStr(list->maxlen) + " lines of pre-join history");
 			if (list->maxtime > 0)
 				message.append(" from the last " + InspIRCd::DurationString(list->maxtime));
+			if (!dobots)
+				message.append(" (opt out with bot mode +B)");
 			memb->WriteNotice(message);
 		}
 


### PR DESCRIPTION
## Summary
When replaying chat history, mention the bot mode (`+B`) opt-out from channel history if `bots` is set to `no` in the channel configuration.

## Rationale
This guides those who are unfamiliar with InspIRCd's `chanhistory` module on how to disable the history playback if the server admins have enabled the bot opt-out (off by default) and have left `prefixmsg` enabled.

### Considerations

A nicer approach would be an unambiguous mode to specifically opt out of channel history, rather than potentially invoking other functionality differences tied to the `+B` bot mode.

**I'd personally prefer this new user mode approach** as it would not depend upon opting all bots out of channel history, but I felt it was important to bring this issue up first before spending a few hours learning how to add a new user mode.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** `Kubuntu 20.04 LTS, Linux kernel 5.4.0-59-generic`
**Compiler name and version:** `GCC 9.3`

### Configuration changes

1.  Copy the default `inspircd.example.conf`
2.  Append this to the end:
```
<module name="chanhistory">
<chanhistory bots="no"
             maxlines="50"
             prefixmsg="yes">
```

3.  Join a test channel with two users
4.  Set `/MODE #channel +H 25:2h`
5.  Part/join the channel from one account

### Opt-out disabled (`bots="yes"`)
*This is the default configuration.*

```
--> digitalcircuit (quassel@127.0.0.1) has joined #test
[...example.org] Replaying up to 25 lines of pre-join history from the last 2h
*** Mode #test +Hnt 25:2h by penguin.omega.example.org
* Channel #test created on 2021-01-08 07:46:21 UTC
```

### Opt-out enabled (`bots="no"`)
```
--> digitalcircuit (quassel@127.0.0.1) has joined #test
[...example.org] Replaying up to 25 lines of pre-join history from the last 2h (opt out with bot mode +B)
*** Mode #test +Hnt 25:2h by penguin.omega.example.org
* Channel #test created on 2021-01-08 07:46:21 UTC
```

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - It does introduce a new string for translation.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - No ABI changes made.
  - [x] I have documented any features added by this pull request.
  - It does not seem to require additional documentation.
