### PR TITLE
Add "if-host-match" option to sslinfo oper autologin

### DIFF
--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -122,9 +122,11 @@
       #fingerprint="67cb9dc013248a829bb2171ed11becd4"
 
       # autologin: If a TLS (SSL) client certificate fingerprint for this oper is specified,
-      # you can have the oper block automatically log in. This moves all security
-      # of the oper block to the protection of the TLS (SSL) client certificate, so be sure
-      # that the private key is well-protected! Requires the sslinfo module.
+      # you can have the oper block automatically log in. This can also be set to
+      # "if-host-match", to additionally check the host setting for this block before
+      # automatically logging in. Otherwise, all security of the oper block rests on the
+      # protection of the TLS (SSL) client certificate, so be sure that the private key is
+      # well-protected!. Requires the sslinfo module.
       #autologin="yes"
 
       # sslonly: If enabled, this oper can only oper up if they're using a TLS (SSL) connection.

--- a/src/modules/m_sslinfo.cpp
+++ b/src/modules/m_sslinfo.cpp
@@ -373,7 +373,23 @@ class ModuleSSLInfo
 		{
 			OperInfo* ifo = i->second;
 			std::string fp = ifo->oper_block->getString("fingerprint");
-			if (MatchFP(cert, fp) && ifo->oper_block->getBool("autologin"))
+			if (!MatchFP(cert, fp))
+				continue;
+
+			bool do_login = false;
+			const std::string autologin = ifo->oper_block->getString("autologin");
+			if (stdalgo::string::equalsci(autologin, "if-host-match"))
+			{
+				const std::string& userHost = localuser->MakeHost();
+				const std::string& userIP = localuser->MakeHostIP();
+				do_login = InspIRCd::MatchMask(ifo->oper_block->getString("host"), userHost, userIP);
+			}
+			else if (ifo->oper_block->getBool("autologin"))
+			{
+				do_login = true;
+			}
+
+			if (do_login)
 				user->Oper(ifo);
 		}
 	}


### PR DESCRIPTION
## Summary

This PR adds an `if-host-match` option to the (previously boolean) `autologin` functionality offered by the `sslinfo` module, for automatically logging opers in at connection time. If this option is set, then opers matching the given block will only be logged in if they have *both* a matching client certificate and a matching source host.

## Rationale

When logging into an oper block manually, the requesting client's source host is checked against the `host` setting in the oper block. However, automatic oper login provided by `sslinfo` does not otherwise check the source host, relying solely on the connecting client's certificate fingerprint. This PR adds the ability to also perform source host checking for automatic oper logins, both for consistency and as this might be a useful extra verification step in some environments.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Debian 10, with OpenSSL 1.1.1d
**Compiler name and version:** GCC 8.3.0

I have verified that this change does not introduce any regressions in the existing oper automatic login logic, and also that clients are not automatically opered when connecting from a non-matching source host when `autologin="if-host-match"` is set.

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
