### PR TITLE
mysql ssl - detect + add 5.7/mariadb fallback

### DIFF
--- a/src/modules/extra/m_mysql.cpp
+++ b/src/modules/extra/m_mysql.cpp
@@ -334,9 +334,13 @@ public:
 		mysql_options(connection, MYSQL_OPT_CONNECT_TIMEOUT, &timeout);
 
 		// Enable SSL if requested.
-#if defined LIBMYSQL_VERSION_ID && LIBMYSQL_VERSION_ID > 80000
+#ifdef MYSQL_OPT_SSL_MODE
 		unsigned int ssl = config->getBool("ssl") ? SSL_MODE_REQUIRED : SSL_MODE_PREFERRED;
 		mysql_options(connection, MYSQL_OPT_SSL_MODE, &ssl);
+#elif defined MYSQL_OPT_SSL_VERIFY_SERVER_CERT && defined MYSQL_OPT_SSL_ENFORCE
+        unsigned my_bool ssl = config->getBool("ssl"), on= 1;
+        mysql_options(connection, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl);
+        mysql_options(connection, MYSQL_OPT_SSL_ENFORCE, &on);
 #endif
 
 		// Attempt to connect to the database.


### PR DESCRIPTION
For detecting MYSQL_OPT_SSL_MODE, look at the define rather than the version.

Add a 5.7/MariaDB fallback using MYSQL_OPT_SSL_VERIFY_SERVER_CERT and MYSQL_OPT_SSL_ENFORCE.

Based on suggestion by Sergei Golubchik on:
https://jira.mariadb.org/browse/CONC-729

And cross reference with https://dev.mysql.com/doc/c-api/5.7/en/mysql-options.html

<!--
Please fill in the template below. Pull requests that do not use this template may be closed without warning.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->

## Rationale

<!--
Describe why you have made this change.
-->

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** <!-- e.g. Linux 3.11 -->
**Compiler name and version:** <!-- e.g. GCC 4.2.0 -->

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
- [X] If the pull request contains a security fix I have followed the reporting rules mentioned in [the security policy](https://github.com/inspircd/inspircd/security/policy) (delete if not applicable).
- [N/A] I have documented any features added by this pull request (delete if not applicable).
- [X] This pull request does not introduce any incompatible API changes (stable branches only, delete if not applicable).
- [N/A] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only, delete if not applicable).
