### PR TITLE
add m_canjoinban: matches users banned from a given channel

### DIFF
--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -1111,6 +1111,8 @@ Matching extbans:
                (requires gecosban module).
  j:<channel>   Matches anyone in the given channel. Does not support
                wildcards (requires the channelban module).
+ J:<channel>   Matches anyone banned from the given channel. Does not
+               support wildcards.
  n:<class>     Matches users in a matching connect class (requires
                the classban module).
  r:<realname>  Matches users with a matching real name (requires the

--- a/src/modules/m_canjoinban.cpp
+++ b/src/modules/m_canjoinban.cpp
@@ -1,0 +1,51 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2021 David Schultz <me@zpld.me>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+
+class ModuleBadChannelExtban : public Module
+{
+ public:
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Adds extended ban J: which checks whether users are banned from a certain channel.", VF_OPTCOMMON|VF_VENDOR);
+	}
+
+	ModResult OnCheckBan(User *user, Channel *c, const std::string& mask) CXX11_OVERRIDE
+	{
+		if ((mask.length() > 2) && (mask[0] == 'J') && (mask[1] == ':'))
+		{
+			std::string rm(mask, 2);
+			Channel* chan = ServerInstance->FindChan(rm);
+
+			if (chan && chan->IsBanned(user))
+			{
+				return MOD_RES_DENY;
+			}
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
+	{
+		tokens["EXTBAN"].push_back('J');
+	}
+};
+
+MODULE_INIT(ModuleBadChannelExtban)


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->
Adds `m_canjoinban`. This provides the `J:<channel>` extban which checks if a user is banned from a channel.

## Rationale

<!--
Describe why you have made this change.
-->
This is useful for communities that consist of multiple channels and want to have a global namespace ban list. For example, you could have `#inspircd` and `#inspircd.dev` and a `#inspircd.bans` channel with `+b J:#inspircd.bans` on the other two channels. Then, when a user tries to join `#inspircd` and they are banned in `#inspircd.bans`, they will not be permitted to enter the channel. This module is inspired by [extb_canjoin](https://github.com/solanum-ircd/solanum/blob/main/extensions/extb_canjoin.c) on solanum.

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Debian 10
**Compiler name and version:** gcc version 8.3.0

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
