### PR TITLE
Do initial config check before ForkIntoBackground

### DIFF
--- a/src/inspircd.cpp
+++ b/src/inspircd.cpp
@@ -498,8 +498,6 @@ InspIRCd::InspIRCd(int argc, char** argv)
 	SetSignals();
 	if (!Config->CommandLine.runasroot)
 		CheckRoot();
-	if (!Config->CommandLine.nofork)
-		ForkIntoBackground();
 
 	fmt::println("InspIRCd Process ID: {}", fmt::styled(getpid(), fmt::emphasis::bold | fmt::fg(fmt::terminal_color::green)));
 
@@ -520,6 +518,9 @@ InspIRCd::InspIRCd(int argc, char** argv)
 		fmt::println("Exiting...");
 		Exit(EXIT_FAILURE);
 	}
+
+	if (!Config->CommandLine.nofork)
+		ForkIntoBackground();
 
 	// If we don't have a SID, generate one based on the server name and the server description
 	if (Config->ServerId.empty())


### PR DESCRIPTION
## Summary

This PR reorders the initial config check to happen *before* ForkIntoBackground.

## Rationale

Potential fix for issue 1369.

I reorder the call to this->Config->Read and ->Apply to happen before forking so that we exit in the parent process with a proper exit code.
I've tested with `./bin/inspircd -F -d` and `./bin/inspircd -d`. Both return an exitcode 1 for my test case.

The only other use of Config->Apply is in `src/configreader.cpp`, line 721. That code seems to handle rehash and should independently enough from `src/main.cpp`. I *assume* this will not be affected, but I can test it if you want me to.

## Testing Environment

Plain inspircd *master* compile with an additional `<delibertate error` added to inspircd.conf

`src/main.cpp` seems to be the same for insp3 and master, so probably easy backport.

I have tested this pull request on:

**Operating system name and version:** Linux 6.5
**Compiler name and version:** GCC 13.2.1 (gentoo hardened)

## Checks

I have ensured that:

  - [X] This pull request does not introduce any incompatible API changes.
  - [X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h`.
  - [X] I have documented any features added by this pull request.
