### PR TITLE
tools/convert-unreal-*: Parse input in linear time

### DIFF
--- a/tools/convert-unreal-channel
+++ b/tools/convert-unreal-channel
@@ -18,6 +18,7 @@
 #
 
 
+import io
 import os
 import sys
 
@@ -29,36 +30,28 @@ class UnrealDB:
             with open(sys.argv[1], mode="rb") as fh:
                 data = fh.read()
                 if data.startswith(b"UnrealIRCd-DB-v1"):
-                    self.data = data[40:]
+                    self.data = io.BytesIO(data[40:])
                 elif data.startswith(b"UnrealIRCd-DB"):
                     self.error = f"Unsupported database version: {data[0:32]}"
                 else:
-                    self.data = data
+                    self.data = io.BytesIO(data)
         except OSError as e:
             self.error = f"Read error: {e}"
 
     def read_i16(self):
-        tmp = int.from_bytes(self.data[0:2], byteorder="little")
-        self.data = self.data[2:]
-        return tmp
+        return int.from_bytes(self.data.read(2), byteorder="little")
 
     def read_i32(self):
-        tmp = int.from_bytes(self.data[0:4], byteorder="little")
-        self.data = self.data[4:]
-        return tmp
+        return int.from_bytes(self.data.read(4), byteorder="little")
 
     def read_i64(self):
-        tmp = int.from_bytes(self.data[0:8], byteorder="little")
-        self.data = self.data[8:]
-        return tmp
+        return int.from_bytes(self.data.read(8), byteorder="little")
 
     def read_str(self):
         len = self.read_i16()
         if len == 0 or len == 0xFFFF:
             return ""
-        tmp = self.data[0:len]
-        self.data = self.data[len:]
-        return str(tmp, "utf-8")
+        return self.data.read(len).decode("utf-8")
 
 
 def error(msg):

--- a/tools/convert-unreal-tkl
+++ b/tools/convert-unreal-tkl
@@ -18,6 +18,7 @@
 #
 
 
+import io
 import os
 import sys
 
@@ -29,41 +30,31 @@ class UnrealDB:
             with open(sys.argv[1], mode="rb") as fh:
                 data = fh.read()
                 if data.startswith(b"UnrealIRCd-DB-v1"):
-                    self.data = data[40:]
+                    self.data = io.BytesIO(data[40:])
                 elif data.startswith(b"UnrealIRCd-DB"):
                     self.error = f"Unsupported database version: {data[0:32]}"
                 else:
-                    self.data = data
+                    self.data = io.BytesIO(data)
         except OSError as e:
             self.error = f"Read error: {e}"
 
     def read_char(self):
-        tmp = self.data[0:1]
-        self.data = self.data[1:]
-        return str(tmp, "utf-8")
+        return self.data.read(1).decode("utf-8")
 
     def read_i16(self):
-        tmp = int.from_bytes(self.data[0:2], byteorder="little")
-        self.data = self.data[2:]
-        return tmp
+        return int.from_bytes(self.data.read(2), byteorder="little")
 
     def read_i32(self):
-        tmp = int.from_bytes(self.data[0:4], byteorder="little")
-        self.data = self.data[4:]
-        return tmp
+        return int.from_bytes(self.data.read(4), byteorder="little")
 
     def read_i64(self):
-        tmp = int.from_bytes(self.data[0:8], byteorder="little")
-        self.data = self.data[8:]
-        return tmp
+        return int.from_bytes(self.data.read(8), byteorder="little")
 
     def read_str(self):
         len = self.read_i16()
         if len == 0 or len == 0xFFFF:
             return ""
-        tmp = self.data[0:len]
-        self.data = self.data[len:]
-        return str(tmp, "utf-8")
+        return self.data.read(len).decode("utf-8")
 
 
 def error(msg):


### PR DESCRIPTION
## Summary

This replaces string slicing with `io.Bytes`, which keeps the original string and moves a cursor.

## Rationale

Non-trivial string slicing on CPython makes a copy of the string, making the overall parsing run in quadratic time.

For example, assuming an average field size of 10 bytes, parsing a 1MB file on my computer would take 70s in slicing alone.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Debian 12.5
**Compiler name and version:** Python 3.11

## Checks

I have ensured that:

  - [x] The code I am submitting is my own work and/or I have permission from the author to share it.
  - [ ] I have documented any features added by this pull request.
  - [x] This pull request does not introduce any incompatible API changes (stable branches only).
  - [ ] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only).
