### PR TITLE
Add fix to Compare result True to LDAP Auth Module

### DIFF
--- a/src/modules/m_ldapauth.cpp
+++ b/src/modules/m_ldapauth.cpp
@@ -186,6 +186,11 @@ class BindInterface : public LDAPInterface
 
 	void OnError(const LDAPResult& err) CXX11_OVERRIDE
 	{
+	
+		//ldap_compare_s() returns an LDAP error code.
+		if (err.getError().find("Compare True") != std::string::npos) //Should be changed to a better implementation
+			OnResult(err); //Relay that to OnResult
+		
 		if (checkingAttributes && --attrCount)
 			return;
 


### PR DESCRIPTION
## Summary
<ldaprequire> Wasn't working properly as ldap_compare_s() returns an error instead of a result.
This Commit fixes that issue by relaying the error to OnResult() if the error message contains "Compare True".

<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

<!--
Briefly describe what this pull request changes.
-->

## Rationale

This change should make \<ldaprequire\> work as intended.

<!--
Describe why you have made this change.
-->

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Ubuntu 20.04 (Linux)
**Compiler name and version:** GCC 9.3.0

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [ X] This pull request does not introduce any incompatible API changes.
  - [ X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [ X] I have documented any features added by this pull request.
