### PR TITLE
Added -Wshorten-64-to-32 and fixed all warnings

### DIFF
--- a/include/clientprotocol.h
+++ b/include/clientprotocol.h
@@ -376,20 +376,20 @@ class ClientProtocol::Message : public ClientProtocol::MessageSource
 	 * @param index Index of the parameter to replace. Must be less than GetParams().size().
 	 * @param str String to replace the parameter or placeholder with, will be copied.
 	 */
-	void ReplaceParam(unsigned int index, const char* str) { params[index] = Param(0, str); }
+	void ReplaceParam(size_t index, const char* str) { params[index] = Param(0, str); }
 
 	/** Replace a parameter or a placeholder that is already in the parameter list.
 	 * @param index Index of the parameter to replace. Must be less than GetParams().size().
 	 * @param str String to replace the parameter or placeholder with, will be copied.
 	 */
-	void ReplaceParam(unsigned int index, const std::string& str) { params[index] = Param(0, str); }
+	void ReplaceParam(size_t index, const std::string& str) { params[index] = Param(0, str); }
 
 	/** Replace a parameter or a placeholder that is already in the parameter list.
 	 * @param index Index of the parameter to replace. Must be less than GetParams().size().
 	 * @param str String to replace the parameter or placeholder with.
 	 * The string will NOT be copied, it must remain alive until ClearParams() is called or until the object is destroyed.
 	 */
-	void ReplaceParamRef(unsigned int index, const std::string& str) { params[index] = Param(str); }
+	void ReplaceParamRef(size_t index, const std::string& str) { params[index] = Param(str); }
 
 	/** Add a tag.
 	 * @param tagname Raw name of the tag to use in the protocol.

--- a/include/configreader.h
+++ b/include/configreader.h
@@ -347,12 +347,12 @@ class CoreExport ServerConfig
 	 * handling code, used to read data into a user's
 	 * recvQ.
 	 */
-	int NetBufferSize;
+	unsigned long NetBufferSize;
 
 	/** The value to be used for listen() backlogs
 	 * as default.
 	 */
-	int MaxConn;
+	unsigned long MaxConn;
 
 	/** If we should check for clones during CheckClass() in AddUser()
 	 * Setting this to false allows to not trigger on maxclones for users
@@ -365,12 +365,12 @@ class CoreExport ServerConfig
 	 * The IRC server will not allow more than this
 	 * number of local users.
 	 */
-	unsigned int SoftLimit;
+	unsigned long SoftLimit;
 
 	/** Maximum number of targets for a multi target command
 	 * such as PRIVMSG or KICK
 	 */
-	unsigned int MaxTargets;
+	unsigned long MaxTargets;
 
 	/** The number of seconds that the server clock can skip by before server operators are warned. */
 	time_t TimeSkipWarn;
@@ -426,11 +426,11 @@ class CoreExport ServerConfig
 
 	/** Default value for <connect:maxchans>, deprecated in 3.0
 	 */
-	unsigned int MaxChans;
+	unsigned long MaxChans;
 
 	/** Default value for <oper:maxchans>, deprecated in 3.0
 	 */
-	unsigned int OperMaxChans;
+	unsigned long OperMaxChans;
 
 	/** Unique server ID.
 	 * NOTE: 000...999 are usable for InspIRCd servers. This

--- a/include/inspircd.h
+++ b/include/inspircd.h
@@ -328,7 +328,7 @@ class CoreExport InspIRCd
 	 * @param printable if false, the string will use characters 0-255; otherwise,
 	 * it will be limited to 0x30-0x7E ('0'-'~', nonspace printable characters)
 	 */
-	std::string GenRandomStr(unsigned int length, bool printable = true);
+	std::string GenRandomStr(size_t length, bool printable = true);
 	/** Generate a random integer.
 	 * This is generally more secure than rand()
 	 */

--- a/include/inspsocket.h
+++ b/include/inspsocket.h
@@ -95,7 +95,7 @@ class CoreExport SocketTimeout : public Timer
 	 * @param thesock BufferedSocket to attach to
 	 * @param secs_from_now Seconds from now to time out
 	 */
-	SocketTimeout(int fd, BufferedSocket* thesock, unsigned int secs_from_now)
+	SocketTimeout(int fd, BufferedSocket* thesock, unsigned long secs_from_now)
 		: Timer(secs_from_now)
 		, sock(thesock)
 		, sfd(fd)
@@ -268,7 +268,7 @@ class CoreExport StreamSocket : public EventHandler
 	 * @param rq Receive queue to put incoming data into
 	 * @return < 0 on error or close, 0 if no new data is ready (but the socket is still connected), > 0 if data was read from the socket and put into the recvq
 	 */
-	int ReadToRecvQ(std::string& rq);
+	long ReadToRecvQ(std::string& rq);
 
 	/** Read data from a hook chain recursively, starting at 'hook'.
 	 * If 'hook' is NULL, the recvq is filled with data from SocketEngine::Recv(), otherwise it is filled with data from the
@@ -278,7 +278,7 @@ class CoreExport StreamSocket : public EventHandler
 	 * @return < 0 on error or close, 0 if no new data is ready (but the socket is still connected), > 0 if data was read from
 	 * the socket and put into the recvq
 	 */
-	int HookChainRead(IOHook* hook, std::string& rq);
+	long HookChainRead(IOHook* hook, std::string& rq);
 
  protected:
 	/** The data which has been received from the socket. */
@@ -414,7 +414,7 @@ class CoreExport BufferedSocket : public StreamSocket
 	 * @param bind Local endpoint to connect from.
 	 * @param maxtime Time to wait for connection
 	 */
-	void DoConnect(const irc::sockets::sockaddrs& dest, const irc::sockets::sockaddrs& bind, unsigned int maxtime);
+	void DoConnect(const irc::sockets::sockaddrs& dest, const irc::sockets::sockaddrs& bind, unsigned long maxtime);
 
 	/** This method is called when an outbound connection on your socket is
 	 * completed.
@@ -440,7 +440,7 @@ class CoreExport BufferedSocket : public StreamSocket
 	virtual ~BufferedSocket();
  protected:
 	void OnEventHandlerWrite() CXX11_OVERRIDE;
-	BufferedSocketError BeginConnect(const irc::sockets::sockaddrs& dest, const irc::sockets::sockaddrs& bind, unsigned int timeout);
+	BufferedSocketError BeginConnect(const irc::sockets::sockaddrs& dest, const irc::sockets::sockaddrs& bind, unsigned long timeout);
 };
 
 inline IOHook* StreamSocket::GetIOHook() const { return iohook; }

--- a/include/listmode.h
+++ b/include/listmode.h
@@ -46,7 +46,7 @@ class CoreExport ListModeBase : public ModeHandler
 	{
 	public:
 		ModeList list;
-		int maxitems;
+		long maxitems;
 
 		ChanData() : maxitems(-1) { }
 	};
@@ -56,8 +56,8 @@ class CoreExport ListModeBase : public ModeHandler
 	struct ListLimit
 	{
 		std::string mask;
-		unsigned int limit;
-		ListLimit(const std::string& Mask, unsigned int Limit) : mask(Mask), limit(Limit) { }
+		unsigned long limit;
+		ListLimit(const std::string& Mask, unsigned long Limit) : mask(Mask), limit(Limit) { }
 		bool operator==(const ListLimit& other) const { return (this->mask == other.mask && this->limit == other.limit); }
 	};
 
@@ -72,7 +72,7 @@ class CoreExport ListModeBase : public ModeHandler
 	 * @param channame The channel name to find the limit for
 	 * @return The maximum number of modes of this type that we allow to be set on the given channel name
 	 */
-	unsigned int FindLimit(const std::string& channame);
+	unsigned long FindLimit(const std::string& channame);
 
 	/** Returns the limit on the given channel for this mode.
 	 * If the limit is cached then the cached value is returned,
@@ -82,7 +82,7 @@ class CoreExport ListModeBase : public ModeHandler
 	 * @param cd The ChanData associated with channel channame
 	 * @return The maximum number of modes of this type that we allow to be set on the given channel
 	 */
-	unsigned int GetLimitInternal(const std::string& channame, ChanData* cd);
+	unsigned long GetLimitInternal(const std::string& channame, ChanData* cd);
 
  protected:
 	/** Numeric to use when outputting the list
@@ -129,7 +129,7 @@ class CoreExport ListModeBase : public ModeHandler
 	 * @param channel The channel to inspect
 	 * @return Maximum number of modes of this type that can be placed on the given channel
 	 */
-	unsigned int GetLimit(Channel* channel);
+	unsigned long GetLimit(Channel* channel);
 
 	/** Gets the lower list limit for this listmode.
 	 */

--- a/include/mode.h
+++ b/include/mode.h
@@ -763,7 +763,7 @@ class CoreExport ModeParser : public fakederef<ModeParser>
 	 * @param endindex Index of the first element that is not part of the MODE list. By default,
 	 * the entire container is considered part of the MODE list.
 	 */
-	void ModeParamsToChangeList(User* user, ModeType type, const std::vector<std::string>& parameters, Modes::ChangeList& changelist, unsigned int beginindex = 1, unsigned int endindex = UINT_MAX);
+	void ModeParamsToChangeList(User* user, ModeType type, const std::vector<std::string>& parameters, Modes::ChangeList& changelist, size_t beginindex = 1, size_t endindex = UINT_MAX);
 
 	/** Find the mode handler for a given mode name and type.
 	 * @param modename The mode name to search for.

--- a/include/modules/dns.h
+++ b/include/modules/dns.h
@@ -166,7 +166,7 @@ namespace DNS
 		/* Creator of this request */
 		Module* const creator;
 
-		Request(Manager* mgr, Module* mod, const std::string& addr, QueryType qt, bool usecache = true, unsigned int timeout = 0)
+		Request(Manager* mgr, Module* mod, const std::string& addr, QueryType qt, bool usecache = true, unsigned long timeout = 0)
 			: Timer(timeout ? timeout : ServerInstance->Config->ConfValue("dns")->getDuration("timeout", 5, 1))
 			, manager(mgr)
 			, question(addr, qt)

--- a/include/protocol.h
+++ b/include/protocol.h
@@ -47,9 +47,9 @@ class CoreExport ProtocolInterface
 		std::string servername;
 		std::string parentname;
 		std::string description;
-		unsigned int usercount;
-		unsigned int opercount;
-		unsigned int latencyms;
+		size_t usercount;
+		size_t opercount;
+		unsigned long latencyms;
 	};
 
 	typedef std::vector<ServerInfo> ServerList;

--- a/include/socketengine.h
+++ b/include/socketengine.h
@@ -250,14 +250,14 @@ class CoreExport SocketEngine
 		 * @param len_in Number of bytes received, or -1 for error, as typically
 		 * returned by a read-style syscall.
 		 */
-		void UpdateReadCounters(int len_in);
+		void UpdateReadCounters(ssize_t len_in);
 
 		/** Update counters for network data sent.
 		 * This should be called after every write-type syscall.
 		 * @param len_out Number of bytes sent, or -1 for error, as typically
 		 * returned by a read-style syscall.
 		 */
-		void UpdateWriteCounters(int len_out);
+		void UpdateWriteCounters(ssize_t len_out);
 
 		/** Get data transfer statistics.
 		 * @param kbitpersec_in Filled with incoming traffic in this second in kbit/s.
@@ -442,7 +442,7 @@ public:
 	 * @param flags A flag value that controls the sending of the data.
 	 * @return This method should return exactly the same values as the system call it emulates.
 	 */
