### PR TITLE
Add support for HAProxy certificate fingerprint in PROXY protocol

### DIFF
--- a/src/modules/m_haproxy.cpp
+++ b/src/modules/m_haproxy.cpp
@@ -21,7 +21,6 @@
 
 #include "inspircd.h"
 #include "iohook.h"
-#include "stringutils.h"
 #include "modules/ssl.h"
 
 enum

--- a/src/modules/m_haproxy.cpp
+++ b/src/modules/m_haproxy.cpp
@@ -158,7 +158,7 @@ private:
 	std::string certificate_fingerprint;
 
 	// The fake certificate we attach for this connection, if any.
-	ssl_cert* certificate = nullptr;
+	reference<ssl_cert> certificate;
 
 	// The current state of the PROXY parser.
 	HAProxyState state = HPS_WAITING_FOR_HEADER;

--- a/src/modules/m_haproxy.cpp
+++ b/src/modules/m_haproxy.cpp
@@ -58,6 +58,9 @@ enum
 	// The identifier for a TLS TLV entry.
 	PP2_TYPE_SSL = 0x20,
 
+	// The identifier for a TLS certificate fingerprint TLV entry.
+	PP2_TYPE_CERTFP = 0xE0,
+
 	// The minimum length of a PP2_TYPE_SSL TLV entry.
 	PP2_TYPE_SSL_LENGTH = 5,
 
@@ -150,6 +153,12 @@ private:
 	// The API for interacting with user TLS internals.
 	UserCertificateAPI& sslapi;
 
+	// The fingerprint forwarded by the proxy for the client certificate.
+	std::string certificate_fingerprint;
+
+	// The fake certificate we attach for this connection, if any.
+	ssl_cert* certificate = nullptr;
+
 	// The current state of the PROXY parser.
 	HAProxyState state = HPS_WAITING_FOR_HEADER;
 
@@ -172,15 +181,62 @@ private:
 		}
 
 		// What type of TLV are we parsing?
-		switch (recvq[start_index])
+		switch (static_cast<uint8_t>(recvq[start_index]))
 		{
 			case PP2_TYPE_SSL:
 				if (!ReadProxyTLVSSL(sock, start_index + PP2_TLV_LENGTH, length))
 					return 0;
 				break;
+
+			case PP2_TYPE_CERTFP:
+				if (!ReadProxyTLVCertFP(sock, start_index + PP2_TLV_LENGTH, length))
+					return 0;
+				break;
 		}
 
 		return PP2_TLV_LENGTH + length;
+	}
+
+	bool ReadProxyTLVCertFP(StreamSocket* sock, size_t start_index, uint16_t buffer_length)
+	{
+		// If the socket is not a user socket we don't have to do
+		// anything with this TLV's information.
+		if (sock->type != StreamSocket::SS_USER)
+			return true;
+
+		// The fingerprint must be a 20-byte raw SHA-1 digest.
+		if (buffer_length != 20)
+		{
+			ServerInstance->Logs.Debug(MODNAME, "Ignoring PP2_TYPE_CERTFP TLV with unexpected length {} (expected 20)", buffer_length);
+			return true;
+		}
+
+		std::string& recvq = GetRecvQ();
+
+		// Convert to lowercase hex to match InspIRCd's fingerprint format.
+		static constexpr char hex[] = "0123456789abcdef";
+		certificate_fingerprint.resize(40);
+		for (size_t i = 0; i < 20; ++i)
+		{
+			const uint8_t byte = static_cast<uint8_t>(recvq[start_index + i]);
+			certificate_fingerprint[i * 2]     = hex[byte >> 4];
+			certificate_fingerprint[i * 2 + 1] = hex[byte & 0x0F];
+		}
+
+		ServerInstance->Logs.Debug(MODNAME, "Received certificate fingerprint from HAProxy: {}", certificate_fingerprint);
+
+		// If the SSL TLV was already processed, patch the existing certificate
+		// with the fingerprint now that we have it.
+		if (certificate)
+		{
+			certificate->fingerprints.push_back(certificate_fingerprint);
+			certificate->invalid = false;
+			certificate->trusted = true;
+			certificate->unknownsigner = false;
+			certificate->revoked = false;
+			certificate->error.clear();
+		}
+		return true;
 	}
 
 	bool ReadProxyTLVSSL(StreamSocket* sock, size_t start_index, uint16_t buffer_length)
@@ -207,19 +263,35 @@ private:
 		if ((recvq[start_index] & PP2_CLIENT_SSL) == 0)
 			return true;
 
