### PR TITLE
Fix PREFIX in RPL_ISUPPORT

### DIFF
--- a/src/coremods/core_mode.cpp
+++ b/src/coremods/core_mode.cpp
@@ -346,11 +346,11 @@ class CoreModMode final
 		std::string prefixchars;
 		for (const auto& pm : insp::iterator_range(prefixes.rbegin(), prefixes.rend()))
 		{
-			modechars += pm->GetPrefix();
-			prefixchars += pm->GetModeChar();
+			modechars += pm->GetModeChar();
+			prefixchars += pm->GetPrefix();
 		}
 
-		return includeprefixes ? "(" + prefixchars + ")" + prefixchars : modechars;
+		return includeprefixes ? "(" + modechars + ")" + prefixchars : prefixchars;
 	}
 
  public:

--- a/src/coremods/core_mode.cpp
+++ b/src/coremods/core_mode.cpp
@@ -329,7 +329,7 @@ class CoreModMode final
 		return InspIRCd::Format("%s,%s,%s,%s", type1.c_str(), type2.c_str(), type3.c_str(), type4.c_str());
 	}
 
-	std::string GeneratePrefixList(bool includeprefixes)
+	std::string GeneratePrefixList(bool includemodechars)
 	{
 		std::vector<PrefixMode*> prefixes;
 		for (const auto& pm : ServerInstance->Modes.GetPrefixModes())
@@ -350,7 +350,7 @@ class CoreModMode final
 			prefixchars += pm->GetPrefix();
 		}
 
-		return includeprefixes ? "(" + modechars + ")" + prefixchars : prefixchars;
+		return includemodechars ? "(" + modechars + ")" + prefixchars : prefixchars;
 	}
 
  public:


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

In InspIRCd 4.0.0a7, the `PREFIX` token in `RPL_ISUPPORT` was observed as `PREFIX=(Yqaohv)Yqaohv`. This commit fixes it so that this configuration would produce `PREFIX=(Yqaohv)!~&@%+`.

## Rationale

The existing behaviour is incorrect: the characters outside the brackets are supposed to be the prefix characters, not the mode letters. In particular, presenting letters as channel status prefixes could cause very messy behaviour in clients.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Ubuntu 20.04 under WSL 2
**Compiler name and version:** gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
