### PR TITLE
Precompile inspircd.h

### DIFF
--- a/make/calcdep.pl
+++ b/make/calcdep.pl
@@ -52,7 +52,10 @@ sub run() {
 	chdir BUILDPATH or die "Could not open build directory: $!";
 	unlink 'include';
 	symlink "${\SOURCEPATH}/include", 'include';
-	mkdir $_ for qw/bin modules obj/;
+	mkdir $_ for qw/bin gch modules obj/;
+
+	# fallback in case gch/inspircd.h.gch can't be used:
+	symlink "${\SOURCEPATH}/include/inspircd.h", 'gch/inspircd.h';
 
 	open MAKE, '>real.mk' or die "Could not write real.mk: $!";
 	chdir "${\SOURCEPATH}/src";
@@ -76,6 +79,7 @@ bad-target:
 all: inspircd modules
 
 END
+	dep_cpp "../include/inspircd.h", "gch/inspircd.h.gch", 'gen-o';
 	my(@core_deps, @modlist);
 	for my $file (<*.cpp>, <socketengines/*.cpp>, "threadengines/threadengine_pthread.cpp") {
 		my $out = find_output $file;
@@ -164,6 +168,9 @@ sub gendep($) {
 				$dep{$_}++ for split / /, gendep $loc;
 				$loc =~ s#^\.\./##;
 				$dep{$loc}++;
+				if ($f !~ /.h$/ && $loc eq 'include/inspircd.h') {
+					$dep{'gch/inspircd.h.gch'}++;
+				}
 			}
 			if ($found == 0 && $inc ne 'inspircd_win32wrapper.h') {
 				print STDERR "WARNING: could not find header $inc for $f\n";

--- a/make/template/main.mk
+++ b/make/template/main.mk
@@ -46,7 +46,7 @@ SYSTEM = @SYSTEM_NAME@
 SOURCEPATH = @SOURCE_DIR@
 BUILDPATH ?= $(SOURCEPATH)/build/@COMPILER_NAME@-@COMPILER_VERSION@
 SOCKETENGINE = @SOCKETENGINE@
-CORECXXFLAGS = -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -pipe -Iinclude -Wall -Wextra -Wfatal-errors -Wno-unused-parameter -Wshadow
+CORECXXFLAGS = -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -pipe -Igch -Iinclude -Wall -Wextra -Wfatal-errors -Wno-unused-parameter -Wshadow
 LDLIBS = -lstdc++
 CORELDFLAGS = -rdynamic -L.
 PICLDFLAGS = -fPIC -shared -rdynamic
@@ -272,7 +272,7 @@ GNUmakefile: make/template/main.mk src/version.sh configure @CONFIGURE_CACHE_FIL
 clean:
 	@echo Cleaning...
 	-rm -f "$(BUILDPATH)/bin/inspircd" "$(BUILDPATH)/include" "$(BUILDPATH)/real.mk"
-	-rm -rf "$(BUILDPATH)/obj" "$(BUILDPATH)/modules"
+	-rm -rf "$(BUILDPATH)/gch" "$(BUILDPATH)/obj" "$(BUILDPATH)/modules"
 	@-rmdir "$(BUILDPATH)/bin" 2>/dev/null
 	@-rmdir "$(BUILDPATH)" 2>/dev/null
 	@echo Completed.


### PR DESCRIPTION
## Summary

`inspircd.h` includes a lot of headers (from inspircd or the stdlib), and is included by essentially every compilation unit.
Precompiling it saves a lot of computation time, at the expense of disk space (71MB).

## Rationale

This reduces the compile time by ~40% on my machine. Before:

```
make -j 4  762,05s user 51,53s system 247% cpu 5:28,87 total
```

after:

```
make -j 4  440,73s user 33,39s system 243% cpu 3:14,82 total
```

## Discussion

I don't have much experience working with this kind of compilation tooling or perl, so this code is probably awful. Suggestions are welcome.

In particular, I can't get rid of this warning:

```
/home/dev-irc/inspircd/src/../include/inspircd.h:32:9: warning: #pragma once in main file
 #pragma once
         ^~~~
```

It seems to be a [known issue](https://stackoverflow.com/q/56563679/539465) :/

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Debian 10 (GNU/Linux)
**Compiler name and version:** GCC 8.3.0

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
