### PR TITLE
Add OpenRC support to logrotate

### DIFF
--- a/make/template/logrotate
+++ b/make/template/logrotate
@@ -28,7 +28,10 @@
 	rotate 8
 	weekly
 	postrotate
-		if [ -d /lib/systemd ]
+		if [ -r "@RUNTIME_DIR@/inspircd.pid" ]
+		then
+			kill -HUP $(cat "@RUNTIME_DIR@/inspircd.pid")
+		elif [ -d /lib/systemd ]
 		then
 			if systemctl --quiet is-active inspircd
 			then


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->
Add OpenRC "support" to logrotate.

## Rationale

<!--
Describe why you have made this change.
-->
The current method doesn't work on Gentoo.  Gentoo installs files into `/lib/systemd` even though systemd might not be in use, causing the `systemctl` commands to be run (which fail).  Checking for OpenRC and running its specific rehash command before systemd fixes the issue.

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Gentoo
**Compiler name and version:** GCC 11.3.0
## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
