### PR TITLE
Implemented configurable kick message for module m_repeat

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1900,7 +1900,8 @@
 #               less CPU usage. Increasing this beyond 512 doesn't have
 #               any effect, as the maximum length of a message on IRC
 #               cannot exceed that.
-#<repeat maxbacklog="20" maxdistance="50" maxlines="20" maxtime="0" size="512">
+# kickmessage - Kick message when * is specified
+#<repeat maxbacklog="20" maxdistance="50" maxlines="20" maxtime="0" size="512" kickmessage="Repeat flood">
 #<module name="repeat">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1901,7 +1901,12 @@
 #               any effect, as the maximum length of a message on IRC
 #               cannot exceed that.
 # kickmessage - Kick message when * is specified
-#<repeat maxbacklog="20" maxdistance="50" maxlines="20" maxtime="0" size="512" kickmessage="Repeat flood">
+#<repeat maxbacklog="20"
+#        maxdistance="50"
+#        maxlines="20"
+#        maxtime="0s"
+#        size="512"
+#        kickmessage="Repeat flood">
 #<module name="repeat">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#

--- a/src/modules/m_repeat.cpp
+++ b/src/modules/m_repeat.cpp
@@ -90,6 +90,7 @@ class RepeatMode : public ParamMode<RepeatMode, SimpleExtItem<ChannelSettings> >
 		unsigned int MaxBacklog;
 		unsigned int MaxDiff;
 		unsigned int MaxMessageSize;
+		std::string KickMessage;
 		ModuleSettings() : MaxLines(0), MaxSecs(0), MaxBacklog(0), MaxDiff() { }
 	};
 
@@ -251,11 +252,18 @@ class RepeatMode : public ParamMode<RepeatMode, SimpleExtItem<ChannelSettings> >
 		if (newsize > ServerInstance->Config->Limits.MaxLine)
 			newsize = ServerInstance->Config->Limits.MaxLine;
 		Resize(newsize);
+
+		ms.KickMessage = conf->getString("kickmessage", "Repeat flood");
 	}
 
 	std::string GetModuleSettings() const
 	{
 		return ConvToStr(ms.MaxLines) + ":" + ConvToStr(ms.MaxSecs) + ":" + ConvToStr(ms.MaxDiff) + ":" + ConvToStr(ms.MaxBacklog);
+	}
+
+	std::string GetKickMessage() const
+	{
+		return ms.KickMessage;
 	}
 
 	void SerializeParam(Channel* chan, const ChannelSettings* chset, std::string& out)
@@ -402,7 +410,7 @@ class RepeatModule : public Module
 				ServerInstance->Modes->Process(ServerInstance->FakeClient, chan, NULL, changelist);
 			}
 
-			memb->chan->KickUser(ServerInstance->FakeClient, user, "Repeat flood");
+			memb->chan->KickUser(ServerInstance->FakeClient, user, rm.GetKickMessage());
 			return MOD_RES_DENY;
 		}
 		return MOD_RES_PASSTHRU;


### PR DESCRIPTION
## Summary

Be able to setup a custom kick message.

## Rationale

It is useful to be able to customize the message with more descritive one and/or in another language for non-english networks.

## Testing Environment

Latest insp3 branch.

I have tested this pull request on:

**Operating system name and version:** Debian 10.6
**Compiler name and version:** gcc 8.3.0

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
