### PR TITLE
Adding option to customize message sent to user when m_joinflood deni…

### DIFF
--- a/docs/conf/modules.conf.example
+++ b/docs/conf/modules.conf.example
@@ -1320,20 +1320,23 @@
 # Closes the channel for N seconds if X users join in Y seconds.
 #<module name="joinflood">
 #
-# duration:  The number of seconds to close a channel for when it is
-#            being flooded with joins.
+# duration:    The number of seconds to close a channel for when it is
+#              being flooded with joins.
 #
-# bootwait:  The number of seconds to disengage joinflood for after
-#            a server boots. This allows users to reconnect without
-#            being throttled by joinflood.
+# bootwait:    The number of seconds to disengage joinflood for after
+#              a server boots. This allows users to reconnect without
+#              being throttled by joinflood.
 #
-# splitwait: The number of seconds to disengage joinflood for after
-#            a server splits. This allows users to reconnect without
-#            being throttled by joinflood.
+# splitwait:   The number of seconds to disengage joinflood for after
+#              a server splits. This allows users to reconnect without
+#              being throttled by joinflood.
+#
+# denymessage: Message to display to the user when a join is denied.
 #
 #<joinflood duration="1m"
 #           bootwait="30s"
-#           splitwait="30s">
+#           splitwait="30s"
+#           denymessage="This channel is temporarily unavailable (+j is set). Please try again later.">
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 # Anti auto rejoin: Adds support for prevention of auto-rejoin (+J).

--- a/src/modules/m_joinflood.cpp
+++ b/src/modules/m_joinflood.cpp
@@ -135,6 +135,7 @@ class ModuleJoinFlood
 	time_t ignoreuntil;
 	unsigned long bootwait;
 	unsigned long splitwait;
+	std::string denymessage;
 
  public:
 	// Stop GCC warnings about the deprecated OnServerSplit event.
@@ -153,6 +154,7 @@ class ModuleJoinFlood
 		duration = tag->getDuration("duration", 60, 10, 600);
 		bootwait = tag->getDuration("bootwait", 30);
 		splitwait = tag->getDuration("splitwait", 30);
+		denymessage = tag->getString("denymessage", "This channel is temporarily unavailable (+j is set). Please try again later.");
 
 		if (status.initial)
 			ignoreuntil = ServerInstance->startup_time + bootwait;
@@ -171,7 +173,7 @@ class ModuleJoinFlood
 			joinfloodsettings *f = jf.ext.get(chan);
 			if (f && f->islocked())
 			{
-				user->WriteNumeric(ERR_UNAVAILRESOURCE, chan->name, "This channel is temporarily unavailable (+j is set). Please try again later.");
+				user->WriteNumeric(ERR_UNAVAILRESOURCE, chan->name, denymessage);
 				return MOD_RES_DENY;
 			}
 		}


### PR DESCRIPTION
## Summary

Be able tu customize m_joinflood messages in configuration.

## Rationale

To allow customizing module messages or translate it to another language.

## Testing Environment

Latest insp branch.

I have tested this pull request on:

**Operating system name and version:** Debian 10.6
**Compiler name and version:** gcc 8.3.0

## Checks

I have ensured that:

  - [ x ] This pull request does not introduce any incompatible API changes.
  - [ x ] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [ x ] I have documented any features added by this pull request.