### PR TITLE
silence: Fix retrieval of incorrect setting for exemptservice

### DIFF
--- a/src/modules/m_silence.cpp
+++ b/src/modules/m_silence.cpp
@@ -488,7 +488,7 @@ public:
 	void ReadConfig(ConfigStatus& status) override
 	{
 		const auto& tag = ServerInstance->Config->ConfValue("silence");
-		exemptservice = tag->getBool("exemptservice", tag->getBool("exemptuline", true));
+		exemptservice = tag->getBool("exemptservice", tag->getBool("exemptservice", true));
 		cmd.ext.maxsilence = tag->getNum<unsigned long>("maxentries", 32, 1);
 	}
 


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->

Fixes the retrieval of the `exemptservice` setting for the `silence` module to retrieve the setting of the same name.

## Rationale

<!--
Describe why you have made this change.
-->

The `exemptservice` setting in the module should retrieve the setting of the same name from the server configuration.


## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

Not tested, but it's a one-line change of some simple code.

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [X] The code I am submitting is my own work and/or I have permission from the author to share it.
  - [X] I have documented any features added by this pull request.
  - [X] This pull request does not introduce any incompatible API changes (stable branches only).
  - [X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only).
