### PR TITLE
Fix cert expiration for dates after year 2049

### DIFF
--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -704,11 +704,11 @@ class OpenSSLIOHook : public SSLIOHook
 		certinfo->activation = GetTime(X509_getm_notBefore(cert));
 		certinfo->expiration = GetTime(X509_getm_notAfter(cert));
 
-		int activated = ASN1_UTCTIME_cmp_time_t(X509_getm_notBefore(cert), ServerInstance->Time());
+		int activated = ASN1_TIME_cmp_time_t(X509_getm_notBefore(cert), ServerInstance->Time());
 		if (activated != -1 && activated != 0)
 			certinfo->error = "Certificate not activated";
 
-		int expired = ASN1_UTCTIME_cmp_time_t(X509_getm_notAfter(cert), ServerInstance->Time());
+		int expired = ASN1_TIME_cmp_time_t(X509_getm_notAfter(cert), ServerInstance->Time());
 		if (expired != 0 && expired != 1)
 			certinfo->error = "Certificate has expired";
 


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->
Fixes issue where certificates which expire after 2049 might erroneously be marked as expired.

## Rationale

<!--
Describe why you have made this change.
-->
I generated certificates to last 'till 2120 in my test environment so I wouldn't have to deal with tests failing due to expiration.  The irony is rich.

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->
Gentoo VM.

I have tested this pull request on:

**Operating system name and version:** Gentoo!  `Linux test 5.15.88 #1 SMP Sun Feb 12 17:24:09 PST 2023 x86_64 QEMU Virtual CPU version 2.5+ GenuineIntel GNU/Linux`
**Compiler name and version:** <!-- e.g. GCC 4.2.0 --> gcc (Gentoo Hardened 12.2.1_p20230428-r1 p2) 12.2.1 20230428

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [x] This pull request does not introduce any incompatible API changes.
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [x] I have documented any features added by this pull request.
