### PR TITLE
Add support for the <count> param of WHOWAS

### DIFF
--- a/docs/conf/helpop.conf.example
+++ b/docs/conf/helpop.conf.example
@@ -419,9 +419,11 @@ server.
 You should not use it during an established connection.
 ">
 
-<helpop key="whowas" title="/WHOWAS <nick>" value="
+<helpop key="whowas" title="/WHOWAS <nick> [<count>]" value="
 Returns a list of times the user was seen recently on IRC along with
 the time they were last seen and their server.
+
+If <count> is given, only return the <count> most recent entries.
 ">
 
 <helpop key="links" title="/LINKS" value="

--- a/src/coremods/core_whowas.cpp
+++ b/src/coremods/core_whowas.cpp
@@ -187,7 +187,7 @@ class CommandWhowas : public Command
 CommandWhowas::CommandWhowas( Module* parent)
 	: Command(parent, "WHOWAS", 1)
 {
-	syntax = "<nick>";
+	syntax = "<nick> [<count>]";
 	Penalty = 2;
 }
 
@@ -200,6 +200,13 @@ CmdResult CommandWhowas::Handle(User* user, const Params& parameters)
 		return CMD_FAILURE;
 	}
 
+	unsigned int count = UINT_MAX;
+	if (parameters.size() > 1) {
+		count = ConvToNum<unsigned int>(parameters[1]);
+		if (count == 0)
+			count = UINT_MAX;
+	}
+
 	const WhoWas::Nick* const nick = manager.FindNick(parameters[0]);
 	if (!nick)
 	{
@@ -208,7 +215,7 @@ CmdResult CommandWhowas::Handle(User* user, const Params& parameters)
 	else
 	{
 		const WhoWas::Nick::List& list = nick->entries;
-		for (WhoWas::Nick::List::const_reverse_iterator i = list.rbegin(); i != list.rend(); ++i)
+		for (WhoWas::Nick::List::const_reverse_iterator i = list.rbegin(); i != list.rend() && count >= 1; ++i, count--)
 		{
 			WhoWas::Entry* u = *i;
 

--- a/src/coremods/core_whowas.cpp
+++ b/src/coremods/core_whowas.cpp
@@ -200,13 +200,6 @@ CmdResult CommandWhowas::Handle(User* user, const Params& parameters)
 		return CMD_FAILURE;
 	}
 
-	unsigned int count = UINT_MAX;
-	if (parameters.size() > 1) {
-		count = ConvToNum<unsigned int>(parameters[1]);
-		if (count == 0)
-			count = UINT_MAX;
-	}
-
 	const WhoWas::Nick* const nick = manager.FindNick(parameters[0]);
 	if (!nick)
 	{
@@ -215,7 +208,15 @@ CmdResult CommandWhowas::Handle(User* user, const Params& parameters)
 	else
 	{
 		const WhoWas::Nick::List& list = nick->entries;
-		for (WhoWas::Nick::List::const_reverse_iterator i = list.rbegin(); i != list.rend() && count >= 1; ++i, count--)
+		WhoWas::Nick::List::const_reverse_iterator last = list.rend();
+		if (parameters.size() > 1)
+		{
+			size_t count = ConvToNum<size_t>(parameters[1]);
+			if (count > 0 && (size_t) std::distance(list.rbegin(), last) > count)
+				last = list.rbegin() + count;
+		}
+
+		for (WhoWas::Nick::List::const_reverse_iterator i = list.rbegin(); i != last; ++i)
 		{
 			WhoWas::Entry* u = *i;
 


### PR DESCRIPTION
Note: this PR includes the commit in #1967, because it touches the same line.

## Summary

Add support for the <count> param of WHOWAS, which limits the number of returned replies

## Rationale

Not very useful IMO, but every server but InspIRCd seems to implement it, and it's part of the RFCs:
    
* https://datatracker.ietf.org/doc/html/rfc1459#section-4.5.3
* https://datatracker.ietf.org/doc/html/rfc2812#section-3.6.3


## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Debian 11
**Compiler name and version:** GCC 10.2.1

## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request. (though it's not on docs.inspircd.org yet, but I'll send a PR if this gets merged)