### PR TITLE
Call $compiler with --version instead of -v

### DIFF
--- a/make/configure.pm
+++ b/make/configure.pm
@@ -94,7 +94,7 @@ sub __get_template_settings($$$) {
 
 sub __test_compiler($) {
 	my $compiler = shift;
-	return 0 unless run_test("`$compiler`", !system "$compiler -v ${\CONFIGURE_ERROR_PIPE}");
+	return 0 unless run_test("`$compiler`", !system "$compiler --version ${\CONFIGURE_ERROR_PIPE}");
 	return 0 unless run_test("`$compiler`", test_file($compiler, 'compiler.cpp', '-fno-rtti'), 'compatible');
 	return 1;
 }


### PR DESCRIPTION
## Summary

This is an attempt to fix issue 2070

clang++ does not have -v for --version, so call it by the long option

Interestingly the bug manifested very strangely on my machine - maybe user error too.

GOOD: CXX=clang++ ./configure
BAD: CXX=clang++ ./configure --disable-ownership
BAD: CXX=clang++ ./configure --disable-ownership | cat
BAD: CXX=clang++ ./configure | cat


## Rationale

People try to build inspircd using clang and this fails for example in https://bugs.gentoo.org/919508

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** <!-- e.g. Linux 6.6, Gentoo 2.14 ~amd64 -->
**Compiler name and version:** <!-- e.g. GCC 13 / CLANG 17 -->

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [x] The code I am submitting is my own work and/or I have permission from the author to share it.
  - [x] I have documented any features added by this pull request.
  - [x] This pull request does not introduce any incompatible API changes (stable branches only).
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only).
