### PR TITLE
Fix logrotate conf bug

### DIFF
--- a/make/template/logrotate
+++ b/make/template/logrotate
@@ -18,7 +18,7 @@
 
 # To use this file move it to /etc/logrotate.d/inspircd
 
-@LOG_DIR@/* {
+@LOG_DIR@/*.log {
 	compress
 	create 0644 @USER@ @GROUP@
 	dateext


### PR DESCRIPTION


<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

Previously-rotated logfiles would get rotated again, causing multiple
rehashes and very long file names.

## Rationale
```
ircd.log
ircd.log-20220522.gz
ircd.log-20220522.gz-20220605
ircd.log-20220522.gz-20220605-20220612
ircd.log-20220522.gz-20220605-20220612-20220619
ircd.log-20220522.gz-20220605-20220612-20220619-20220626
ircd.log-20220522.gz-20220605-20220612-20220619-20220626-20220703
ircd.log-20220529.gz
ircd.log-20220529.gz-20220612
ircd.log-20220529.gz-20220612-20220619
ircd.log-20220529.gz-20220612-20220619-20220626
ircd.log-20220529.gz-20220612-20220619-20220626-20220703
ircd.log-20220605.gz
ircd.log-20220605.gz-20220619
ircd.log-20220605.gz-20220619-20220626
ircd.log-20220605.gz-20220619-20220626-20220703
ircd.log-20220612.gz
ircd.log-20220612.gz-20220626
ircd.log-20220612.gz-20220626-20220703
ircd.log-20220619.gz
ircd.log-20220619.gz-20220703
ircd.log-20220626.gz
ircd.log-20220703
startup.log
startup.log-20220522
startup.log-20220522-20220529
startup.log-20220522-20220529-20220605
startup.log-20220522-20220529-20220605-20220612
startup.log-20220522-20220529-20220605-20220612-20220619
startup.log-20220522-20220529-20220605-20220612-20220619-20220626
startup.log-20220522-20220529-20220605-20220612-20220619-20220626-20220703
```
Madness!

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Gentoo
**Compiler name and version:** GCC 11.3.0
## Checks

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
