### PR TITLE
Insp3 fix delaymsg exemption

### DIFF
--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -699,6 +699,8 @@
          #  - stripcolor      Channel mode +S - strips formatting codes from
          #                    messages (requires the stripcolor module).
          #  - topiclock       Channel mode +t - limits changing the topic to (half)ops
+         #  - delaymsg        Channel mode +d - blocks sending messages until specified
+         #                    seconds have passed since user join
          # You can also configure this on a per-channel basis with a channel mode and
          # even negate the configured exemptions below.
          # See exemptchanops in modules.conf.example for more details.

--- a/docs/conf/inspircd.conf.example
+++ b/docs/conf/inspircd.conf.example
@@ -682,6 +682,8 @@
          #                    (requires the blockcolor module).
          #  - censor          Channel mode +G - censors messages based on the network
          #                    configuration (requires the censor module).
+         #  - delaymsg        Channel mode +d - blocks sending messages until specified
+         #                    seconds have passed since user join
          #  - filter          Channel mode +g - blocks messages containing the given
          #                    glob mask (requires the chanfilter module).
          #  - flood           Channel mode +f - kicks (and bans) on text flood of a
@@ -699,8 +701,6 @@
          #  - stripcolor      Channel mode +S - strips formatting codes from
          #                    messages (requires the stripcolor module).
          #  - topiclock       Channel mode +t - limits changing the topic to (half)ops
-         #  - delaymsg        Channel mode +d - blocks sending messages until specified
-         #                    seconds have passed since user join
          # You can also configure this on a per-channel basis with a channel mode and
          # even negate the configured exemptions below.
          # See exemptchanops in modules.conf.example for more details.

--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -30,6 +30,7 @@
      #   - channels/ignore-noctcp: allows opers with this priv to send a CTCP to a +C channel.
      #   - channels/ignore-nonicks: allows opers with this priv to change their nick when on a +N channel.
      #   - channels/ignore-repeat: allows opers with this priv to be immune to repeat punishment on a +E channel.
+     #   - channels/ignore-delaymsg: allows opers with this priv to be immune to delaymsg restriction on a +d channel.
      #   - channels/restricted-create: allows opers with this priv to create channels if the restrictchans module is loaded.
      #   - users/flood/increased-buffers: allows opers with this priv to send and receive data without worrying about being disconnected for exceeding limits (*NOTE).
      #   - users/flood/no-fakelag: prevents opers from being penalized with fake lag for flooding (*NOTE).

--- a/docs/conf/opers.conf.example
+++ b/docs/conf/opers.conf.example
@@ -27,10 +27,10 @@
      #   - users/mass-message: allows opers with this priv to PRIVMSG and NOTICE to a server mask (e.g. NOTICE $*).
      #   - users/samode-usermodes: allows opers with this priv to change the user modes of any other user using /SAMODE.
      #  PERMISSIONS:
+     #   - channels/ignore-delaymsg: allows opers with this priv to be immune to delaymsg restriction on a +d channel.
      #   - channels/ignore-noctcp: allows opers with this priv to send a CTCP to a +C channel.
      #   - channels/ignore-nonicks: allows opers with this priv to change their nick when on a +N channel.
      #   - channels/ignore-repeat: allows opers with this priv to be immune to repeat punishment on a +E channel.
-     #   - channels/ignore-delaymsg: allows opers with this priv to be immune to delaymsg restriction on a +d channel.
      #   - channels/restricted-create: allows opers with this priv to create channels if the restrictchans module is loaded.
      #   - users/flood/increased-buffers: allows opers with this priv to send and receive data without worrying about being disconnected for exceeding limits (*NOTE).
      #   - users/flood/no-fakelag: prevents opers from being penalized with fake lag for flooding (*NOTE).

--- a/src/modules/m_delaymsg.cpp
+++ b/src/modules/m_delaymsg.cpp
@@ -22,6 +22,7 @@
 
 #include "inspircd.h"
 #include "modules/ctctags.h"
+#include "modules/exemption.h"
 
 class DelayMsgMode : public ParamMode<DelayMsgMode, LocalIntExt>
 {
@@ -56,12 +57,14 @@ class ModuleDelayMsg
  private:
 	DelayMsgMode djm;
 	bool allownotice;
+	CheckExemption::EventProvider exemptionprov;
 	ModResult HandleMessage(User* user, const MessageTarget& target, bool notice);
 
  public:
 	ModuleDelayMsg()
 		: CTCTags::EventListener(this)
 		, djm(this)
+		, exemptionprov(this)
 	{
 	}
 
@@ -139,12 +142,16 @@ ModResult ModuleDelayMsg::HandleMessage(User* user, const MessageTarget& target,
 
 	if ((ts + len) > ServerInstance->Time())
 	{
-		if (channel->GetPrefixValue(user) < VOICE_VALUE)
-		{
-			const std::string message = InspIRCd::Format("You cannot send messages to this channel until you have been a member for %d seconds.", len);
-			user->WriteNumeric(Numerics::CannotSendTo(channel, message));
-			return MOD_RES_DENY;
-		}
+		ModResult res = CheckExemption::Call(exemptionprov, user, channel, "delaymsg");
+		if (res == MOD_RES_ALLOW)
+			return MOD_RES_PASSTHRU;
+
+		if (user->HasPrivPermission("channels/ignore-delaymsg"))
+			return MOD_RES_PASSTHRU;
+
+		const std::string message = InspIRCd::Format("You cannot send messages to this channel until you have been a member for %d seconds.", len);
+		user->WriteNumeric(Numerics::CannotSendTo(channel, message));
+		return MOD_RES_DENY;
 	}
 	else
 	{


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

This pull request tries to use HasPrivPermission and exemptchanops to be able to exclude operators or some channel ranks like op and voice from being affected by channel +d mode (delaymsg module).

<!--
Briefly describe what this pull request changes.
-->

- Condition that channel rank voice or upper is not affected is removed.
- Added condition to exempt operators with channels/ignore-delaymsg priv.
- Added condition to exempt users with CheckExemption::Call "delaymsg" so if you add delaymsg:v into exemptchanops all ranks equal or above voice (v) are not affected.
- Updated inspircd.conf.example to document new delaymsg option for exemptchanops.
- Updated opers.conf.example to document new operators privilege channels/ignore-delaymsg.

<!--
Describe why you have made this change.
-->

I have tested with latest insp3 branch.

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** 5.13.0-23-generic
**Compiler name and version:** GCC 11.2.0

## Checks

I have ensured that:

  - [ x ] This pull request does not introduce any incompatible API changes.
  - [ x ] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [ x ] I have documented any features added by this pull request.