-		// Create a fake ssl_cert for the user. Ideally we should use the user's
-		// TLS client certificate here but as of 2018-10-16 this is not forwarded
-		// by HAProxy.
-		auto* cert = new ssl_cert();
-		cert->error = "HAProxy does not forward client TLS certificates";
-		cert->invalid = true;
-		cert->revoked = true;
-		cert->trusted = false;
-		cert->unknownsigner = true;
+		// Create a fake ssl_cert for the user. If the proxy already forwarded a
+		// certificate fingerprint via PP2_TYPE_CERTFP we use it; otherwise we only
+		// know the client was connected over TLS.
+		if (!certificate)
+		{
+			auto* cert = new ssl_cert();
+			cert->dn = "(unknown)";
+			cert->issuer = "(unknown)";
 
-		// Extract the user for this socket and set their certificate.
-		LocalUser* luser = static_cast<UserIOHandler*>(sock)->user;
-		sslapi->SetCertificate(luser, cert);
+			if (!certificate_fingerprint.empty())
+			{
+				cert->fingerprints.push_back(certificate_fingerprint);
+				cert->invalid = false;
+				cert->trusted = true;
+				cert->unknownsigner = false;
+			}
+			else
+			{
+				cert->error = "HAProxy does not forward client TLS certificates";
+				cert->invalid = true;
+				cert->revoked = true;
+				cert->trusted = false;
+				cert->unknownsigner = true;
+			}
+
+			LocalUser* luser = static_cast<UserIOHandler*>(sock)->user;
+			sslapi->SetCertificate(luser, cert);
+			certificate = cert;
+		}
 		return true;
 	}
 

--- a/src/modules/m_haproxy.cpp
+++ b/src/modules/m_haproxy.cpp
@@ -205,16 +205,23 @@ private:
 		if (sock->type != StreamSocket::SS_USER)
 			return true;
 
-		// The fingerprint must be a non-empty raw digest of a plausible size.
-		if (buffer_length == 0 || buffer_length > 64)
+		// The fingerprint must be a non-empty hex-encoded digest of a plausible size.
+		// A hex string must have an even length and at most 128 chars (64-byte digest).
+		if (buffer_length == 0 || buffer_length % 2 != 0 || buffer_length > 128)
 		{
 			ServerInstance->Logs.Debug(MODNAME, "Ignoring PP2_TYPE_CERTFP TLV with unexpected length {}", buffer_length);
 			return true;
 		}
 
 		std::string& recvq = GetRecvQ();
+		const std::string certificate_fingerprint(&recvq[start_index], buffer_length);
 
-		certificate_fingerprint = Hex::Encode(&recvq[start_index], buffer_length);
+		// Verify every character is a valid hexadecimal digit.
+		if (!std::all_of(certificate_fingerprint.begin(), certificate_fingerprint.end(), [](unsigned char c) { return std::isxdigit(c); }))
+		{
+			ServerInstance->Logs.Debug(MODNAME, "Ignoring PP2_TYPE_CERTFP TLV with non-hex content");
+			return true;
+		}
 
 		ServerInstance->Logs.Debug(MODNAME, "Received certificate fingerprint from HAProxy: {}", certificate_fingerprint);
 

--- a/src/modules/m_haproxy.cpp
+++ b/src/modules/m_haproxy.cpp
@@ -205,10 +205,10 @@ private:
 		if (sock->type != StreamSocket::SS_USER)
 			return true;
 
-		// The fingerprint must be a 20-byte raw SHA-1 digest.
-		if (buffer_length != 20)
+		// The fingerprint must be a non-empty raw digest of a plausible size.
+		if (buffer_length == 0 || buffer_length > 64)
 		{
-			ServerInstance->Logs.Debug(MODNAME, "Ignoring PP2_TYPE_CERTFP TLV with unexpected length {} (expected 20)", buffer_length);
+			ServerInstance->Logs.Debug(MODNAME, "Ignoring PP2_TYPE_CERTFP TLV with unexpected length {}", buffer_length);
 			return true;
 		}
 

--- a/src/modules/m_haproxy.cpp
+++ b/src/modules/m_haproxy.cpp
@@ -228,12 +228,7 @@ private:
 		// with the fingerprint now that we have it.
 		if (certificate)
 		{
-			certificate->fingerprints.push_back(certificate_fingerprint);
-			certificate->invalid = false;
-			certificate->trusted = true;
-			certificate->unknownsigner = false;
-			certificate->revoked = false;
-			certificate->error.clear();
+			SetCertificateFingerprint(certificate);
 		}
 		return true;
 	}
@@ -273,10 +268,7 @@ private:
 
 			if (!certificate_fingerprint.empty())
 			{
-				cert->fingerprints.push_back(certificate_fingerprint);
-				cert->invalid = false;
-				cert->trusted = true;
-				cert->unknownsigner = false;
+				SetCertificateFingerprint(cert);
 			}
 			else
 			{
@@ -445,6 +437,16 @@ private:
 
 		state = HPS_WAITING_FOR_ADDRESS;
 		return ReadProxyAddress(sock, destrecvq);
+	}
+
+	void SetCertificateFingerprint(ssl_cert* cert)
+	{
+		cert->fingerprints.push_back(std::move(certificate_fingerprint));
+		cert->invalid = false;
+		cert->trusted = true;
+		cert->unknownsigner = false;
+		cert->revoked = false;
+		cert->error.clear();
 	}
 
 public:

