### PR TITLE
m_botmode: Send draft/bot tag in addition to inspircd.org/bot

### DIFF
--- a/src/modules/m_botmode.cpp
+++ b/src/modules/m_botmode.cpp
@@ -52,7 +52,10 @@ class BotTag : public ClientProtocol::MessageTagProvider
 	{
 		User* const user = msg.GetSourceUser();
 		if (user && user->IsModeSet(botmode))
+		{
+			msg.AddTag("draft/bot", this, "");
 			msg.AddTag("inspircd.org/bot", this, "");
+		}
 	}
 
 	bool ShouldSendTag(LocalUser* user, const ClientProtocol::MessageTagData& tagdata) CXX11_OVERRIDE


### PR DESCRIPTION
## Summary

This follows <https://ircv3.net/specs/extensions/bot-mode>, without breaking
clients that might rely on the vendor tag.

## Rationale

Add the "standard" draft tag, that should replace the vendor tag eventually

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Debian 10
**Compiler name and version:** gcc (Debian 8.3.0-6) 8.3.0

## Checks


I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request. https://github.com/inspircd/inspircd-docs/pull/67
