### PR TITLE
Used standardised websocket subprotocol names

### DIFF
--- a/src/modules/m_websocket.cpp
+++ b/src/modules/m_websocket.cpp
@@ -468,8 +468,8 @@ class WebSocketHook final
 			{
 				proto.erase(std::remove_if(proto.begin(), proto.end(), ::isspace), proto.end());
 
-				bool is_binary = insp::equalsci(proto, "binary.inspircd.org");
-				bool is_text = insp::equalsci(proto, "text.inspircd.org");
+				bool is_binary = insp::equalsci(proto, "binary.ircv3.net");
+				bool is_text = insp::equalsci(proto, "text.ircv3.net");
 
 				if (is_binary || is_text)
 				{


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->

The websocket module should use the standardised subprotocol names as specified here: https://ircv3.net/specs/extensions/websocket

## Rationale

<!--
Describe why you have made this change.
-->

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

Tested with kiwiirc and https://ircdocs.horse/tools/wstester 

> **Note**
> the following must be set in your modules.conf
> `<websocket defaultmode="reject">`

I have tested this pull request on:

**Operating system name and version:** Archlinux 6.9.7-arch1-1 x86_64.
**Compiler name and version:**  make 4.4.1-2, gcc 14.1.1+r58+gfc9fb69ad62-1


## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [x] The code I am submitting is my own work and/or I have permission from the author to share it.
  - [x] I have documented any features added by this pull request.
  - [ ] This pull request does not introduce any incompatible API changes (stable branches only).
  - [ ] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only).
