### PR TITLE
ircv3_sts: Update default STS duration to 60 days

### DIFF
--- a/src/modules/m_ircv3_sts.cpp
+++ b/src/modules/m_ircv3_sts.cpp
@@ -184,7 +184,7 @@ public:
 		if (!HasValidSSLPort(port))
 			throw ModuleException(this, "<sts:port> must be a TLS port, at " + tag->source.str());
 
-		unsigned long duration = tag->getDuration("duration", 5*60, 60);
+		unsigned long duration = tag->getDuration("duration", 60*60*24*60, 60);
 		bool preload = tag->getBool("preload");
 		cap.SetPolicy(host, duration, port, preload);
 


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->

Updates the default duration of the STS policy to 60 days (`60*60*24*60`) from the current default of 5 minutes.

## Rationale

<!--
Describe why you have made this change.
-->

The current default is inconsistent with the [published documentation](https://docs.inspircd.org/4/modules/ircv3_sts/) and is also so low as to be essentially useless from a security perspective. By updating it to 60 days the default will be consistent with the existing published documentation for the module.

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

Not tested, but it's a one-line change of some simple code. I have verified the existing default is being set to `300` seconds when the duration key is absent, and the new default sets it to what it should be and what is being set in my own configuration:

On removing the `duration` key:
```
20-16:20  -!- inspircd.conf Rehashing <snip>
20-16:20 !<snip> *** Successfully rehashed server.
20-16:20  -!- Capabilities removed: sts
20-16:20  -!- Capabilities now available: sts=duration=300
```

On adding the `duration` key with `60d`:
```
20-16:20  -!- inspircd.conf Rehashing <snip>
20-16:20 !<snip> *** Successfully rehashed server.
20-16:20  -!- Capabilities removed: sts
20-16:20  -!- Capabilities now available: sts=duration=5184000
```

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

  - [X] The code I am submitting is my own work and/or I have permission from the author to share it.
  - [X] I have documented any features added by this pull request.
  - [X] This pull request does not introduce any incompatible API changes (stable branches only).
  - [X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only).