### PR TITLE
fix: m_pgsql: Clear vector before adding new values to prevent duplicates

### DIFF
--- a/src/modules/extra/m_pgsql.cpp
+++ b/src/modules/extra/m_pgsql.cpp
@@ -177,7 +177,8 @@ public:
 		if (currentrow >= PQntuples(res))
 			return false;
 		int ncols = PQnfields(res);
-
+		
+		result.clear();
 		for(int i = 0; i < ncols; i++)
 		{
 			result.push_back(GetValue(currentrow, i));


### PR DESCRIPTION
## Summary

The SQL row vector was not being cleared between iterations, causing values to accumulate and duplicate. This adds result.clear() before populating each row.

## Rationale

In order to be able to use the pgsql module effectively

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Ubuntu22.04.1 (aarch64) / macOS Sequoia 15.1
**Compiler name and version:** GCC 11.4 / clang 16.0.0 (clang-1600.0.26.4)

## Checks

I have ensured that:

  - [x] The code I am submitting is my own work and/or I have permission from the author to share it.
  - [x] I have documented any features added by this pull request.
  - [x] This pull request does not introduce any incompatible API changes (stable branches only).
  - [ ] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only).
