### PR TITLE
Fix websock pings

### DIFF
--- a/include/iohook.h
+++ b/include/iohook.h
@@ -117,9 +117,10 @@ public:
 	virtual ssize_t OnStreamSocketRead(StreamSocket* sock, std::string& recvq) = 0;
 
 	/** Sends a ping to the remote client to check whether it is still connected.
+	 * @param sock Hooked socket
 	 * @return True if the client was pinged; otherwise, false.
 	 */
-	virtual bool Ping() { return false; }
+	virtual bool Ping(StreamSocket* sock) { return false; }
 };
 
 class IOHookMiddle

--- a/include/moduledefs.h
+++ b/include/moduledefs.h
@@ -22,7 +22,7 @@
 class Module;
 
 /** The version of the InspIRCd ABI which is presently in use. */
-#define MODULE_ABI 4012UL
+#define MODULE_ABI 4011UL
 
 /** Stringifies the value of a symbol. */
 #define MODULE_STRINGIFY_SYM1(DEF) MODULE_STRINGIFY_SYM2(DEF)

--- a/include/moduledefs.h
+++ b/include/moduledefs.h
@@ -22,7 +22,7 @@
 class Module;
 
 /** The version of the InspIRCd ABI which is presently in use. */
-#define MODULE_ABI 4011UL
+#define MODULE_ABI 4012UL
 
 /** Stringifies the value of a symbol. */
 #define MODULE_STRINGIFY_SYM1(DEF) MODULE_STRINGIFY_SYM2(DEF)

--- a/src/modules/m_websocket.cpp
+++ b/src/modules/m_websocket.cpp
@@ -655,7 +655,7 @@ public:
 		return wsret;
 	}
 
-	bool Ping() override
+	bool Ping(StreamSocket* sock) override
 	{
 		if (!config.nativeping)
 			return false;
@@ -665,6 +665,7 @@ public:
 		const std::string& message = ServerInstance->Config->GetServerName();
 		mysendq.push_back(PrepareSendQElem(message.length(), OP_PING));
 		mysendq.push_back(message);
+		SocketEngine::ChangeEventMask(sock, FD_ADD_TRIAL_WRITE);
 
 		return true;
 	}

--- a/src/usermanager.cpp
+++ b/src/usermanager.cpp
@@ -78,7 +78,7 @@ namespace
 		IOHook* hook = user->eh.GetIOHook();
 		while (hook)
 		{
-			if (hook->Ping())
+			if (hook->Ping(&(user->eh)))
 				return; // Client has been pinged.
 
 			IOHookMiddle* middlehook = IOHookMiddle::ToMiddleHook(hook);


### PR DESCRIPTION
## Summary

Pass StreamSock to Ping() so FD_ADD_TRIAL_WRITE can be set; set it for native websocket pings.

## Rationale

With nativeping enabled, websocket clients will currently time out when they're not receiving events (e.g. no/idle channels.)

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Ubuntu 24.04.4 LTS (5.10.102) under WSL
**Compiler name and version:** GCC 13.3.0

## Checks

Tested locally with and without the `ChangeEventMask()` call. Timed out without, worked with.

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
- [X] If ABI changes have been made I have incremented MODULE_ABI in `moduledefs.h` (stable branches only, delete if not applicable).
