### PR TITLE
Two simple performance optimizations for large servers

### DIFF
--- a/include/channels.h
+++ b/include/channels.h
@@ -43,7 +43,7 @@ class CoreExport Channel final
 public:
 	/** A map of Memberships on a channel keyed by User pointers
 	 */
-	typedef std::map<User*, insp::aligned_storage<Membership>> MemberMap;
+	typedef std::unordered_map<User*, insp::aligned_storage<Membership>> MemberMap;
 
 private:
 	/** Set default modes for the channel on creation

--- a/src/coremods/core_who.cpp
+++ b/src/coremods/core_who.cpp
@@ -445,7 +445,7 @@ void CommandWho::WhoUsers(LocalUser* source, const std::vector<std::string>& par
 		User* user = GetUser(iter);
 
 		// Only show users in response to a fuzzy WHO if we can see them normally.
-		bool can_see_normally = user == source || source->SharesChannelWith(user) || !user->IsModeSet(invisiblemode);
+		bool can_see_normally = user == source || !user->IsModeSet(invisiblemode) || source->SharesChannelWith(user);
 		if (data.fuzzy_match && !can_see_normally && !source_has_users_auspex)
 			continue;
 


### PR DESCRIPTION
## Summary

On our server hosting 150K users was running hot and some perf captures turned up a few easy optimizations we thought we would share.

## Rationale

These two low-risk changes combined seem to have cut a few percent off of the CPU capture. 

## Testing Environment

These changes have been live in our production environment all day and there has been no problems.

I have tested this pull request on:

Ubuntu 22.04.4 LTS
gcc version 11.4.0

## Checks

I have ensured that:

  - [x] The code I am submitting is my own work and/or I have permission from the author to share it.
  - [x] I have documented any features added by this pull request.
  - [x] This pull request does not introduce any incompatible API changes (stable branches only).
  - [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only).
