### PR TITLE
m_sasl: Send * D A on user disconnect

### DIFF
--- a/src/modules/m_sasl.cpp
+++ b/src/modules/m_sasl.cpp
@@ -272,6 +272,15 @@ public:
 		this->result = SASL_ABORT;
 	}
 
+	void NotifyServicesAbort()
+	{
+		if (this->state == SASL_DONE)
+			return;
+
+		SendSASL(this->user, this->agent.empty() ? "*" : this->agent, 'D', { "A" });
+		this->state = SASL_DONE;
+	}
+
 	bool SendClientMessage(const std::vector<std::string>& parameters)
 	{
 		if (this->state != SASL_COMM)
@@ -461,6 +470,13 @@ public:
 			saslauth->AnnounceState();
 			authExt.Unset(user);
 		}
+	}
+
+	void OnUserDisconnect(LocalUser* user) override
+	{
+		SaslAuthenticator* saslauth = authExt.Get(user);
+		if (saslauth)
+			saslauth->NotifyServicesAbort();
 	}
 
 	void OnDecodeMetadata(Extensible* target, const std::string& extname, const std::string& extdata) override

--- a/src/modules/m_sasl.cpp
+++ b/src/modules/m_sasl.cpp
@@ -272,7 +272,7 @@ public:
 		this->result = SASL_ABORT;
 	}
 
-	void NotifyServicesAbort()
+	void NotifyAbort()
 	{
 		if (this->state == SASL_DONE)
 			return;
@@ -476,7 +476,7 @@ public:
 	{
 		SaslAuthenticator* saslauth = authExt.Get(user);
 		if (saslauth)
-			saslauth->NotifyServicesAbort();
+			saslauth->NotifyAbort();
 	}
 
 	void OnDecodeMetadata(Extensible* target, const std::string& extname, const std::string& extdata) override


### PR DESCRIPTION
## Summary

Send SASL agent/* D A when a user with pending SASL disconnects.

## Rationale

So services don't have to rely on a timeout to discard users

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Linux $hostname 7.0.10-0-stable #1-Alpine SMP PREEMPT_DYNAMIC 2026-05-23 11:50:19 x86_64 GNU/Linux

**Compiler name and version:** gcc version 15.2.0 (Alpine 15.2.0) 

## Checks

I have ensured that:

- [x] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.