### PR TITLE
Update example help configs with missing restriction exemptions, extbans and user and channel modes

### DIFF
--- a/docs/conf/help.example.conf
+++ b/docs/conf/help.example.conf
@@ -862,6 +862,8 @@ using their cloak when they quit.
               (requires the account module).
  S            Strips formatting codes out of private messages
               to the user (requires the stripcolor module).
+ T            Enables blocking private messages that contain CTCPs
+              (requires the noctcp module).
  W            Receives notifications when a user uses WHOIS on them
               (server operators only, requires the showwhois module).
 ">
@@ -878,6 +880,13 @@ using their cloak when they quit.
  q <nickname>       Gives owner status to <nickname>, preventing them
                     from being kicked (Services or +q only, requires
                     the customprefix module).
+ y <nickname>       Grants the server operator-only channel operprefix
+                    status to <nickname>. Can not be directly set by users,
+                    gets set automatically on server operators.
+                    (requires the operprefix module).
+ Y <nickname>       Grants the server operator-only channel official-join
+                    status to <nickname>. Can not be directly set by users,
+                    use /OJOIN to have it set (requires the ojoin module).
 
  b <hostmask>       Bans <hostmask> from the channel.
  e <hostmask>       Excepts <hostmask> from bans (requires the
@@ -973,9 +982,13 @@ using their cloak when they quit.
                     channel (requires the stripcolor module).
  T                  Blocks /NOTICEs to the channel from users who are
                     not at least halfop (requires the nonotice module).
+ U                  Hides the messages of unprivileged users from other
+                    unprivileged users (requires the opmoderated module).
  X <type>:<status>  Makes users of <status> or higher exempt to the
                     specified restriction <type>. For example: flood:h
                     (requires the exemptchanops module).
+ Z <name>[=<value>] Add and remove modes via their long names (requires
+                    the namedmodes module).
 
  Possible restriction types to exempt with +X are:
 

--- a/docs/conf/help.example.conf
+++ b/docs/conf/help.example.conf
@@ -1109,55 +1109,50 @@ setting +I <extban>.
 
 Matching extbans:
 
- a:<mask>      Matches user with both a matching banmask and real name,
-               where <mask> is in the format nick!user@host+realname
-               (requires the realnameban module).
- j:<channel>   Matches anyone in the given channel. Does not support
-               wildcards (requires the channelban module).
- n:<class>     Matches users in a matching connect class (requires
-               the classban module).
- o:<pattern>   Checks whether users are logged into a server operator
-               account with a name matching <pattern> (requires the
-               operchans module).
- r:<realname>  Matches users with a matching real name (requires the
-               realnameban module).
- s:<server>    Matches users on a matching server (requires the
-               serverban module).
- z:<tlsfp>     Matches users having the given TLS certificate
-               fingerprint (requires the sslmodes module).
- w:<gateway>   Matches users who are connecting via a WebIRC gateway that
-               matches <gateway>.
- G:<pattern>   Matches against the two letter country code for the
-               country that users are connecting from (requires the
-               geoban module).
- O:<opertype>  Matches server operators of a matching type, mostly
-               useful as an invite exception (requires the
-               operchans module).
- R:<account>   Matches users logged into a matching account (requires
-               the account module).
- U:<banmask>   Matches unregistered users matching the given banmask.
-               (requires the account module).
+realmask:<mask>, a:<mask>          Matches user with both a matching banmask and real name, where
+                                   <mask> is in the format nick!user@host+realname (requires the
+                                   realnameban module).
+channel:<channel>, j:<channel>     Matches anyone in the given channel. Does not support wildcards
+                                   (requires the channelban module).
+class:<class>, n:<class>           Matches users in a matching connect class (requires the
+                                   classban module).
+oper:<pattern>, o:<pattern>        Checks whether users are logged into a server operator account
+                                   with a name matching <pattern> (requires the operchans module).
+realname:<realname>, r:<realname>  Matches users with a matching real name (requires the
+                                   realnameban module).
+server:<server>, s:<server>        Matches users on a matching server (requires the serverban
+                                   module).
+sslfp:<tlsfp>, z:<tlsfp>           Matches users having the given TLS certificate fingerprint
+                                   (requires the sslmodes module).
+gateway:<gateway>, w:<gateway>     Matches users who are connecting via a WebIRC gateway that
+                                   matches <gateway> (requires the gateway module).
+country:<pattern>, G:<pattern>     Matches against the two letter country code for the country
+                                   that users are connecting from (requires the geoban module).
+opertype:<opertype>, O:<opertype>  Matches server operators of a matching type, mostly useful as
+                                   an invite exception (requires the operchans module).
+account:<account>, R:<account>     Matches users logged into a matching account (requires the
+                                   account module).
+unauthed:<banmask>, U:<banmask>    Matches unregistered users matching the given banmask (requires
+                                   the account module).
 
 Acting extbans:
 
- c:<banmask>   Blocks any messages that contain formatting codes from
-               matching users (requires the blockcolor module).
- m:<banmask>   Blocks messages from matching users (requires the muteban
-               module). Users with +v or above are not affected.
- u:<banmask>   Blocks matching users from speaking to unprivileged users
-               in the channel (requires the opmoderated module).
- A:<banmask>   Blocks invites by matching users even when +A is set
-               (requires the allowinvite module).
- C:<banmask>   Blocks CTCPs from matching users (requires the noctcp
-               module).
- N:<banmask>   Blocks nick changes from matching users (requires
-               the nonicks module).
- Q:<banmask>   Blocks kicks by matching users (requires the nokicks
-               module).
- S:<banmask>   Strips formatting codes from messages from matching
-               users (requires the stripcolor module).
- T:<banmask>   Blocks notices from matching users (requires the
-               nonotice module).
+blockcolor:<banmask>, c:<banmask>  Blocks any messages that contain formatting codes from matching
+                                   users (requires the blockcolor module).
+mute:<banmask>, m:<banmask>        Blocks messages from matching users (requires the muteban
+                                   module). Users with +v or above are not affected.
+opmoderated:<banmask>, u:<banmask> Blocks matching users from speaking to unprivileged users in
+                                   the channel (requires the opmoderated module).
+blockinvite:<banmask>, A:<banmask> Blocks invites by matching users even when +A is set (requires
+                                   the allowinvite module).
+noctcp:<banmask>, C:<banmask>      Blocks CTCPs from matching users (requires the noctcp module).
+nonick:<banmask>, N:<banmask>      Blocks nick changes from matching users (requires the nonicks
+                                   module).
+nokick:<banmask>, Q:<banmask>      Blocks kicks by matching users (requires the nokicks module).
+stripcolor:<banmask>, S:<banmask>  Strips formatting codes from messages from matching users
+                                   (requires the stripcolor module).
+nonotice:<banmask>, T:<banmask>    Blocks notices from matching users (requires the nonotice
+                                   module).
 
 A ban given to an Acting extban may either be a nick!user@host mask
 (unless stated otherwise), matched against users as for a normal ban,

--- a/docs/conf/help.example.conf
+++ b/docs/conf/help.example.conf
@@ -1098,11 +1098,14 @@ Matching extbans:
 
  a:<mask>      Matches user with both a matching banmask and real name,
                where <mask> is in the format nick!user@host+realname
-               (requires realnameban module).
+               (requires the realnameban module).
  j:<channel>   Matches anyone in the given channel. Does not support
                wildcards (requires the channelban module).
  n:<class>     Matches users in a matching connect class (requires
                the classban module).
+ o:<pattern>   Checks whether users are logged into a server operator
+               account with a name matching <pattern> (requires the
+               operchans module).
  r:<realname>  Matches users with a matching real name (requires the
                realnameban module).
  s:<server>    Matches users on a matching server (requires the
@@ -1111,6 +1114,9 @@ Matching extbans:
                fingerprint (requires the sslmodes module).
  w:<gateway>   Matches users who are connecting via a WebIRC gateway that
                matches <gateway>.
+ G:<pattern>   Matches against the two letter country code for the
+               country that users are connecting from (requires the
+               geoban module).
  O:<opertype>  Matches server operators of a matching type, mostly
                useful as an invite exception (requires the
                operchans module).
@@ -1125,10 +1131,10 @@ Acting extbans:
                matching users (requires the blockcolor module).
  m:<banmask>   Blocks messages from matching users (requires the muteban
                module). Users with +v or above are not affected.
+ u:<banmask>   Blocks matching users from speaking to unprivileged users
+               in the channel (requires the opmoderated module).
  A:<banmask>   Blocks invites by matching users even when +A is set
                (requires the allowinvite module).
- B:<banmask>   Blocks all capital or nearly all capital messages from
-               matching users (requires the blockcaps module).
  C:<banmask>   Blocks CTCPs from matching users (requires the noctcp
                module).
  N:<banmask>   Blocks nick changes from matching users (requires

--- a/docs/conf/help.example.conf
+++ b/docs/conf/help.example.conf
@@ -1112,7 +1112,7 @@ Matching extbans:
 realmask:<mask>, a:<mask>          Matches user with both a matching banmask and real name, where
                                    <mask> is in the format nick!user@host+realname (requires the
                                    realnameban module).
-channel:<channel>, j:<channel>     Matches anyone in the given channel. Does not support wildcards
+channel:<channel>, j:<channel>     Matches anyone in the given channel. Supports wildcards
                                    (requires the channelban module).
 class:<class>, n:<class>           Matches users in a matching connect class (requires the
                                    classban module).

--- a/docs/conf/help.example.conf
+++ b/docs/conf/help.example.conf
@@ -976,6 +976,7 @@ using their cloak when they quit.
  X <type>:<status>  Makes users of <status> or higher exempt to the
                     specified restriction <type>. For example: flood:h
                     (requires the exemptchanops module).
+
  Possible restriction types to exempt with +X are:
 
  anticaps            Channel mode +B
@@ -984,12 +985,14 @@ using their cloak when they quit.
  auditorium-vis      Permission required to be visible in a +u channel
                      (requires the auditorium module).
  blockcolor          Channel mode +c
+ delaymsg            Channel mode +d
  filter              Channel mode +g
  flood               Channel mode +f
  nickflood           Channel mode +F
  noctcp              Channel mode +C
  nonick              Channel mode +N
  nonotice            Channel mode +T
+ opmoderated         Channel mode +U
  regmoderated        Channel mode +M
  repeat              Channel mode +E
  stripcolor          Channel mode +S

--- a/docs/conf/inspircd.example.conf
+++ b/docs/conf/inspircd.example.conf
@@ -690,8 +690,6 @@
          #                    a +u channel (requires the auditorium module).
          #  - auditorium-vis  Permission required to be visible in a +u channel
          #                    (requires the auditorium module).
-         #  - blockcaps       Channel mode +B - blocks messages with too many capital
-         #                    letters (requires the blockcaps module).
          #  - blockcolor      Channel mode +c - blocks messages with formatting codes
          #                    (requires the blockcolor module).
          #  - delaymsg        Channel mode +d - blocks sending messages until specified
@@ -708,8 +706,12 @@
          #                    changing nicks (requires the nonicks module).
          #  - nonotice        Channel mode +T - blocks /NOTICEs to the channel
          #                    (requires the nonotice module).
+         #  - opmoderated     Channel mode +U - hides the messages of unprivileged users
+         #                    from other unprivileged users (requires the opmoderated module).
          #  - regmoderated    Channel mode +M - blocks unregistered users from
          #                    speaking (requires the account module).
+         #  - repeat          Channel mode +E - allows blocking of similar messages
+         #                    (requires the repeat module).
          #  - stripcolor      Channel mode +S - strips formatting codes from
          #                    messages (requires the stripcolor module).
          #  - topiclock       Channel mode +t - limits changing the topic to (half)ops


### PR DESCRIPTION
## Summary
Update example help configs with missing restriction exemptions, extbans and user and channel modes. Remove mentions of blockcaps as it doesn't exist anymore.

## Rationale
To keep the documentation updated.

## Testing Environment
Not applicable

## Checks
I have ensured that:

- [x] The code I am submitting is my own work and/or I have permission from the author to share it.
- [x] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
- [x] I have documented any features added by this pull request.
- [x] This pull request does not introduce any incompatible API changes (stable branches only, delete if not applicable).
- [x] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only, delete if not applicable).