### PR TITLE
This commit adds documentation for /PROP

### DIFF
--- a/docs/conf/help.conf.example
+++ b/docs/conf/help.conf.example
@@ -219,6 +219,10 @@ Your client should send this to answer server PINGs. You
 should not issue this command manually.
 ">
 
+<helptopic key="prop" title="/PROP <target> [(+|-)<name> [<value>]]+" value="
+Allows users to add, remove, and view the modes of a specific target.
+">
+
 <helptopic key="admin" title="/ADMIN [<servername>]" value="
 Shows the administrative information for the given server.
 ">


### PR DESCRIPTION
## Summary

This PR solves issue 2034: missing documentation for /PROP in /help.

## Rationale

I went bug hunting and spotted this bug as something that I can quickly add.
This PR is against master, but also cleanly applies to insp3 if we want to backport.

## Testing Environment

This PR was tested with a minimal inspircd running stock inspircd.conf, including help.conf and modules.conf (help module only)

I have tested this pull request on:

**Operating system name and version:** Not relevant, documentation change
**Compiler name and version:** Not relevant, documentation change

## Checks


I have ensured that:

  - [X] This pull request does not introduce any incompatible API changes.
  - [X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [X] I have documented any features added by this pull request.