-	static int Send(EventHandler* fd, const void *buf, size_t len, int flags);
+	static ssize_t Send(EventHandler* fd, const void *buf, size_t len, int flags);
 
 	/** Abstraction for vector write function writev().
 	 * This function should emulate its namesake system call exactly.
@@ -452,7 +452,7 @@ public:
 	 * @param count Number of elements in iov.
 	 * @return This method should return exactly the same values as the system call it emulates.
 	 */
-	static int WriteV(EventHandler* fd, const IOVector* iov, int count);
+	static ssize_t WriteV(EventHandler* fd, const IOVector* iov, int count);
 
 #ifdef _WIN32
 	/** Abstraction for vector write function writev() that accepts a POSIX format iovec.
@@ -473,7 +473,7 @@ public:
 	 * @param flags A flag value that controls the reception of the data.
 	 * @return This method should return exactly the same values as the system call it emulates.
 	 */
-	static int Recv(EventHandler* fd, void *buf, size_t len, int flags);
+	static ssize_t Recv(EventHandler* fd, void *buf, size_t len, int flags);
 
 	/** Abstraction for BSD sockets recvfrom(2).
 	 * This function should emulate its namesake system call exactly.
@@ -485,7 +485,7 @@ public:
 	 * @param fromlen The size of the from parameter.
 	 * @return This method should return exactly the same values as the system call it emulates.
 	 */
-	static int RecvFrom(EventHandler* fd, void *buf, size_t len, int flags, sockaddr *from, socklen_t *fromlen);
+	static ssize_t RecvFrom(EventHandler* fd, void *buf, size_t len, int flags, sockaddr *from, socklen_t *fromlen);
 
 	/** Abstraction for BSD sockets sendto(2).
 	 * This function should emulate its namesake system call exactly.
@@ -496,7 +496,7 @@ public:
 	 * @param address The remote IP address and port.
 	 * @return This method should return exactly the same values as the system call it emulates.
 	 */
-	static int SendTo(EventHandler* fd, const void* buf, size_t len, int flags, const irc::sockets::sockaddrs& address);
+	static ssize_t SendTo(EventHandler* fd, const void* buf, size_t len, int flags, const irc::sockets::sockaddrs& address);
 
 	/** Abstraction for BSD sockets connect(2).
 	 * This function should emulate its namesake system call exactly.

--- a/include/timer.h
+++ b/include/timer.h
@@ -46,7 +46,7 @@ class CoreExport Timer
 
 	/** Number of seconds between triggers
 	 */
-	unsigned int secs;
+	unsigned long secs;
 
 	/** True if this is a repeating timer
 	 */
@@ -57,7 +57,7 @@ class CoreExport Timer
 	 * @param secs_from_now The number of seconds from now to trigger the timer
 	 * @param repeating Repeat this timer every secs_from_now seconds if set to true
 	 */
-	Timer(unsigned int secs_from_now, bool repeating = false);
+	Timer(unsigned long secs_from_now, bool repeating = false);
 
 	/** Default destructor, removes the timer from the timer manager
 	 */
@@ -81,7 +81,7 @@ class CoreExport Timer
 
 	/** Sets the interval between two ticks.
 	 */
-	void SetInterval(unsigned int interval);
+	void SetInterval(unsigned long interval);
 
 	/** Called when the timer ticks.
 	 * You should override this method with some useful code to
@@ -101,7 +101,7 @@ class CoreExport Timer
 	/** Returns the interval (number of seconds between ticks)
 	 * of this timer object.
 	 */
-	unsigned int GetInterval() const
+	unsigned long GetInterval() const
 	{
 		return secs;
 	}

--- a/include/usermanager.h
+++ b/include/usermanager.h
@@ -158,32 +158,32 @@ class CoreExport UserManager : public fakederef<UserManager>
 	/** Return a count of all global users, unknown and known connections
 	 * @return The number of users on the network, including local unregistered users
 	 */
-	unsigned int UserCount() const { return this->clientlist.size(); }
+	size_t UserCount() const { return this->clientlist.size(); }
 
 	/** Return a count of fully registered connections on the network
 	 * @return The number of registered users on the network
 	 */
-	unsigned int RegisteredUserCount() { return this->clientlist.size() - this->UnregisteredUserCount() - this->ULineCount(); }
+	size_t RegisteredUserCount() { return this->clientlist.size() - this->UnregisteredUserCount() - this->ULineCount(); }
 
 	/** Return a count of opered (umode +o) users on the network
 	 * @return The number of opers on the network
 	 */
-	unsigned int OperCount() const { return this->all_opers.size(); }
+	size_t OperCount() const { return this->all_opers.size(); }
 
 	/** Return a count of local unregistered (before NICK/USER) users
 	 * @return The number of local unregistered (unknown) connections
 	 */
-	unsigned int UnregisteredUserCount() const { return this->unregistered_count; }
+	size_t UnregisteredUserCount() const { return this->unregistered_count; }
 
 	/** Return a count of users on a u-lined servers.
 	 * @return The number of users on u-lined servers.
 	 */
-	unsigned int ULineCount() const { return this->all_ulines.size(); }
+	size_t ULineCount() const { return this->all_ulines.size(); }
 
 	/** Return a count of local registered users
 	 * @return The number of registered local users
 	 */
-	unsigned int LocalUserCount() const { return (this->local_users.size() - this->UnregisteredUserCount()); }
+	size_t LocalUserCount() const { return (this->local_users.size() - this->UnregisteredUserCount()); }
 
 	/** Get a hash map containing all users, keyed by their nickname
 	 * @return A hash map mapping nicknames to User pointers

--- a/include/users.h
+++ b/include/users.h
@@ -89,7 +89,7 @@ struct CoreExport ConnectClass : public refcountbase
 
 	/** Max time to register the connection in seconds
 	 */
-	unsigned int registration_timeout;
+	unsigned long registration_timeout;
 
 	/** Hosts that this user can connect from as a string. */
 	std::string host;
@@ -99,7 +99,7 @@ struct CoreExport ConnectClass : public refcountbase
 
 	/** Number of seconds between pings for this line
 	 */
-	unsigned int pingtime;
+	unsigned long pingtime;
 
 	/** Maximum size of sendq for users in this class (bytes)
 	 * Users cannot send commands if they go over this limit
@@ -117,10 +117,10 @@ struct CoreExport ConnectClass : public refcountbase
 
 	/** Seconds worth of penalty before penalty system activates
 	 */
-	unsigned int penaltythreshold;
+	unsigned long penaltythreshold;
 
 	/** Maximum rate of commands (units: millicommands per second) */
-	unsigned int commandrate;
+	unsigned long commandrate;
 
 	/** Local max when connecting by this connection class
 	 */
@@ -136,7 +136,7 @@ struct CoreExport ConnectClass : public refcountbase
 
 	/** Max channels for this class
 	 */
-	unsigned int maxchans;
+	unsigned long maxchans;
 
 	/** How many users may be in this connect class before they are refused?
 	 * (0 = no limit = default)
@@ -181,9 +181,9 @@ struct CoreExport ConnectClass : public refcountbase
 
 	/** Returns the ping frequency
 	 */
-	unsigned int GetPingTime()
+	unsigned long GetPingTime()
 	{
-		return (pingtime ? pingtime : 120);
+		return (pingtime ? pingtime : 120L);
 	}
 
 	/** Returns the maximum sendq value (soft limit)
@@ -191,33 +191,33 @@ struct CoreExport ConnectClass : public refcountbase
 	 */
 	unsigned long GetSendqSoftMax()
 	{
-		return (softsendqmax ? softsendqmax : 4096);
+		return (softsendqmax ? softsendqmax : 4096L);
 	}
 
 	/** Returns the maximum sendq value (hard limit)
 	 */
 	unsigned long GetSendqHardMax()
 	{
-		return (hardsendqmax ? hardsendqmax : 0x100000);
+		return (hardsendqmax ? hardsendqmax : 0x100000L);
 	}
 
 	/** Returns the maximum recvq value
 	 */
 	unsigned long GetRecvqMax()
 	{
-		return (recvqmax ? recvqmax : 4096);
+		return (recvqmax ? recvqmax : 4096L);
 	}
 
 	/** Returns the penalty threshold value
 	 */
-	unsigned int GetPenaltyThreshold()
+	unsigned long GetPenaltyThreshold()
 	{
-		return penaltythreshold ? penaltythreshold : (fakelag ? 10 : 20);
+		return penaltythreshold ? penaltythreshold : (fakelag ? 10L : 20L);
 	}
 