--- a/src/modules/m_haproxy.cpp
+++ b/src/modules/m_haproxy.cpp
@@ -21,6 +21,7 @@
 
 #include "inspircd.h"
 #include "iohook.h"
+#include "stringutils.h"
 #include "modules/ssl.h"
 
 enum
@@ -213,15 +214,7 @@ private:
 
 		std::string& recvq = GetRecvQ();
 
-		// Convert to lowercase hex to match InspIRCd's fingerprint format.
-		static constexpr char hex[] = "0123456789abcdef";
-		certificate_fingerprint.resize(40);
-		for (size_t i = 0; i < 20; ++i)
-		{
-			const uint8_t byte = static_cast<uint8_t>(recvq[start_index + i]);
-			certificate_fingerprint[i * 2]     = hex[byte >> 4];
-			certificate_fingerprint[i * 2 + 1] = hex[byte & 0x0F];
-		}
+		certificate_fingerprint = Hex::Encode(&recvq[start_index], buffer_length);
 
 		ServerInstance->Logs.Debug(MODNAME, "Received certificate fingerprint from HAProxy: {}", certificate_fingerprint);
 

--- a/src/modules/m_haproxy.cpp
+++ b/src/modules/m_haproxy.cpp
@@ -213,7 +213,7 @@ private:
 		}
 
 		std::string& recvq = GetRecvQ();
-		const std::string certificate_fingerprint(&recvq[start_index], buffer_length);
+		certificate_fingerprint.assign(&recvq[start_index], buffer_length);
 
 		// Verify every character is a valid hexadecimal digit.
 		if (!std::all_of(certificate_fingerprint.begin(), certificate_fingerprint.end(), [](unsigned char c) { return std::isxdigit(c); }))


### PR DESCRIPTION
## Summary

Add support for a custom HAProxy PROXY protocol v2 TLV (`PP2_TYPE_CERTFP = 0xE0`) that carries the hex encoded fingerprint of the client's TLS certificate, forwarded by HAProxy. When present, the fingerprint is used to populate the fake `ssl_cert` that `m_haproxy` already creates for SSL-terminated connections.

## Rationale

When HAProxy terminates TLS on behalf of InspIRCd, the server never sees the client's certificate. This means `SASL EXTERNAL` authentication against services (e.g. Atheme's saslserv/external) doesn't work, and `/WHOIS` shows no certificate fingerprint.

HAProxy already supports forwarding the client certificate fingerprint as a custom TLV. This change reads that TLV, and attaches it to the fake `ssl_cert` so the rest of InspIRCd treats the connection exactly as if TLS terminated locally.

Connections that don't include the `0xE0` TLV are unaffected, so the existing behaviour is preserved.

Example of required HAProxy configuration using multiple hash types:
```
backend irc_backend
    mode tcp
    balance roundrobin
    # Using the native ssl_c_sha1 function
    server inspircd_node1 <ip>:<port> send-proxy-v2-ssl set-proxy-v2-tlv-fmt(0xe0) "%[ssl_c_sha1,hex,lower]"
    # Using the native ssl_c_der function
    server inspircd_node5 <ip>:<port> send-proxy-v2-ssl set-proxy-v2-tlv-fmt(0xe0) "%[ssl_c_der,sha1,hex,lower]"
    server inspircd_node2 <ip>:<port> send-proxy-v2-ssl set-proxy-v2-tlv-fmt(0xe0) "%[ssl_c_der,sha2(256),hex,lower]"
    server inspircd_node3 <ip>:<port> send-proxy-v2-ssl set-proxy-v2-tlv-fmt(0xe0) "%[ssl_c_der,sha2(384),hex,lower]"
    server inspircd_node4 <ip>:<port> send-proxy-v2-ssl set-proxy-v2-tlv-fmt(0xe0) "%[ssl_c_der,sha2(512),hex,lower]"
```
Obviously, all servers should use the same hash conversion. These are just examples of use.

## Testing Environment

I tested this change in a production-like setup consisting of multiple InspIRCd nodes behind an HAProxy load balancer with TLS termination. HAProxy was configured to forward the client certificate SHA-1 fingerprint via the custom `0xE0` TLV using `%[ssl_c_sha1,hex,lower]`. The connection from HAProxy to InspIRCd is plain TCP (non-TLS), as is expected in this architecture; the HAProxy listener should be restricted to trusted local or internal network traffic only.

On connect, clients correctly received their certificate fingerprint in `/WHOIS` and `/SSLINFO`. I then registered the fingerprint with Atheme services using `/ns CERT ADD`, and on subsequent reconnections Atheme automatically recognised the certificate and logged the user in without a password prompt, confirming end-to-end SASL EXTERNAL authentication works as expected.

**Operating system name and version:** Linux 6.12.90+deb13-cloud-amd64
**Compiler name and version:** gcc (Debian 14.2.0-19) 14.2.0


## Checks

I have ensured that:

- [x] The code I am submitting is my own work and/or I have permission from the author to share it.
- [x] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
- [ ] I have documented any features added by this pull request (delete if not applicable).
