### PR TITLE
Reverse order of WHOWAS replies

### DIFF
--- a/src/coremods/core_whowas.cpp
+++ b/src/coremods/core_whowas.cpp
@@ -208,7 +208,7 @@ CmdResult CommandWhowas::Handle(User* user, const Params& parameters)
 	else
 	{
 		const WhoWas::Nick::List& list = nick->entries;
-		for (WhoWas::Nick::List::const_iterator i = list.begin(); i != list.end(); ++i)
+		for (WhoWas::Nick::List::const_reverse_iterator i = list.rbegin(); i != list.rend(); ++i)
 		{
 			WhoWas::Entry* u = *i;
 


### PR DESCRIPTION
## Summary

Reverse order of WHOWAS replies, so the most recent is first

## Rationale

To be consistent with other implementations + the RFCs:

* https://datatracker.ietf.org/doc/html/rfc1459#section-4.5.3
* https://datatracker.ietf.org/doc/html/rfc2812#section-3.6.3

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Debian 11
**Compiler name and version:** GCC 10.2.1

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
