### PR TITLE
Fix two use-after-free crashes in ModuleManager::DoSafeUnload

### DIFF
--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -440,6 +440,8 @@ void ModuleManager::DoSafeUnload(Module* mod)
 
 	std::map<std::string, Module*>::iterator modfind = Modules.find(mod->ModuleFile);
 
+	std::string modfile = mod->ModuleFile;
+
 	// Unregister modes before extensions because modes may require their extension to show the mode being unset
 	UnregisterModes(mod, MODETYPE_USER);
 	UnregisterModes(mod, MODETYPE_CHANNEL);
@@ -476,8 +478,9 @@ void ModuleManager::DoSafeUnload(Module* mod)
 		DataProviderMap::iterator curr = i++;
 		if (curr->second->creator == mod)
 		{
+			ServiceProvider* provider = curr->second;
 			DataProviders.erase(curr);
-			FOREACH_MOD(OnServiceDel, (*curr->second));
+			FOREACH_MOD(OnServiceDel, (*provider));
 		}
 	}
 
@@ -488,7 +491,7 @@ void ModuleManager::DoSafeUnload(Module* mod)
 	Modules.erase(modfind);
 	ServerInstance->GlobalCulls.AddItem(mod);
 
-	ServerInstance->Logs.Normal("MODULE", "The {} module was unloaded", mod->ModuleFile);
+	ServerInstance->Logs.Normal("MODULE", "The {} module was unloaded", modfile);
 }
 
 void ModuleManager::UnloadAll()

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -440,8 +440,6 @@ void ModuleManager::DoSafeUnload(Module* mod)
 
 	std::map<std::string, Module*>::iterator modfind = Modules.find(mod->ModuleFile);
 
-	std::string modfile = mod->ModuleFile;
-
 	// Unregister modes before extensions because modes may require their extension to show the mode being unset
 	UnregisterModes(mod, MODETYPE_USER);
 	UnregisterModes(mod, MODETYPE_CHANNEL);
@@ -491,7 +489,7 @@ void ModuleManager::DoSafeUnload(Module* mod)
 	Modules.erase(modfind);
 	ServerInstance->GlobalCulls.AddItem(mod);
 
-	ServerInstance->Logs.Normal("MODULE", "The {} module was unloaded", modfile);
+	ServerInstance->Logs.Normal("MODULE", "The {} module was unloaded", mod->ModuleFile);
 }
 
 void ModuleManager::UnloadAll()


### PR DESCRIPTION
<!--
Please fill in the template below. Pull requests that do not use this template will be closed without warning.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->

Fix two use-after-free crashes in ModuleManager::DoSafeUnload

## Rationale

<!--
Describe why you have made this change.
-->

When unloading a module, DoSafeUnload erases its entries from the DataProviders
map and then reads the erased iterator to call OnServiceDel. This is a
use-after-free that crashes in downstream handlers when they access the
ServiceProvider name. The shutdown also logs mod->ModuleFile after adding the
module to GlobalCulls, which can be freed before the log call. These crashes
are reproducible on graceful shutdown when the unloaded module provides
services.

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Arch Linux 7.0.5-zen1-1-zen
**Compiler name and version:** GCC 16.1.1

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

- [x] The code I am submitting is my own work and/or I have permission from the author to share it.
- [x] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
- [ ] I have documented any features added by this pull request.
- [x] This pull request does not introduce any incompatible API changes (stable branches only, delete if not applicable).