### PR TITLE
Fix argv index error in 'unknown option' message.

### DIFF
--- a/src/inspircd.cpp
+++ b/src/inspircd.cpp
@@ -324,7 +324,7 @@ namespace
 
 				default:
 					// An unknown option was specified.
-					std::cout << con_red << "Error:" <<  con_reset << " unknown option '" << argv[optind] << "'." << std::endl
+					std::cout << con_red << "Error:" <<  con_reset << " unknown option '" << argv[optind-1] << "'." << std::endl
 						<< con_bright << "Usage: " << con_reset << argv[0] << " [--config <file>] [--debug] [--nofork] [--nolog]" << std::endl
 						<< std::string(strlen(argv[0]) + 8, ' ') << "[--nopid] [--runasroot] [--version]" << std::endl;
 					ServerInstance->Exit(EXIT_STATUS_ARGV);


### PR DESCRIPTION
## Summary

It looks like ya_getopt increments `optind` between reading the argument and returning, so it needs to be decremented before accessing argv.


## Rationale

Before

```
$ ./build/GCC-8.3/bin/inspircd --foo bar
Error: unknown option 'bar'.
$ ./build/GCC-8.3/bin/inspircd --help
Error: unknown option '%
```

(`%` means there is no newline at the end)

After:

```
$ ./build/GCC-8.3/bin/inspircd --foo bar
Error: unknown option '--foo'.
Usage: ./build/GCC-8.3/bin/inspircd [--config <file>] [--debug] [--nofork] [--nolog]
                                    [--nopid] [--runasroot] [--version]
$ ./build/GCC-8.3/bin/inspircd --help
Error: unknown option '--help'.
Usage: ./build/GCC-8.3/bin/inspircd [--config <file>] [--debug] [--nofork] [--nolog]
                                    [--nopid] [--runasroot] [--version]

```
## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Debian 10
**Compiler name and version:** GCC 8.3.0

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
