### PR TITLE
m_repeat: allow opers to be immune to repeat punishment

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1924,14 +1924,12 @@
 #               any effect, as the maximum length of a message on IRC
 #               cannot exceed that.
 # kickmessage - Kick message when * is specified
-# opersimmune - Should opers be affected by repeat checking?
 #<repeat maxbacklog="20"
 #        maxdistance="50"
 #        maxlines="20"
 #        maxtime="0s"
 #        size="512"
-#        kickmessage="Repeat flood"
-#        opersimmune="yes">
+#        kickmessage="Repeat flood">
 #<module name="repeat">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -2048,7 +2048,7 @@
 
 # You must define <sasl:target> to the name of your services server so
 # that InspIRCd knows where to send SASL authentication messages and
-# when it should enable the SASL capability.
+# when it should enable the SASL capability.
 # You can also define <sasl:requiressl> to require users to use TLS (SSL)
 # in order to be able to use SASL.
 #<sasl target="services.mynetwork.com"
@@ -2511,4 +2511,3 @@
 # You will almost always want to load this.
 #
 #<module name="spanningtree">
-

--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1924,12 +1924,14 @@
 #               any effect, as the maximum length of a message on IRC
 #               cannot exceed that.
 # kickmessage - Kick message when * is specified
+# opersimmune - Should opers be affected by repeat checking?
 #<repeat maxbacklog="20"
 #        maxdistance="50"
 #        maxlines="20"
 #        maxtime="0s"
 #        size="512"
-#        kickmessage="Repeat flood">
+#        kickmessage="Repeat flood"
+#        opersimmune="yes">
 #<module name="repeat">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
@@ -2048,7 +2050,7 @@
 
 # You must define <sasl:target> to the name of your services server so
 # that InspIRCd knows where to send SASL authentication messages and
-# when it should enable the SASL capability.
+# when it should enable the SASL capability.
 # You can also define <sasl:requiressl> to require users to use TLS (SSL)
 # in order to be able to use SASL.
 #<sasl target="services.mynetwork.com"
@@ -2511,3 +2513,4 @@
 # You will almost always want to load this.
 #
 #<module name="spanningtree">
+

--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -29,6 +29,7 @@
      #  PERMISSIONS:
      #   - channels/ignore-noctcp: allows opers with this priv to send a CTCP to a +C channel.
      #   - channels/ignore-nonicks: allows opers with this priv to change their nick when on a +N channel.
+     #   - channels/ignore-repeat: allows opers with this priv to be immune to repeat punishment on a +E channel.
      #   - channels/restricted-create: allows opers with this priv to create channels if the restrictchans module is loaded.
      #   - users/flood/increased-buffers: allows opers with this priv to send and receive data without worrying about being disconnected for exceeding limits (*NOTE).
      #   - users/flood/no-fakelag: prevents opers from being penalized with fake lag for flooding (*NOTE).

--- a/src/modules/m_repeat.cpp
+++ b/src/modules/m_repeat.cpp
@@ -432,4 +432,3 @@ class RepeatModule : public Module
 };
 
 MODULE_INIT(RepeatModule)
-

--- a/src/modules/m_repeat.cpp
+++ b/src/modules/m_repeat.cpp
@@ -92,6 +92,7 @@ class RepeatMode : public ParamMode<RepeatMode, SimpleExtItem<ChannelSettings> >
 		unsigned int MaxDiff;
 		unsigned int MaxMessageSize;
 		std::string KickMessage;
+		bool OpersImmune;
 		ModuleSettings() : MaxLines(0), MaxSecs(0), MaxBacklog(0), MaxDiff() { }
 	};
 
@@ -255,6 +256,8 @@ class RepeatMode : public ParamMode<RepeatMode, SimpleExtItem<ChannelSettings> >
 		Resize(newsize);
 
 		ms.KickMessage = conf->getString("kickmessage", "Repeat flood");
+
+		ms.OpersImmune = conf->getBool("opersimmune");
 	}
 
 	std::string GetModuleSettings() const
@@ -265,6 +268,11 @@ class RepeatMode : public ParamMode<RepeatMode, SimpleExtItem<ChannelSettings> >
 	std::string GetKickMessage() const
 	{
 		return ms.KickMessage;
+	}
+
+	bool IsOpersImmune()
+	{
+		return ms.OpersImmune;
 	}
 
 	void SerializeParam(Channel* chan, const ChannelSettings* chset, std::string& out)
@@ -396,6 +404,9 @@ class RepeatModule : public Module
 		if (res == MOD_RES_ALLOW)
 			return MOD_RES_PASSTHRU;
 
+		if (rm.IsOpersImmune() && user->IsOper())
+			return MOD_RES_PASSTHRU;
+
 		if (rm.MatchLine(memb, settings, details.text))
 		{
 			if (settings->Action == ChannelSettings::ACT_BLOCK)
@@ -429,3 +440,4 @@ class RepeatModule : public Module
 };
 
 MODULE_INIT(RepeatModule)
+

--- a/src/modules/m_repeat.cpp
+++ b/src/modules/m_repeat.cpp
@@ -92,7 +92,6 @@ class RepeatMode : public ParamMode<RepeatMode, SimpleExtItem<ChannelSettings> >
 		unsigned int MaxDiff;
 		unsigned int MaxMessageSize;
 		std::string KickMessage;
-		bool OpersImmune;
 		ModuleSettings() : MaxLines(0), MaxSecs(0), MaxBacklog(0), MaxDiff() { }
 	};
 
@@ -256,8 +255,6 @@ class RepeatMode : public ParamMode<RepeatMode, SimpleExtItem<ChannelSettings> >
 		Resize(newsize);
 
 		ms.KickMessage = conf->getString("kickmessage", "Repeat flood");
-
-		ms.OpersImmune = conf->getBool("opersimmune");
 	}
 
 	std::string GetModuleSettings() const
@@ -268,11 +265,6 @@ class RepeatMode : public ParamMode<RepeatMode, SimpleExtItem<ChannelSettings> >
 	std::string GetKickMessage() const
 	{
 		return ms.KickMessage;
-	}
-
-	bool IsOpersImmune()
-	{
-		return ms.OpersImmune;
 	}
 
 	void SerializeParam(Channel* chan, const ChannelSettings* chset, std::string& out)
@@ -404,7 +396,7 @@ class RepeatModule : public Module
 		if (res == MOD_RES_ALLOW)
 			return MOD_RES_PASSTHRU;
 
-		if (rm.IsOpersImmune() && user->IsOper())
+		if (user->HasPrivPermission("channels/ignore-repeat"))
 			return MOD_RES_PASSTHRU;
 
 		if (rm.MatchLine(memb, settings, details.text))


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->
Allows network admins to make opers immune to repeat punishment (mode `+E`) via a config setting (`repeat/opersimmune`)

## Rationale

<!--
Describe why you have made this change.
-->
Resolves #1847

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Debian 10
**Compiler name and version:** gcc version 8.3.0

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
