### PR TITLE
Makes NAMES reply with RPL_ENDOFNAMES even for nonexisting channels

### DIFF
--- a/src/coremods/core_channel/cmd_names.cpp
+++ b/src/coremods/core_channel/cmd_names.cpp
@@ -72,8 +72,8 @@ CmdResult CommandNames::HandleLocal(LocalUser* user, const Params& parameters)
 		}
 	}
 
-	user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
-	return CMD_FAILURE;
+	user->WriteNumeric(RPL_ENDOFNAMES, parameters[0], "End of /NAMES list.");
+	return CMD_SUCCESS;
 }
 
 void CommandNames::SendNames(LocalUser* user, Channel* chan, bool show_invisible)


### PR DESCRIPTION
## Summary

Makes NAMES reply with RPL_ENDOFNAMES even for nonexisting channels

Instead of ERR_NOSUCHCHANNEL.

## Rationale

This is the behavior described by the RFCs and the Modern spec,
and is implemented by Hybrid/Chary/Solanum, Ergo, and Unreal.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Debian 10
**Compiler name and version:** GCC 8.3.0

## Checks


I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