-	unsigned int GetCommandRate()
+	unsigned long GetCommandRate()
 	{
-		return commandrate ? commandrate : 1000;
+		return commandrate ? commandrate : 1000L;
 	}
 
 	/** Return the maximum number of local sessions

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -68,7 +68,10 @@ INSTMODE_TXT ?= 0644
 INSTMODE_PRV ?= 0640
 
 ifneq ($(COMPILER), ICC)
-  CORECXXFLAGS += -Woverloaded-virtual -Wshadow
+    CORECXXFLAGS += -Woverloaded-virtual -Wshadow -Werror
+    ifneq ($COMPILER), GCC)
+      CORECXXFLAGS += -Wshorten-64-to-32
+    endif
 ifneq ($(SYSTEM), openbsd)
     CORECXXFLAGS += -pedantic -Wformat=2 -Wmissing-format-attribute -Wno-format-nonliteral
 endif

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -177,12 +177,12 @@ Channel* Channel::JoinUser(LocalUser* user, std::string cname, bool override, co
 	 */
 	if (!override)
 	{
-		unsigned int maxchans = user->GetClass()->maxchans;
+		unsigned long maxchans = user->GetClass()->maxchans;
 		if (!maxchans)
 			maxchans = ServerInstance->Config->MaxChans;
 		if (user->IsOper())
 		{
-			unsigned int opermaxchans = ConvToNum<unsigned int>(user->oper->getConfig("maxchans"));
+			unsigned long opermaxchans = ConvToNum<unsigned long>(user->oper->getConfig("maxchans"));
 			// If not set, use 2.0's <channels:opers>, if that's not set either, use limit from CC
 			if (!opermaxchans && user->HasPrivPermission("channels/high-join-limit"))
 				opermaxchans = ServerInstance->Config->OperMaxChans;

--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -307,8 +307,8 @@ void ServerConfig::CrossCheckConnectBlocks(ServerConfig* current)
 			if (!ports.empty())
 			{
 				irc::portparser portrange(ports, false);
-				while (int port = portrange.GetToken())
-					me->ports.insert(port);
+				while (long port = portrange.GetToken())
+					me->ports.insert(static_cast<int>(port));
 			}
 
 			ClassMap::iterator oldMask = oldBlocksByMask.find(std::make_pair(me->name, me->type));

--- a/src/coremods/core_dns.cpp
+++ b/src/coremods/core_dns.cpp
@@ -323,7 +323,7 @@ class Packet : public Query
 				}
 				else
 				{
-					unsigned long forward = ip.in4.sin_addr.s_addr;
+					in_addr_t forward = ip.in4.sin_addr.s_addr;
 					ip.in4.sin_addr.s_addr = forward << 24 | (forward & 0xFF00) << 8 | (forward & 0xFF0000) >> 8 | forward >> 24;
 
 					q.name = ip.addr() + ".in-addr.arpa";
@@ -476,7 +476,7 @@ class MyManager : public Manager, public Timer, public EventHandler
 
 		/* Create an id */
 		unsigned int tries = 0;
-		int id;
+		long id;
 		do
 		{
 			id = ServerInstance->GenRandomInt(DNS::MAX_REQUEST_ID+1);
@@ -600,7 +600,7 @@ class MyManager : public Manager, public Timer, public EventHandler
 		irc::sockets::sockaddrs from;
 		socklen_t x = sizeof(from);
 
-		int length = SocketEngine::RecvFrom(this, buffer, sizeof(buffer), 0, &from.sa, &x);
+		ssize_t length = SocketEngine::RecvFrom(this, buffer, sizeof(buffer), 0, &from.sa, &x);
 
 		if (length < Packet::HEADER_LENGTH)
 			return;
@@ -873,7 +873,7 @@ class ModuleDNS : public Module
 		SourceIP = tag->getString("sourceip");
 
 		const unsigned int oldport = SourcePort;
-		SourcePort = tag->getUInt("sourceport", 0, 0, UINT16_MAX);
+		SourcePort = static_cast<unsigned int>(tag->getUInt("sourceport", 0, 0, UINT16_MAX));
 
 		if (DNSServer.empty())
 			FindDNSServer();

--- a/src/coremods/core_lusers.cpp
+++ b/src/coremods/core_lusers.cpp
@@ -28,8 +28,8 @@
 
 struct LusersCounters
 {
-	unsigned int max_local;
-	unsigned int max_global;
+	unsigned long max_local;
+	unsigned long max_global;
 	unsigned int invisible;
 
 	LusersCounters(unsigned int inv)
@@ -41,7 +41,7 @@ struct LusersCounters
 
 	inline void UpdateMaxUsers()
 	{
-		unsigned int current = ServerInstance->Users->LocalUserCount();
+		unsigned long current = ServerInstance->Users->LocalUserCount();
 		if (current > max_local)
 			max_local = current;
 
@@ -74,10 +74,10 @@ class CommandLusers : public Command
  */
 CmdResult CommandLusers::Handle(User* user, const Params& parameters)
 {
-	unsigned int n_users = ServerInstance->Users->RegisteredUserCount();
+	size_t n_users = ServerInstance->Users->RegisteredUserCount();
 	ProtocolInterface::ServerList serverlist;
 	ServerInstance->PI->GetServerList(serverlist);
-	unsigned int n_serv = serverlist.size();
+	size_t n_serv = serverlist.size();
 	unsigned int n_local_servs = 0;
 	for (ProtocolInterface::ServerList::const_iterator i = serverlist.begin(); i != serverlist.end(); ++i)
 	{
@@ -90,7 +90,7 @@ CmdResult CommandLusers::Handle(User* user, const Params& parameters)
 
 	counters.UpdateMaxUsers();
 
-	user->WriteNumeric(RPL_LUSERCLIENT, InspIRCd::Format("There are %d users and %d invisible on %d servers",
+	user->WriteNumeric(RPL_LUSERCLIENT, InspIRCd::Format("There are %lu users and %d invisible on %zu servers",
 			n_users - counters.invisible, counters.invisible, n_serv));
 
 	if (ServerInstance->Users->OperCount())
@@ -100,9 +100,9 @@ CmdResult CommandLusers::Handle(User* user, const Params& parameters)
 		user->WriteNumeric(RPL_LUSERUNKNOWN, ServerInstance->Users.UnregisteredUserCount(), "unknown connections");
 
 	user->WriteNumeric(RPL_LUSERCHANNELS, ServerInstance->GetChans().size(), "channels formed");
-	user->WriteNumeric(RPL_LUSERME, InspIRCd::Format("I have %d clients and %d servers", ServerInstance->Users.LocalUserCount(), n_local_servs));
-	user->WriteNumeric(RPL_LOCALUSERS, InspIRCd::Format("Current local users: %d  Max: %d", ServerInstance->Users.LocalUserCount(), counters.max_local));
-	user->WriteNumeric(RPL_GLOBALUSERS, InspIRCd::Format("Current global users: %d  Max: %d", n_users, counters.max_global));
+	user->WriteNumeric(RPL_LUSERME, InspIRCd::Format("I have %zu clients and %d servers", ServerInstance->Users.LocalUserCount(), n_local_servs));
+	user->WriteNumeric(RPL_LOCALUSERS, InspIRCd::Format("Current local users: %zu  Max: %lu", ServerInstance->Users.LocalUserCount(), counters.max_local));
+	user->WriteNumeric(RPL_GLOBALUSERS, InspIRCd::Format("Current global users: %lu  Max: %lu", n_users, counters.max_global));
 
 	return CMD_SUCCESS;
 }

--- a/src/coremods/core_user/cmd_userhost.cpp
+++ b/src/coremods/core_user/cmd_userhost.cpp
@@ -32,11 +32,12 @@ CmdResult CommandUserhost::Handle(User* user, const Params& parameters)
 
 	std::string retbuf;
 
-	unsigned int max = parameters.size();
+	size_t max = parameters.size();
 	if (max > 5)
 		max = 5;
 
-	for (unsigned int i = 0; i < max; i++)
+  // This cast is safe thanks to the above clamp.
+	for (unsigned int i = 0; i < static_cast<unsigned int>(max); i++)
 	{
 		User *u = ServerInstance->FindNickOnly(parameters[i]);
 

--- a/src/coremods/core_user/cmd_userhost.cpp
+++ b/src/coremods/core_user/cmd_userhost.cpp
@@ -36,7 +36,7 @@ CmdResult CommandUserhost::Handle(User* user, const Params& parameters)
 	if (max > 5)
 		max = 5;
 
-  // This cast is safe thanks to the above clamp.
+	// This cast is safe thanks to the above clamp.
 	for (unsigned int i = 0; i < static_cast<unsigned int>(max); i++)
 	{
 		User *u = ServerInstance->FindNickOnly(parameters[i]);

--- a/src/coremods/core_whowas.cpp
+++ b/src/coremods/core_whowas.cpp
@@ -443,9 +443,9 @@ class ModuleWhoWas : public Module, public Stats::EventListener
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("whowas");
-		unsigned int NewGroupSize = tag->getUInt("groupsize", 10, 0, 10000);
-		unsigned int NewMaxGroups = tag->getUInt("maxgroups", 10240, 0, 1000000);
-		unsigned int NewMaxKeep = tag->getDuration("maxkeep", 3600, 3600);
+		unsigned int NewGroupSize = static_cast<unsigned int>(tag->getUInt("groupsize", 10, 0, 10000));
+		unsigned int NewMaxGroups = static_cast<unsigned int>(tag->getUInt("maxgroups", 10240, 0, 1000000));
+		unsigned int NewMaxKeep = static_cast<unsigned int>(tag->getDuration("maxkeep", 3600, 3600));
 
 		cmd.manager.UpdateConfig(NewGroupSize, NewMaxGroups, NewMaxKeep);
 	}

--- a/src/helperfuncs.cpp
+++ b/src/helperfuncs.cpp
@@ -513,7 +513,7 @@ std::string InspIRCd::TimeString(time_t curtime, const char* format, bool utc)
 	return buffer;
 }
 
-std::string InspIRCd::GenRandomStr(unsigned int length, bool printable)
+std::string InspIRCd::GenRandomStr(size_t length, bool printable)
 {
 	std::vector<char> str(length);
 	GenRandom(&str[0], length);

--- a/src/inspircd.cpp
+++ b/src/inspircd.cpp
@@ -351,7 +351,7 @@ namespace
 #if defined _WIN32
 		srand(ts.tv_nsec ^ ts.tv_sec);
 #elif !defined HAS_ARC4RANDOM_BUF
-		srandom(ts.tv_nsec ^ ts.tv_sec);
+		srandom(static_cast<int>(ts.tv_nsec ^ ts.tv_sec));
 #endif
 	}
 

--- a/src/inspstring.cpp
+++ b/src/inspstring.cpp
@@ -103,7 +103,7 @@ std::string Base64ToBin(const std::string& data_str, const char* table)
 		const char* find = strchr(table, *data++);
 		if (!find || find >= table + 64)
 			break;
-		buffer = (buffer << 6) | (find - table);
+		buffer = (buffer << 6) | static_cast<uint32_t>(find - table);
 		bitcount += 6;
 		if (bitcount >= 8)
 		{

--- a/src/listensocket.cpp
+++ b/src/listensocket.cpp
@@ -96,7 +96,8 @@ ListenSocket::ListenSocket(ConfigTag* tag, const irc::sockets::sockaddrs& bind_t
 		const std::string permissionstr = tag->getString("permissions");
 		unsigned long permissions = strtoul(permissionstr.c_str(), NULL, 8);
 		if (permissions && permissions <= 07777)
-			chmod(bind_to.str().c_str(), static_cast<__mode_t>(permissions));
+			// This cast is safe thanks to the above check.
+			chmod(bind_to.str().c_str(), static_cast<int>(permissions));
 	}
 
 	// Default defer to on for TLS listeners because in TLS the client always speaks first

--- a/src/listmode.cpp
+++ b/src/listmode.cpp
@@ -110,7 +110,7 @@ void ListModeBase::DoRehash()
 	}
 }
 
-unsigned int ListModeBase::FindLimit(const std::string& channame)
+unsigned long ListModeBase::FindLimit(const std::string& channame)
 {
 	for (limitlist::iterator it = chanlimits.begin(); it != chanlimits.end(); ++it)
 	{
@@ -123,14 +123,14 @@ unsigned int ListModeBase::FindLimit(const std::string& channame)
 	return 0;
 }
 
-unsigned int ListModeBase::GetLimitInternal(const std::string& channame, ChanData* cd)
+unsigned long ListModeBase::GetLimitInternal(const std::string& channame, ChanData* cd)
 {
 	if (cd->maxitems < 0)
 		cd->maxitems = FindLimit(channame);
 	return cd->maxitems;
 }
 
-unsigned int ListModeBase::GetLimit(Channel* channel)
+unsigned long ListModeBase::GetLimit(Channel* channel)
 {
 	ChanData* cd = extItem.get(channel);
 	if (!cd) // just find the limit
@@ -144,13 +144,14 @@ unsigned int ListModeBase::GetLowerLimit()
 	if (chanlimits.empty())
 		return DEFAULT_LIST_SIZE;
 
-	unsigned int limit = UINT_MAX;
+	// The below cast to unsigned int is safe thanks to this initializer.
+	unsigned long limit = UINT_MAX;
 	for (limitlist::iterator iter = chanlimits.begin(); iter != chanlimits.end(); ++iter)
 	{
 		if (iter->limit < limit)
 			limit = iter->limit;
 	}
-	return limit;
+	return static_cast<unsigned int>(limit);
 }
 
 ModeAction ListModeBase::OnModeChange(User* source, User*, Channel* channel, std::string &parameter, bool adding)

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -125,7 +125,7 @@ void LogManager::OpenFileLogs()
 			struct tm *mytime = gmtime(&time);
 			strftime(realtarget, sizeof(realtarget), target.c_str(), mytime);
 			FILE* f = fopen(realtarget, "a");
-			fw = new FileWriter(f, tag->getUInt("flush", 20, 1, UINT_MAX));
+			fw = new FileWriter(f, static_cast<unsigned int>(tag->getUInt("flush", 20, 1, UINT_MAX)));
 			logmap.insert(std::make_pair(target, fw));
 		}
 		else

--- a/src/mode.cpp
+++ b/src/mode.cpp
@@ -365,7 +365,7 @@ ModeAction ModeParser::TryMode(User* user, User* targetuser, Channel* chan, Mode
 	return MODEACTION_ALLOW;
 }
 
-void ModeParser::ModeParamsToChangeList(User* user, ModeType type, const std::vector<std::string>& parameters, Modes::ChangeList& changelist, unsigned int beginindex, unsigned int endindex)
+void ModeParser::ModeParamsToChangeList(User* user, ModeType type, const std::vector<std::string>& parameters, Modes::ChangeList& changelist, size_t beginindex, size_t endindex)
 {
 	if (endindex > parameters.size())
 		endindex = parameters.size();
@@ -373,7 +373,7 @@ void ModeParser::ModeParamsToChangeList(User* user, ModeType type, const std::ve
 	const std::string& mode_sequence = parameters[beginindex];
 
 	bool adding = true;
-	unsigned int param_at = beginindex+1;
+	size_t param_at = beginindex+1;
 
 	for (std::string::const_iterator letter = mode_sequence.begin(); letter != mode_sequence.end(); letter++)
 	{

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -322,7 +322,7 @@ swap_now:
 		if (my_pos > swap_pos)
 			incrmnt = -1;
 
-		for (unsigned int j = my_pos; j != swap_pos; j += incrmnt)
+		for (size_t j = my_pos; j != swap_pos; j += incrmnt)
 		{
 			if ((j + incrmnt > EventHandlers[i].size() - 1) || ((incrmnt == -1) && (j == 0)))
 				continue;

--- a/src/modules/extra/m_regex_pcre.cpp
+++ b/src/modules/extra/m_regex_pcre.cpp
@@ -65,7 +65,7 @@ class PCRERegex : public Regex
 
 	bool Matches(const std::string& text) CXX11_OVERRIDE
 	{
-    // Possibly unsafe cast here, but pcre_exec expects an int.
+		// Possibly unsafe cast here, but pcre_exec expects an int.
 		return (pcre_exec(regex, NULL, text.c_str(), int(text.length()), 0, 0, NULL, 0) >= 0);
 	}
 };

--- a/src/modules/extra/m_regex_pcre.cpp
+++ b/src/modules/extra/m_regex_pcre.cpp
@@ -65,7 +65,8 @@ class PCRERegex : public Regex
 
 	bool Matches(const std::string& text) CXX11_OVERRIDE
 	{
-		return (pcre_exec(regex, NULL, text.c_str(), text.length(), 0, 0, NULL, 0) >= 0);
+    // Possibly unsafe cast here, but pcre_exec expects an int.
+		return (pcre_exec(regex, NULL, text.c_str(), int(text.length()), 0, 0, NULL, 0) >= 0);
 	}
 };
 

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -276,7 +276,7 @@ namespace OpenSSL
 				crlfile.empty() ? NULL : crlfile.c_str(),
 				crlpath.empty() ? NULL : crlpath.c_str()))
 			{
-				int err = ERR_get_error();
+				unsigned long err = ERR_get_error();
 				throw ModuleException("Unable to load CRL file '" + crlfile + "' or CRL path '" + crlpath + "': '" + (err ? ERR_error_string(err, NULL) : "unknown") + "'");
 			}
 
@@ -408,7 +408,7 @@ namespace OpenSSL
 			, ctx(SSL_CTX_new(SSLv23_server_method()))
 			, clictx(SSL_CTX_new(SSLv23_client_method()))
 			, allowrenego(tag->getBool("renegotiation")) // Disallow by default
-			, outrecsize(tag->getUInt("outrecsize", 2048, 512, 16384))
+			, outrecsize(static_cast<unsigned int>(tag->getUInt("outrecsize", 2048, 512, 16384)))
 		{
 			if ((!ctx.SetDH(dh)) || (!clictx.SetDH(dh)))
 				throw Exception("Couldn't set DH parameters");
@@ -518,6 +518,8 @@ namespace OpenSSL
 			return 0;
 		}
 
+		// These signatures are required by the BIO_meth_set_write|read interface
+		// even though they lead to shortening issues.
 		static int read(BIO* bio, char* buf, int len);
 		static int write(BIO* bio, const char* buf, int len);
 
@@ -774,7 +776,8 @@ class OpenSSLIOHook : public SSLIOHook
 		{
 			ERR_clear_error();
 			char* buffer = ServerInstance->GetReadBuffer();
-			size_t bufsiz = ServerInstance->Config->NetBufferSize;
+      // This cast may be unsafe but an int is expected by SSL_read.
+			int bufsiz = static_cast<int>(ServerInstance->Config->NetBufferSize);
 			int ret = SSL_read(sess, buffer, bufsiz);
 
 			if (!CheckRenego(user))
@@ -838,7 +841,7 @@ class OpenSSLIOHook : public SSLIOHook
 			ERR_clear_error();
 			FlattenSendQueue(sendq, GetProfile().GetOutgoingRecordSize());
 			const StreamSocket::SendQueue::Element& buffer = sendq.front();
-			int ret = SSL_write(sess, buffer.data(), buffer.size());
+			int ret = SSL_write(sess, buffer.data(), static_cast<int>(buffer.size()));
 
 			if (!CheckRenego(user))
 				return -1;
@@ -926,7 +929,7 @@ static int OpenSSL::BIOMethod::write(BIO* bio, const char* buffer, int size)
 		return -1;
 	}
 
-	int ret = SocketEngine::Send(sock, buffer, size, 0);
+	ssize_t ret = SocketEngine::Send(sock, buffer, size, 0);
 	if ((ret < size) && ((ret > 0) || (SocketEngine::IgnoreError())))
 	{
 		// Blocked, set retry flag for OpenSSL
@@ -934,7 +937,7 @@ static int OpenSSL::BIOMethod::write(BIO* bio, const char* buffer, int size)
 		BIO_set_retry_write(bio);
 	}
 
-	return ret;
+	return static_cast<int>(ret);
 }
 
 static int OpenSSL::BIOMethod::read(BIO* bio, char* buffer, int size)
@@ -949,7 +952,7 @@ static int OpenSSL::BIOMethod::read(BIO* bio, char* buffer, int size)
 		return -1;
 	}
 
-	int ret = SocketEngine::Recv(sock, buffer, size, 0);
+	ssize_t ret = SocketEngine::Recv(sock, buffer, size, 0);
 	if ((ret < size) && ((ret > 0) || (SocketEngine::IgnoreError())))
 	{
 		// Blocked, set retry flag for OpenSSL
@@ -957,7 +960,7 @@ static int OpenSSL::BIOMethod::read(BIO* bio, char* buffer, int size)
 		BIO_set_retry_read(bio);
 	}
 
-	return ret;
+	return static_cast<int>(ret);
 }
 
 class OpenSSLIOHookProvider : public SSLIOHookProvider

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -776,7 +776,7 @@ class OpenSSLIOHook : public SSLIOHook
 		{
 			ERR_clear_error();
 			char* buffer = ServerInstance->GetReadBuffer();
-      // This cast may be unsafe but an int is expected by SSL_read.
+			// This cast may be unsafe but an int is expected by SSL_read.
 			int bufsiz = static_cast<int>(ServerInstance->Config->NetBufferSize);
 			int ret = SSL_read(sess, buffer, bufsiz);
 

--- a/src/modules/m_banredirect.cpp
+++ b/src/modules/m_banredirect.cpp
@@ -85,11 +85,11 @@ class BanRedirect : public ModeWatcher
 				return true;
 
 			ListModeBase* banlm = static_cast<ListModeBase*>(*ban);
-			unsigned int maxbans = banlm->GetLimit(channel);
+			unsigned long maxbans = banlm->GetLimit(channel);
 			ListModeBase::ModeList* list = banlm->GetList(channel);
 			if ((list) && (adding) && (maxbans <= list->size()))
 			{
-				source->WriteNumeric(ERR_BANLISTFULL, channel->name, banlm->GetModeChar(), InspIRCd::Format("Channel ban list for %s is full (maximum entries for this channel is %u)", channel->name.c_str(), maxbans));
+				source->WriteNumeric(ERR_BANLISTFULL, channel->name, banlm->GetModeChar(), InspIRCd::Format("Channel ban list for %s is full (maximum entries for this channel is %lu)", channel->name.c_str(), maxbans));
 				return false;
 			}
 

--- a/src/modules/m_bcrypt.cpp
+++ b/src/modules/m_bcrypt.cpp
@@ -42,7 +42,7 @@ class BCryptProvider : public HashProvider
 	}
 
  public:
-	unsigned int rounds;
+	unsigned long rounds;
 
 	std::string Generate(const std::string& data, const std::string& salt)
 	{

--- a/src/modules/m_blockamsg.cpp
+++ b/src/modules/m_blockamsg.cpp
@@ -50,7 +50,7 @@ class BlockedMessage
 
 class ModuleBlockAmsg : public Module
 {
-	unsigned int ForgetDelay;
+	unsigned long ForgetDelay;
 	BlockAction action;
 	SimpleExtItem<BlockedMessage> blockamsg;
 
@@ -118,7 +118,12 @@ class ModuleBlockAmsg : public Module
 			// OR
 			// The number of target channels is equal to the number of channels the sender is on..a little suspicious.
 			// Check it's more than 1 too, or else users on one channel would have fun.
-			if ((m && (m->message == parameters[1]) && (!irc::equals(m->target, parameters[0])) && ForgetDelay && (m->sent >= ServerInstance->Time()-ForgetDelay)) || ((targets > 1) && (targets == user->chans.size())))
+			if ((m &&
+						(m->message == parameters[1]) &&
+						(!irc::equals(m->target, parameters[0])) &&
+						ForgetDelay &&
+						(m->sent >= ServerInstance->Time()-(long)ForgetDelay)) ||
+					((targets > 1) && (targets == user->chans.size())))
 			{
 				// Block it...
 				if (action == IBLOCK_KILLOPERS || action == IBLOCK_NOTICEOPERS)

--- a/src/modules/m_blockcaps.cpp
+++ b/src/modules/m_blockcaps.cpp
@@ -33,7 +33,7 @@ class ModuleBlockCAPS : public Module
 	CheckExemption::EventProvider exemptionprov;
 	SimpleChannelModeHandler bc;
 	unsigned int percent;
-	unsigned int minlen;
+	size_t minlen;
 	std::bitset<UCHAR_MAX + 1> lowercase;
 	std::bitset<UCHAR_MAX + 1> uppercase;
 
@@ -98,7 +98,7 @@ public:
 				// any upper case letters.
 				if (length > 0 && round((upper * 100) / length) >= percent)
 				{
-					const std::string msg = InspIRCd::Format("Your message cannot contain %d%% or more capital letters if it's longer than %d characters", percent, minlen);
+					const std::string msg = InspIRCd::Format("Your message cannot contain %d%% or more capital letters if it's longer than %zu characters", percent, minlen);
 					user->WriteNumeric(Numerics::CannotSendTo(c, msg));
 					return MOD_RES_DENY;
 				}
@@ -110,7 +110,7 @@ public:
 	void ReadConfig(ConfigStatus& status) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("blockcaps");
-		percent = tag->getUInt("percent", 100, 1, 100);
+		percent = static_cast<unsigned int>(tag->getUInt("percent", 100, 1, 100));
 		minlen = tag->getUInt("minlen", 1, 1, ServerInstance->Config->Limits.MaxLine);
 
 		lowercase.reset();

--- a/src/modules/m_callerid.cpp
+++ b/src/modules/m_callerid.cpp
@@ -181,7 +181,7 @@ class CommandAccept : public Command
 
 public:
 	CallerIDExtInfo extInfo;
-	unsigned int maxaccepts;
+	unsigned long maxaccepts;
 	CommandAccept(Module* Creator) : Command(Creator, "ACCEPT", 1),
 		extInfo(Creator)
 	{
@@ -282,7 +282,7 @@ public:
 		callerid_data* dat = extInfo.get(user, true);
 		if (dat->accepting.size() >= maxaccepts)
 		{
-			user->WriteNumeric(ERR_ACCEPTFULL, InspIRCd::Format("Accept list is full (limit is %d)", maxaccepts));
+			user->WriteNumeric(ERR_ACCEPTFULL, InspIRCd::Format("Accept list is full (limit is %lu)", maxaccepts));
 			return false;
 		}
 		if (!dat->accepting.insert(whotoadd).second)
@@ -362,7 +362,7 @@ class ModuleCallerID
 
 	// Configuration variables:
 	bool tracknick; // Allow ACCEPT entries to update with nick changes.
-	unsigned int notify_cooldown; // Seconds between notifications.
+	unsigned long notify_cooldown; // Seconds between notifications.
 
 	/** Removes a user from all accept lists
 	 * @param who The user to remove from accepts

--- a/src/modules/m_chanhistory.cpp
+++ b/src/modules/m_chanhistory.cpp
@@ -53,10 +53,10 @@ struct HistoryItem
 struct HistoryList
 {
 	std::deque<HistoryItem> lines;
-	unsigned int maxlen;
-	unsigned int maxtime;
+	unsigned long maxlen;
+	unsigned long maxtime;
 
-	HistoryList(unsigned int len, unsigned int time)
+	HistoryList(unsigned long len, unsigned long time)
 		: maxlen(len)
 		, maxtime(time)
 	{
@@ -78,7 +78,7 @@ struct HistoryList
 class HistoryMode : public ParamMode<HistoryMode, SimpleExtItem<HistoryList> >
 {
  public:
-	unsigned int maxlines;
+	unsigned long maxlines;
 	HistoryMode(Module* Creator)
 		: ParamMode<HistoryMode, SimpleExtItem<HistoryList> >(Creator, "history", 'H')
 	{
@@ -101,7 +101,7 @@ class HistoryMode : public ParamMode<HistoryMode, SimpleExtItem<HistoryList> >
 			return MODEACTION_DENY;
 		}
 
-		unsigned int len = ConvToNum<unsigned int>(parameter.substr(0, colon));
+		unsigned long len = ConvToNum<unsigned long>(parameter.substr(0, colon));
 		unsigned long time;
 		if (!InspIRCd::Duration(duration, time) || len == 0 || (len > maxlines && IS_LOCAL(source)))
 		{

--- a/src/modules/m_channames.cpp
+++ b/src/modules/m_channames.cpp
@@ -117,12 +117,12 @@ class ModuleChannelNames : public Module
 		allowedmap.set();
 
 		irc::portparser denyrange(denyToken, false);
-		int denyno = -1;
+		long denyno = -1;
 		while (0 != (denyno = denyrange.GetToken()))
 			allowedmap[denyno & 0xFF] = false;
 
 		irc::portparser allowrange(allowToken, false);
-		int allowno = -1;
+		long allowno = -1;
 		while (0 != (allowno = allowrange.GetToken()))
 			allowedmap[allowno & 0xFF] = true;
 

--- a/src/modules/m_cloaking.cpp
+++ b/src/modules/m_cloaking.cpp
@@ -466,7 +466,7 @@ class ModuleCloaking : public Module
 			const std::string suffix = tag->getString("suffix", ".IP");
 			if (stdalgo::string::equalsci(mode, "half"))
 			{
-				unsigned int domainparts = tag->getUInt("domainparts", 3, 1, 10);
+				unsigned int domainparts = static_cast<unsigned int>(tag->getUInt("domainparts", 3, 1, 10));
 				newcloaks.push_back(CloakInfo(MODE_HALF_CLOAK, key, prefix, suffix, ignorecase, domainparts));
 			}
 			else if (stdalgo::string::equalsci(mode, "full"))

--- a/src/modules/m_conn_join.cpp
+++ b/src/modules/m_conn_join.cpp
@@ -80,7 +80,7 @@ class ModuleConnJoin : public Module
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("autojoin");
 		defchans = tag->getString("channel");
-		defdelay = tag->getDuration("delay", 0, 0, 60*15);
+		defdelay = static_cast<unsigned int>(tag->getDuration("delay", 0, 0, 60*15));
 	}
 
 	void Prioritize() CXX11_OVERRIDE
@@ -100,7 +100,7 @@ class ModuleConnJoin : public Module
 			return;
 
 		std::string chanlist = localuser->GetClass()->config->getString("autojoin");
-		unsigned int chandelay = localuser->GetClass()->config->getDuration("autojoindelay", 0, 0, 60*15);
+		unsigned int chandelay = static_cast<unsigned int>(localuser->GetClass()->config->getDuration("autojoindelay", 0, 0, 60*15));
 
 		if (chanlist.empty())
 		{

--- a/src/modules/m_connectban.cpp
+++ b/src/modules/m_connectban.cpp
@@ -34,8 +34,8 @@ class ModuleConnectBan
 {
 	typedef std::map<irc::sockets::cidr_mask, unsigned int> ConnectMap;
 	ConnectMap connects;
-	unsigned int threshold;
-	unsigned int banduration;
+	unsigned long threshold;
+	unsigned long banduration;
 	unsigned int ipv4_cidr;
 	unsigned int ipv6_cidr;
 	std::string banmessage;
@@ -92,8 +92,8 @@ class ModuleConnectBan
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("connectban");
 
-		ipv4_cidr = tag->getUInt("ipv4cidr", 32, 1, 32);
-		ipv6_cidr = tag->getUInt("ipv6cidr", 128, 1, 128);
+		ipv4_cidr = static_cast<unsigned int>(tag->getUInt("ipv4cidr", 32, 1, 32));
+		ipv6_cidr = static_cast<unsigned int>(tag->getUInt("ipv6cidr", 128, 1, 128));
 		threshold = tag->getUInt("threshold", 10, 1);
 		banduration = tag->getDuration("duration", 10*60, 1);
 		banmessage = tag->getString("banmessage", "Your IP range has been attempting to connect too many times in too short a duration. Wait a while, and you will be able to connect.");
@@ -138,7 +138,7 @@ class ModuleConnectBan
 				std::string maskstr = mask.str();
 				ServerInstance->SNO->WriteGlobalSno('x', "Z-line added by module m_connectban on %s to expire in %s (on %s): Connect flooding",
 					maskstr.c_str(), InspIRCd::DurationString(zl->duration).c_str(), InspIRCd::TimeString(zl->expiry).c_str());
-				ServerInstance->SNO->WriteGlobalSno('a', "Connect flooding from IP range %s (%d)", maskstr.c_str(), threshold);
+				ServerInstance->SNO->WriteGlobalSno('a', "Connect flooding from IP range %s (%lu)", maskstr.c_str(), threshold);
 				connects.erase(i);
 			}
 		}

--- a/src/modules/m_connflood.cpp
+++ b/src/modules/m_connflood.cpp
@@ -28,11 +28,11 @@
 class ModuleConnFlood : public Module
 {
  private:
-	unsigned int seconds;
-	unsigned int timeout;
-	unsigned int boot_wait;
-	unsigned int conns;
-	unsigned int maxconns;
+	unsigned long seconds;
+	unsigned long timeout;
+	unsigned long boot_wait;
+	unsigned long conns;
+	unsigned long maxconns;
 	bool throttled;
 	time_t first;
 	std::string quitmsg;
@@ -81,7 +81,7 @@ public:
 
 		time_t next = ServerInstance->Time();
 
-		if ((ServerInstance->startup_time + boot_wait) > next)
+		if (time_t(ServerInstance->startup_time + boot_wait) > next)
 			return MOD_RES_PASSTHRU;
 
 		/* time difference between first and latest connection */
@@ -92,7 +92,7 @@ public:
 
 		if (throttled)
 		{
-			if (tdiff > seconds + timeout)
+			if (tdiff > time_t(seconds + timeout))
 			{
 				/* expire throttle */
 				throttled = false;
@@ -104,7 +104,7 @@ public:
 			return MOD_RES_DENY;
 		}
 
-		if (tdiff <= seconds)
+		if (tdiff <= time_t(seconds))
 		{
 			if (conns >= maxconns)
 			{

--- a/src/modules/m_customprefix.cpp
+++ b/src/modules/m_customprefix.cpp
@@ -31,13 +31,13 @@ class CustomPrefixMode : public PrefixMode
 		: PrefixMode(parent, Name, Letter, 0, Prefix)
 		, tag(Tag)
 	{
-		unsigned long rank = tag->getUInt("rank", 0, 0, UINT_MAX);
-		unsigned long setrank = tag->getUInt("ranktoset", prefixrank, rank, UINT_MAX);
-		unsigned long unsetrank = tag->getUInt("ranktounset", setrank, setrank, UINT_MAX);
+		unsigned int rank = static_cast<unsigned int>(tag->getUInt("rank", 0, 0, UINT_MAX));
+		unsigned int setrank = static_cast<unsigned int>(tag->getUInt("ranktoset", prefixrank, rank, UINT_MAX));
+		unsigned int unsetrank = static_cast<unsigned int>(tag->getUInt("ranktounset", setrank, setrank, UINT_MAX));
 		bool depriv = tag->getBool("depriv", true);
 		this->Update(rank, setrank, unsetrank, depriv);
 
-		ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Created the %s prefix: letter=%c prefix=%c rank=%u ranktoset=%u ranktounset=%i depriv=%d",
+		ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Created the %s prefix: letter=%c prefix=%c rank=%u ranktoset=%u ranktounset=%u depriv=%d",
 			name.c_str(), GetModeChar(), GetPrefix(), GetPrefixRank(), GetLevelRequired(true), GetLevelRequired(false), CanSelfRemove());
 	}
 };
@@ -67,9 +67,9 @@ class ModuleCustomPrefix : public Module
 				if (!pm)
 					throw ModuleException("<customprefix:change> specified for a non-prefix mode at " + tag->getTagLocation());
 
-				unsigned long rank = tag->getUInt("rank", pm->GetPrefixRank(), 0, UINT_MAX);
-				unsigned long setrank = tag->getUInt("ranktoset", pm->GetLevelRequired(true), rank, UINT_MAX);
-				unsigned long unsetrank = tag->getUInt("ranktounset", pm->GetLevelRequired(false), setrank, UINT_MAX);
+				unsigned int rank = static_cast<unsigned int>(tag->getUInt("rank", pm->GetPrefixRank(), 0, UINT_MAX));
+				unsigned int setrank = static_cast<unsigned int>(tag->getUInt("ranktoset", pm->GetLevelRequired(true), rank, UINT_MAX));
+				unsigned int unsetrank = static_cast<unsigned int>(tag->getUInt("ranktounset", pm->GetLevelRequired(false), setrank, UINT_MAX));
 				bool depriv = tag->getBool("depriv", pm->CanSelfRemove());
 				pm->Update(rank, setrank, unsetrank, depriv);
 

--- a/src/modules/m_dccallow.cpp
+++ b/src/modules/m_dccallow.cpp
@@ -108,7 +108,7 @@ bannedfilelist bfl;
 class DCCAllowExt : public SimpleExtItem<dccallowlist>
 {
  public:
-	unsigned int maxentries;
+	unsigned long maxentries;
 
 	DCCAllowExt(Module* Creator)
 		: SimpleExtItem<dccallowlist>("dccallow", ExtensionItem::EXT_USER, Creator)

--- a/src/modules/m_delaymsg.cpp
+++ b/src/modules/m_delaymsg.cpp
@@ -135,13 +135,13 @@ ModResult ModuleDelayMsg::HandleMessage(User* user, const MessageTarget& target,
 	if (ts == 0)
 		return MOD_RES_PASSTHRU;
 
-	int len = djm.ext.get(channel);
+	intptr_t len = djm.ext.get(channel);
 
 	if ((ts + len) > ServerInstance->Time())
 	{
 		if (channel->GetPrefixValue(user) < VOICE_VALUE)
 		{
-			const std::string message = InspIRCd::Format("You cannot send messages to this channel until you have been a member for %d seconds.", len);
+			const std::string message = InspIRCd::Format("You cannot send messages to this channel until you have been a member for %ld seconds.", len);
 			user->WriteNumeric(Numerics::CannotSendTo(channel, message));
 			return MOD_RES_DENY;
 		}

--- a/src/modules/m_dnsbl.cpp
+++ b/src/modules/m_dnsbl.cpp
@@ -42,7 +42,7 @@ class DNSBLConfEntry : public refcountbase
 		EnumType type;
 		unsigned long duration;
 		unsigned int bitmask;
-		unsigned int timeout;
+		unsigned long timeout;
 		unsigned char records[256];
 		unsigned long stats_hits, stats_misses, stats_errors;
 		DNSBLConfEntry()
@@ -91,7 +91,7 @@ class DNSBLResolver : public DNS::Request
 			return;
 		}
 
-		int i = countExt.get(them);
+		intptr_t i = countExt.get(them);
 		if (i)
 			countExt.set(them, i - 1);
 
@@ -265,7 +265,7 @@ class DNSBLResolver : public DNS::Request
 		if (!them || them->client_sa != theirsa)
 			return;
 
-		int i = countExt.get(them);
+		intptr_t i = countExt.get(them);
 		if (i)
 			countExt.set(them, i - 1);
 
@@ -350,7 +350,7 @@ class ModuleDNSBL : public Module, public Stats::EventListener
 			if (stdalgo::string::equalsci(tag->getString("type"), "bitmask"))
 			{
 				e->type = DNSBLConfEntry::A_BITMASK;
-				e->bitmask = tag->getUInt("bitmask", 0, 0, UINT_MAX);
+				e->bitmask = static_cast<unsigned int>(tag->getUInt("bitmask", 0, 0, UINT_MAX));
 			}
 			else
 			{

--- a/src/modules/m_flashpolicyd.cpp
+++ b/src/modules/m_flashpolicyd.cpp
@@ -46,7 +46,7 @@ class FlashPDSocket : public BufferedSocket, public Timer, public insp::intrusiv
 	}
 
  public:
-	FlashPDSocket(int newfd, unsigned int timeoutsec)
+	FlashPDSocket(int newfd, unsigned long timeoutsec)
 		: BufferedSocket(newfd)
 		, Timer(timeoutsec)
 		, waitingcull(false)
@@ -84,7 +84,7 @@ class FlashPDSocket : public BufferedSocket, public Timer, public insp::intrusiv
 
 class ModuleFlashPD : public Module
 {
-	unsigned int timeout;
+	unsigned long timeout;
 
  public:
 	ModResult OnAcceptConnection(int nfd, ListenSocket* from, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server) CXX11_OVERRIDE

--- a/src/modules/m_hidelist.cpp
+++ b/src/modules/m_hidelist.cpp
@@ -71,7 +71,7 @@ class ModuleHideList : public Module
 				throw ModuleException("Empty <hidelist:mode> at " + tag->getTagLocation());
 			// If rank is set to 0 everyone inside the channel can view the list,
 			// but non-members may not
-			unsigned int rank = tag->getUInt("rank", HALFOP_VALUE);
+			unsigned long rank = tag->getUInt("rank", HALFOP_VALUE);
 			newconfigs.push_back(std::make_pair(modename, rank));
 		}
 

--- a/src/modules/m_hidemode.cpp
+++ b/src/modules/m_hidemode.cpp
@@ -50,11 +50,11 @@ class Settings
 			if (modename.empty())
 				throw ModuleException("<hidemode:mode> is empty at " + tag->getTagLocation());
 
-			unsigned int rank = tag->getUInt("rank", 0);
+			unsigned long rank = tag->getUInt("rank", 0);
 			if (!rank)
 				throw ModuleException("<hidemode:rank> must be greater than 0 at " + tag->getTagLocation());
 
-			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Hiding the %s mode from users below rank %u", modename.c_str(), rank);
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Hiding the %s mode from users below rank %lu", modename.c_str(), rank);
 			newranks.insert(std::make_pair(modename, rank));
 		}
 		rankstosee.swap(newranks);

--- a/src/modules/m_hostchange.cpp
+++ b/src/modules/m_hostchange.cpp
@@ -46,12 +46,12 @@ class HostRule
 	HostChangeAction action;
 	std::string host;
 	std::string mask;
-	insp::flat_set<int> ports;
+	insp::flat_set<long> ports;
 	std::string prefix;
 	std::string suffix;
 
  public:
-	HostRule(const std::string& Mask, const std::string& Host, const insp::flat_set<int>& Ports)
+	HostRule(const std::string& Mask, const std::string& Host, const insp::flat_set<long>& Ports)
 		: action(HCA_SET)
 		, host(Host)
 		, mask(Mask)
@@ -59,7 +59,7 @@ class HostRule
 	{
 	}
 
-	HostRule(HostChangeAction Action, const std::string& Mask, const insp::flat_set<int>& Ports, const std::string& Prefix, const std::string& Suffix)
+	HostRule(HostChangeAction Action, const std::string& Mask, const insp::flat_set<long>& Ports, const std::string& Prefix, const std::string& Suffix)
 		: action(Action)
 		, mask(Mask)
 		, ports(Ports)
@@ -138,12 +138,12 @@ private:
 			if (mask.empty())
 				throw ModuleException("<hostchange:mask> is a mandatory field, at " + tag->getTagLocation());
 
-			insp::flat_set<int> ports;
+			insp::flat_set<long> ports;
 			const std::string portlist = tag->getString("ports");
 			if (!portlist.empty())
 			{
 				irc::portparser portrange(portlist, false);
-				while (int port = portrange.GetToken())
+				while (long port = portrange.GetToken())
 					ports.insert(port);
 			}
 

--- a/src/modules/m_httpd.cpp
+++ b/src/modules/m_httpd.cpp
@@ -216,7 +216,7 @@ class HttpServerSocket : public BufferedSocket, public Timer, public insp::intru
 	}
 
  public:
-	HttpServerSocket(int newfd, const std::string& IP, ListenSocket* via, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server, unsigned int timeoutsec)
+	HttpServerSocket(int newfd, const std::string& IP, ListenSocket* via, irc::sockets::sockaddrs* client, irc::sockets::sockaddrs* server, unsigned long timeoutsec)
 		: BufferedSocket(newfd)
 		, Timer(timeoutsec)
 		, ip(IP)
@@ -421,7 +421,7 @@ class HTTPdAPIImpl : public HTTPdAPIBase
 class ModuleHttpServer : public Module
 {
 	HTTPdAPIImpl APIImpl;
-	unsigned int timeoutsec;
+	unsigned long timeoutsec;
 	Events::ModuleEventProvider acleventprov;
 	Events::ModuleEventProvider reqeventprov;
 

--- a/src/modules/m_ident.cpp
+++ b/src/modules/m_ident.cpp
@@ -204,7 +204,7 @@ class IdentRequestSocket : public EventHandler
 		 * extremely short - there is *no* sane reason it'd be in more than one packet
 		 */
 		char ibuf[256];
-		int recvresult = SocketEngine::Recv(this, ibuf, sizeof(ibuf)-1, 0);
+		ssize_t recvresult = SocketEngine::Recv(this, ibuf, sizeof(ibuf)-1, 0);
 
 		/* Close (but don't delete from memory) our socket
 		 * and flag as done since the ident lookup has finished
@@ -274,7 +274,7 @@ class IdentRequestSocket : public EventHandler
 class ModuleIdent : public Module
 {
  private:
-	unsigned int timeout;
+	unsigned long timeout;
 	bool prefixunqueried;
 	SimpleExtItem<IdentRequestSocket, stdalgo::culldeleter> socket;
 	LocalIntExt state;

--- a/src/modules/m_ircv3_batch.cpp
+++ b/src/modules/m_ircv3_batch.cpp
@@ -150,7 +150,8 @@ class IRCv3::Batch::ManagerImpl : public Manager
 		if (id >= MAX_BATCHES)
 			return;
 
-		batch.Setup(id);
+    // This cast is safe thanks to the clamping above.
+		batch.Setup(static_cast<unsigned int>(id));
 		// Set the manager field which Batch::IsRunning() checks and is also used by AddToBatch()
 		// to set the message tag
 		batch.manager = this;

--- a/src/modules/m_ircv3_batch.cpp
+++ b/src/modules/m_ircv3_batch.cpp
@@ -150,7 +150,7 @@ class IRCv3::Batch::ManagerImpl : public Manager
 		if (id >= MAX_BATCHES)
 			return;
 
-    // This cast is safe thanks to the clamping above.
+		// This cast is safe thanks to the clamping above.
 		batch.Setup(static_cast<unsigned int>(id));
 		// Set the manager field which Batch::IsRunning() checks and is also used by AddToBatch()
 		// to set the message tag

--- a/src/modules/m_ircv3_sts.cpp
+++ b/src/modules/m_ircv3_sts.cpp
@@ -168,7 +168,7 @@ class ModuleIRCv3STS : public Module
 		if (host.empty())
 			throw ModuleException("<sts:host> must contain a hostname, at " + tag->getTagLocation());
 
-		unsigned int port = tag->getUInt("port", 0, 0, UINT16_MAX);
+		unsigned int port = static_cast<unsigned int>(tag->getUInt("port", 0, 0, UINT16_MAX));
 		if (!HasValidSSLPort(port))
 			throw ModuleException("<sts:port> must be a TLS port, at " + tag->getTagLocation());
 

--- a/src/modules/m_joinflood.cpp
+++ b/src/modules/m_joinflood.cpp
@@ -156,7 +156,7 @@ class ModuleJoinFlood
 	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("joinflood");
-		duration = tag->getDuration("duration", 60, 10, 600);
+		duration = static_cast<unsigned int>(tag->getDuration("duration", 60, 10, 600));
 		bootwait = tag->getDuration("bootwait", 30);
 		splitwait = tag->getDuration("splitwait", 30);
 

--- a/src/modules/m_md5.cpp
+++ b/src/modules/m_md5.cpp
@@ -76,14 +76,14 @@ class MD5Provider : public HashProvider
 		ctx->bytes[1] = 0;
 	}
 
-	void MD5Update(MD5Context *ctx, byte const *buf, int len)
+	void MD5Update(MD5Context *ctx, byte const *buf, size_t len)
 	{
 		word32 t;
 
 		/* Update byte count */
 
 		t = ctx->bytes[0];
-		if ((ctx->bytes[0] = t + len) < t)
+		if ((ctx->bytes[0] = word32(t + len)) < t)
 			ctx->bytes[1]++;	/* Carry from low to high */
 
 		t = 64 - (t & 0x3f);	/* Space available in ctx->in (at least 1) */
@@ -229,7 +229,7 @@ class MD5Provider : public HashProvider
 	}
 
 
-	void MyMD5(void *dest, void *orig, int len)
+	void MyMD5(void *dest, void *orig, size_t len)
 	{
 		MD5Context context;
 		MD5Init(&context);

--- a/src/modules/m_modenotice.cpp
+++ b/src/modules/m_modenotice.cpp
@@ -34,12 +34,12 @@ class CommandModeNotice : public Command
 	CmdResult Handle(User* src, const Params& parameters) CXX11_OVERRIDE
 	{
 		std::string msg = "*** From " + src->nick + ": " + parameters[1];
-		int mlen = parameters[0].length();
+		size_t mlen = parameters[0].length();
 		const UserManager::LocalList& list = ServerInstance->Users.GetLocalUsers();
 		for (UserManager::LocalList::const_iterator i = list.begin(); i != list.end(); ++i)
 		{
 			User* user = *i;
-			for (int n = 0; n < mlen; n++)
+			for (size_t n = 0; n < mlen; n++)
 			{
 				if (!user->IsModeSet(parameters[0][n]))
 					goto next_user;

--- a/src/modules/m_monitor.cpp
+++ b/src/modules/m_monitor.cpp
@@ -120,7 +120,7 @@ class IRCv3::Monitor::Manager
 		WR_INVALIDNICK
 	};
 
-	WatchResult Watch(LocalUser* user, const std::string& nick, unsigned int maxwatch)
+	WatchResult Watch(LocalUser* user, const std::string& nick, unsigned long maxwatch)
 	{
 		if (!ServerInstance->IsNick(nick))
 			return WR_INVALIDNICK;
@@ -303,7 +303,7 @@ class CommandMonitor : public SplitCommand
 	}
 
  public:
-	unsigned int maxmonitor;
+	unsigned long maxmonitor;
 
 	CommandMonitor(Module* mod, IRCv3::Monitor::Manager& managerref)
 		: SplitCommand(mod, "MONITOR", 1)

--- a/src/modules/m_nationalchars.cpp
+++ b/src/modules/m_nationalchars.cpp
@@ -386,7 +386,7 @@ class ModuleNationalChars : public Module
 		std::string buf;
 		getline(ifs, buf);
 
-		unsigned int i = 0;
+		unsigned long i = 0;
 		int fail = 0;
 
 		buf.erase(buf.find_last_not_of("\n") + 1);

--- a/src/modules/m_nickflood.cpp
+++ b/src/modules/m_nickflood.cpp
@@ -136,7 +136,7 @@ class ModuleNickFlood : public Module
 	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
 	{
 		ConfigTag* tag = ServerInstance->Config->ConfValue("nickflood");
-		duration = tag->getDuration("duration", 60, 10, 600);
+		duration = static_cast<unsigned int>(tag->getDuration("duration", 60, 10, 600));
 	}
 
 	ModResult OnUserPreNick(LocalUser* user, const std::string& newnick) CXX11_OVERRIDE

--- a/src/modules/m_pbkdf2.cpp
+++ b/src/modules/m_pbkdf2.cpp
@@ -30,12 +30,12 @@
 class PBKDF2Hash
 {
  public:
-	unsigned int iterations;
-	unsigned int length;
+	unsigned long iterations;
+	size_t length;
 	std::string salt;
 	std::string hash;
 
-	PBKDF2Hash(unsigned int itr, unsigned int dkl, const std::string& slt, const std::string& hsh = "")
+	PBKDF2Hash(unsigned long itr, size_t dkl, const std::string& slt, const std::string& hsh = "")
 		: iterations(itr), length(dkl), salt(slt), hash(hsh)
 	{
 	}
@@ -76,10 +76,10 @@ class PBKDF2Provider : public HashProvider
 {
  public:
 	HashProvider* provider;
-	unsigned int iterations;
-	unsigned int dkey_length;
+	unsigned long iterations;
+	size_t dkey_length;
 
-	std::string PBKDF2(const std::string& pass, const std::string& salt, unsigned int itr = 0, unsigned int dkl = 0)
+	std::string PBKDF2(const std::string& pass, const std::string& salt, unsigned long itr = 0, size_t dkl = 0)
 	{
 		size_t blocks = std::ceil((double)dkl / provider->out_size);
 

--- a/src/modules/m_remove.cpp
+++ b/src/modules/m_remove.cpp
@@ -44,7 +44,7 @@ class RemoveBase : public Command
 	ChanModeReference& nokicksmode;
 
  public:
-	unsigned int protectedrank;
+	unsigned long protectedrank;
 
 	RemoveBase(Module* Creator, bool& snk, ChanModeReference& nkm, const char* cmdn)
 		: Command(Creator, cmdn, 2, 3)

--- a/src/modules/m_securelist.cpp
+++ b/src/modules/m_securelist.cpp
@@ -35,7 +35,7 @@ class ModuleSecureList : public Module
 	AllowList allowlist;
 	bool exemptregistered;
 	bool showmsg;
-	unsigned int WaitTime;
+	unsigned long WaitTime;
 
  public:
 	Version GetVersion() CXX11_OVERRIDE

--- a/src/modules/m_sha256.cpp
+++ b/src/modules/m_sha256.cpp
@@ -52,7 +52,8 @@ class HashSHA256 : public HashProvider
 	std::string GenerateRaw(const std::string& data) CXX11_OVERRIDE
 	{
 		unsigned char bytes[SHA256_DIGEST_SIZE];
-		sha256((unsigned char*)data.data(), data.length(),  bytes);
+		// Possibly unsafe cast to unsigned int, but it's expected by sha256.
+		sha256((unsigned char*)data.data(), (unsigned int)data.length(),  bytes);
 		return std::string((char*)bytes, SHA256_DIGEST_SIZE);
 	}
 

--- a/src/modules/m_showfile.cpp
+++ b/src/modules/m_showfile.cpp
@@ -82,9 +82,9 @@ class CommandShowFile : public Command
 	{
 		introtext = tag->getString("introtext", "Showing " + name);
 		endtext = tag->getString("endtext", "End of " + name);
-		intronumeric = tag->getUInt("intronumeric", RPL_RULESTART, 0, 999);
-		textnumeric = tag->getUInt("numeric", RPL_RULES, 0, 999);
-		endnumeric = tag->getUInt("endnumeric", RPL_RULESEND, 0, 999);
+		intronumeric = static_cast<unsigned int>(tag->getUInt("intronumeric", RPL_RULESTART, 0, 999));
+		textnumeric = static_cast<unsigned int>(tag->getUInt("numeric", RPL_RULES, 0, 999));
+		endnumeric = static_cast<unsigned int>(tag->getUInt("endnumeric", RPL_RULESEND, 0, 999));
 		std::string smethod = tag->getString("method");
 
 		method = SF_NUMERIC;

--- a/src/modules/m_silence.cpp
+++ b/src/modules/m_silence.cpp
@@ -186,7 +186,7 @@ typedef insp::flat_set<SilenceEntry> SilenceList;
 class SilenceExtItem : public SimpleExtItem<SilenceList>
 {
  public:
-	unsigned int maxsilence;
+	unsigned long maxsilence;
 
 	SilenceExtItem(Module* Creator)
 		: SimpleExtItem<SilenceList>("silence_list", ExtensionItem::EXT_USER, Creator)

--- a/src/modules/m_spanningtree/link.h
+++ b/src/modules/m_spanningtree/link.h
@@ -39,7 +39,7 @@ class Link : public refcountbase
 	std::vector<std::string> AllowMasks;
 	bool HiddenFromStats;
 	std::string Hook;
-	unsigned int Timeout;
+	unsigned long Timeout;
 	std::string Bind;
 	bool Hidden;
 	Link(ConfigTag* Tag) : tag(Tag) {}

--- a/src/modules/m_spanningtree/override_map.cpp
+++ b/src/modules/m_spanningtree/override_map.cpp
@@ -55,7 +55,7 @@ static inline bool IsHidden(User* user, TreeServer* server)
 }
 
 // Calculate the map depth the servers go, and the longest server name
-static void GetDepthAndLen(TreeServer* current, unsigned int depth, unsigned int& max_depth, unsigned int& max_len, unsigned int& max_version)
+static void GetDepthAndLen(TreeServer* current, unsigned int depth, unsigned int& max_depth, size_t& max_len, size_t& max_version)
 {
 	if (depth > max_depth)
 		max_depth = depth;
@@ -74,7 +74,7 @@ static void GetDepthAndLen(TreeServer* current, unsigned int depth, unsigned int
 	}
 }
 
-static std::vector<std::string> GetMap(User* user, TreeServer* current, unsigned int max_len, unsigned int max_version_len, unsigned int depth)
+static std::vector<std::string> GetMap(User* user, TreeServer* current, size_t max_len, size_t max_version_len, unsigned int depth)
 {
 	float percent = 0;
 
@@ -102,7 +102,7 @@ static std::vector<std::string> GetMap(User* user, TreeServer* current, unsigned
 	// Pad with spaces until its at max len, max_len must always be >= my names length
 	buffer.append(max_len - current->GetName().length(), ' ');
 
-	buffer += InspIRCd::Format("%5d [%5.2f%%]", current->UserCount, percent);
+	buffer += InspIRCd::Format("%5zu [%5.2f%%]", current->UserCount, percent);
 
 	if (user->IsOper())
 	{
@@ -126,7 +126,7 @@ static std::vector<std::string> GetMap(User* user, TreeServer* current, unsigned
 			if (!IsHidden(user, *j))
 				last = false;
 
-		unsigned int next_len;
+		size_t next_len;
 
 		if (user->IsOper() || !Utils->FlatLinks)
 		{
@@ -200,11 +200,11 @@ CmdResult CommandMap::Handle(User* user, const Params& parameters)
 
 	// Max depth and max server name length
 	unsigned int max_depth = 0;
-	unsigned int max_len = 0;
-	unsigned int max_version = 0;
+	size_t max_len = 0;
+	size_t max_version = 0;
 	GetDepthAndLen(Utils->TreeRoot, 0, max_depth, max_len, max_version);
 
-	unsigned int max;
+	size_t max;
 	if (user->IsOper() || !Utils->FlatLinks)
 	{
 		// Each level of the map is indented by 2 characters, making the max possible line (max_depth * 2) + max_len

--- a/src/modules/m_spanningtree/pingtimer.cpp
+++ b/src/modules/m_spanningtree/pingtimer.cpp
@@ -48,7 +48,7 @@ PingTimer::State PingTimer::TickInternal()
 	else if (state == PS_WARN)
 	{
 		// No pong arrived in PingWarnTime seconds, send a warning to opers
-		ServerInstance->SNO->WriteToSnoMask('l', "Server \002%s\002 has not responded to PING for %d seconds, high latency.", server->GetName().c_str(), GetInterval());
+		ServerInstance->SNO->WriteToSnoMask('l', "Server \002%s\002 has not responded to PING for %lu seconds, high latency.", server->GetName().c_str(), GetInterval());
 		return PS_TIMEOUT;
 	}
 	else // PS_TIMEOUT

--- a/src/modules/m_spanningtree/treeserver.cpp
+++ b/src/modules/m_spanningtree/treeserver.cpp
@@ -196,9 +196,9 @@ void TreeServer::SQuitChild(TreeServer* server, const std::string& reason, bool 
 	server->SQuitInternal(num_lost_servers, error);
 
 	const std::string quitreason = GetName() + " " + server->GetName();
-	unsigned int num_lost_users = QuitUsers(quitreason);
+	size_t num_lost_users = QuitUsers(quitreason);
 
-	ServerInstance->SNO->WriteToSnoMask(IsRoot() ? 'l' : 'L', "Netsplit complete, lost \002%u\002 user%s on \002%u\002 server%s.",
+	ServerInstance->SNO->WriteToSnoMask(IsRoot() ? 'l' : 'L', "Netsplit complete, lost \002%zu\002 user%s on \002%u\002 server%s.",
 		num_lost_users, num_lost_users != 1 ? "s" : "", num_lost_servers, num_lost_servers != 1 ? "s" : "");
 
 	// No-op if the socket is already closed (i.e. it called us)
@@ -228,12 +228,12 @@ void TreeServer::SQuitInternal(unsigned int& num_lost_servers, bool error)
 		FOREACH_MOD_CUSTOM(Utils->Creator->GetLinkEventProvider(), ServerProtocol::LinkEventListener, OnServerSplit, (this, error));
 }
 
-unsigned int TreeServer::QuitUsers(const std::string& reason)
+size_t TreeServer::QuitUsers(const std::string& reason)
 {
 	std::string publicreason = Utils->HideSplits ? "*.net *.split" : reason;
 
 	const user_hash& users = ServerInstance->Users->GetUsers();
-	unsigned int original_size = users.size();
+	size_t original_size = users.size();
 	for (user_hash::const_iterator i = users.begin(); i != users.end(); )
 	{
 		User* user = i->second;

--- a/src/modules/m_spanningtree/treeserver.h
+++ b/src/modules/m_spanningtree/treeserver.h
@@ -90,8 +90,8 @@ class TreeServer : public Server
 	FakeUser* const ServerUser;		/* User representing this server */
 	const time_t age;
 
-	unsigned int UserCount;			/* How many users are on this server? [note: doesn't care about +i] */
-	unsigned int OperCount;			/* How many opers are on this server? */
+	size_t UserCount;			/* How many users are on this server? [note: doesn't care about +i] */
+	size_t OperCount;			/* How many opers are on this server? */
 
 	/** We use this constructor only to create the 'root' item, Utils->TreeRoot, which
 	 * represents our own server. Therefore, it has no route, no parent, and
@@ -121,7 +121,7 @@ class TreeServer : public Server
 		GetParent()->SQuitChild(this, reason, error);
 	}
 
-	static unsigned int QuitUsers(const std::string& reason);
+	static size_t QuitUsers(const std::string& reason);
 
 	/** Get route.
 	 * The 'route' is defined as the locally-

--- a/src/modules/m_spanningtree/utils.cpp
+++ b/src/modules/m_spanningtree/utils.cpp
@@ -268,7 +268,7 @@ void SpanningTreeUtilities::ReadConfiguration()
 
 		L->Name = tag->getString("name");
 		L->IPAddr = tag->getString("ipaddr");
-		L->Port = tag->getUInt("port", 0);
+		L->Port = static_cast<unsigned int>(tag->getUInt("port", 0, 0, UINT16_MAX));
 		L->SendPass = tag->getString("sendpass", tag->getString("password"));
 		L->RecvPass = tag->getString("recvpass", tag->getString("password"));
 		L->Fingerprint = tag->getString("fingerprint");

--- a/src/modules/m_spanningtree/utils.h
+++ b/src/modules/m_spanningtree/utils.h
@@ -83,7 +83,7 @@ class SpanningTreeUtilities : public classbase
 	/* Number of seconds that a server can go without ping
 	 * before opers are warned of high latency.
 	 */
-	unsigned int PingWarnTime;
+	unsigned long PingWarnTime;
 	/** This variable represents the root of the server tree
 	 */
 	TreeServer *TreeRoot;
@@ -108,7 +108,7 @@ class SpanningTreeUtilities : public classbase
 
 	/** Ping frequency of server to server links
 	 */
-	unsigned int PingFreq;
+	unsigned long PingFreq;
 
 	/** Initialise utility class
 	 */

--- a/src/modules/m_watch.cpp
+++ b/src/modules/m_watch.cpp
@@ -128,7 +128,7 @@ class CommandWatch : public SplitCommand
 	}
 
  public:
-	unsigned int maxwatch;
+	unsigned long maxwatch;
 
 	CommandWatch(Module* mod, IRCv3::Monitor::Manager& managerref)
 		: SplitCommand(mod, "WATCH")

--- a/src/serializable.cpp
+++ b/src/serializable.cpp
@@ -131,7 +131,7 @@ bool User::Deserialize(Serializable::Data& data)
 	if (!Extensible::Deserialize(exts))
 		return false;
 
-	long client_port;
+	int client_port;
 	std::string client_addr;
 	std::string user_modes;
 	std::string user_oper;
@@ -227,7 +227,7 @@ bool LocalUser::Deserialize(Serializable::Data& data)
 
 	bool user_exempt;
 	bool user_lastping;
-	long server_port;
+	int server_port;
 	std::string server_addr;
 
 	// Apply the members which can be applied directly.

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -193,7 +193,7 @@ void ISupportManager::Build()
 
 	tokens["AWAYLEN"] = ConvToStr(ServerInstance->Config->Limits.MaxAway);
 	tokens["CASEMAPPING"] = ServerInstance->Config->CaseMapping;
-	tokens["CHANLIMIT"] = InspIRCd::Format("#:%u", ServerInstance->Config->MaxChans);
+	tokens["CHANLIMIT"] = InspIRCd::Format("#:%lu", ServerInstance->Config->MaxChans);
 	tokens["CHANNELLEN"] = ConvToStr(ServerInstance->Config->Limits.ChanMax);
 	tokens["CHANTYPES"] = "#";
 	tokens["HOSTLEN"] = ConvToStr(ServerInstance->Config->Limits.MaxHost);

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -85,7 +85,7 @@ size_t InspIRCd::BindPorts(FailedPortList& failed_ports)
 					address.empty() ? "*" : address.c_str(), tag->getTagLocation().c_str());
 
 			irc::portparser portrange(portlist, false);
-			for (int port; (port = portrange.GetToken()); )
+			for (int port; (port = static_cast<int>(portrange.GetToken())); )
 			{
 				irc::sockets::sockaddrs bindspec;
 				if (!irc::sockets::aptosa(address, port, bindspec))

--- a/src/socketengine.cpp
+++ b/src/socketengine.cpp
@@ -234,37 +234,37 @@ void SocketEngine::SetReuse(int fd)
 	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on));
 }
 
-int SocketEngine::RecvFrom(EventHandler* fd, void *buf, size_t len, int flags, sockaddr *from, socklen_t *fromlen)
+ssize_t SocketEngine::RecvFrom(EventHandler* fd, void *buf, size_t len, int flags, sockaddr *from, socklen_t *fromlen)
 {
-	int nbRecvd = recvfrom(fd->GetFd(), (char*)buf, len, flags, from, fromlen);
+	ssize_t nbRecvd = recvfrom(fd->GetFd(), (char*)buf, len, flags, from, fromlen);
 	stats.UpdateReadCounters(nbRecvd);
 	return nbRecvd;
 }
 
-int SocketEngine::Send(EventHandler* fd, const void *buf, size_t len, int flags)
+ssize_t SocketEngine::Send(EventHandler* fd, const void *buf, size_t len, int flags)
 {
-	int nbSent = send(fd->GetFd(), (const char*)buf, len, flags);
+	ssize_t nbSent = send(fd->GetFd(), (const char*)buf, len, flags);
 	stats.UpdateWriteCounters(nbSent);
 	return nbSent;
 }
 
-int SocketEngine::Recv(EventHandler* fd, void *buf, size_t len, int flags)
+ssize_t SocketEngine::Recv(EventHandler* fd, void *buf, size_t len, int flags)
 {
-	int nbRecvd = recv(fd->GetFd(), (char*)buf, len, flags);
+	ssize_t nbRecvd = recv(fd->GetFd(), (char*)buf, len, flags);
 	stats.UpdateReadCounters(nbRecvd);
 	return nbRecvd;
 }
 
-int SocketEngine::SendTo(EventHandler* fd, const void* buf, size_t len, int flags, const irc::sockets::sockaddrs& address)
+ssize_t SocketEngine::SendTo(EventHandler* fd, const void* buf, size_t len, int flags, const irc::sockets::sockaddrs& address)
 {
-	int nbSent = sendto(fd->GetFd(), (const char*)buf, len, flags, &address.sa, address.sa_size());
+	ssize_t nbSent = sendto(fd->GetFd(), (const char*)buf, len, flags, &address.sa, address.sa_size());
 	stats.UpdateWriteCounters(nbSent);
 	return nbSent;
 }
 
-int SocketEngine::WriteV(EventHandler* fd, const IOVector* iovec, int count)
+ssize_t SocketEngine::WriteV(EventHandler* fd, const IOVector* iovec, int count)
 {
-	int sent = writev(fd->GetFd(), iovec, count);
+	ssize_t sent = writev(fd->GetFd(), iovec, count);
 	stats.UpdateWriteCounters(sent);
 	return sent;
 }
@@ -318,24 +318,24 @@ int SocketEngine::Shutdown(int fd, int how)
 	return shutdown(fd, how);
 }
 
-void SocketEngine::Statistics::UpdateReadCounters(int len_in)
+void SocketEngine::Statistics::UpdateReadCounters(ssize_t len_in)
 {
 	CheckFlush();
 
 	ReadEvents++;
 	if (len_in > 0)
-		indata += len_in;
+		indata += static_cast<size_t>(len_in);
 	else if (len_in < 0)
 		ErrorEvents++;
 }
 
-void SocketEngine::Statistics::UpdateWriteCounters(int len_out)
+void SocketEngine::Statistics::UpdateWriteCounters(ssize_t len_out)
 {
 	CheckFlush();
 
 	WriteEvents++;
 	if (len_out > 0)
-		outdata += len_out;
+		outdata += static_cast<size_t>(len_out);
 	else if (len_out < 0)
 		ErrorEvents++;
 }

--- a/src/socketengines/socketengine_epoll.cpp
+++ b/src/socketengines/socketengine_epoll.cpp
@@ -161,7 +161,7 @@ void SocketEngine::DelFd(EventHandler* eh)
 
 int SocketEngine::DispatchEvents()
 {
-	int i = epoll_wait(EngineHandle, &events[0], events.size(), 1000);
+	int i = epoll_wait(EngineHandle, &events[0], static_cast<int>(events.size()), 1000);
 	ServerInstance->UpdateTime();
 
 	stats.TotalEvents += i;

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -26,7 +26,7 @@
 
 #include "inspircd.h"
 
-void Timer::SetInterval(unsigned int newinterval)
+void Timer::SetInterval(unsigned long newinterval)
 {
 	ServerInstance->Timers.DelTimer(this);
 	secs = newinterval;
@@ -34,7 +34,7 @@ void Timer::SetInterval(unsigned int newinterval)
 	ServerInstance->Timers.AddTimer(this);
 }
 
-Timer::Timer(unsigned int secs_from_now, bool repeating)
+Timer::Timer(unsigned long secs_from_now, bool repeating)
 	: trigger(ServerInstance->Time() + secs_from_now)
 	, secs(secs_from_now)
 	, repeat(repeating)

--- a/src/usermanager.cpp
+++ b/src/usermanager.cpp
@@ -182,7 +182,7 @@ void UserManager::AddUser(int socket, ListenSocket* via, irc::sockets::sockaddrs
 
 	if (this->local_users.size() > ServerInstance->Config->SoftLimit)
 	{
-		ServerInstance->SNO->WriteToSnoMask('a', "Warning: softlimit value has been reached: %d clients", ServerInstance->Config->SoftLimit);
+		ServerInstance->SNO->WriteToSnoMask('a', "Warning: softlimit value has been reached: %lu clients", ServerInstance->Config->SoftLimit);
 		this->QuitUser(New,"No more connections allowed");
 		return;
 	}
@@ -394,7 +394,7 @@ void UserManager::DoBackgroundUserStuff()
 
 		if (curr->CommandFloodPenalty || curr->eh.getSendQSize())
 		{
-			unsigned int rate = curr->MyClass->GetCommandRate();
+			unsigned long rate = curr->MyClass->GetCommandRate();
 			if (curr->CommandFloodPenalty > rate)
 				curr->CommandFloodPenalty -= rate;
 			else


### PR DESCRIPTION
## Summary

This pull request adds `-Wshorten-64-to-32` to the compilation flags (when supported... or at least non-ICC and non-GCC compilers... let me know if there's a better way to check for clang). It also fixes all existing warnings, identified by adding `-Werror` locally.

## Rationale

Part of fixing #1414. There shouldn't be any security issues, but there are some potentially unsafe casts identified which could require closer scrutiny. 

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Linux 5.8.0
**Compiler name and version:** clang 11.0.0-2

## Checks

I have ensured that:

  - [X] This pull request does not introduce any incompatible API changes.
  - [ ] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [n/a ] I have documented any features added by this pull request.

I think this is accurate. There are no new features, and all API changes are changes from one integer type to another, which should be compatible with current usages. I'm happy to update MODULE_ABI (and rebase to master) if necessary, obviously.

I'm also happy to split the pull request up into parts (somehow!) if you want.