### PR TITLE
Openssl groups fix

### DIFF
--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -188,8 +188,11 @@ namespace OpenSSL
 					grouplist.append(grouplist.empty() ? "" : ":");
 					grouplist.append(group);
 				}
+				if (grouplist.empty())
+					grouplist = "DEFAULT";
+
 				if (groups != grouplist)
-					ServerInstance->Logs.Debug(MODNAME, "Relaxed groups from {} to {}",
+				ServerInstance->Logs.Debug(MODNAME, "Relaxed groups from {} to {}",
 						groups, grouplist);
 			}
 

--- a/src/modules/extra/m_ssl_openssl.cpp
+++ b/src/modules/extra/m_ssl_openssl.cpp
@@ -59,6 +59,9 @@
 # define OPENSSL_VERSION_STR OPENSSL_VERSION_TEXT
 # define OPENSSL_VERSION_STRING OPENSSL_VERSION
 #else
+# if OPENSSL_VERSION_NUMBER >= 0x30500000L
+#  define INSPIRCD_OPENSSL_GET_GROUPS
+# endif
 # define INSPIRCD_OPENSSL_AUTO_DH
 #endif
 
@@ -168,17 +171,26 @@ namespace OpenSSL
 			else
 			{
 				irc::sepstream groupstream(groups, ':');
+#ifdef INSPIRCD_OPENSSL_GET_GROUPS
+				STACK_OF(OPENSSL_CSTRING) *implemented_groups = sk_OPENSSL_CSTRING_new_null();
+				const int GET_ALL = 1;
+				if (!SSL_CTX_get0_implemented_groups(ctx, GET_ALL, implemented_groups))
+					return false;
+#endif
 				for (std::string group; groupstream.GetToken(group); )
 				{
-					if (OBJ_sn2nid(group.c_str()) == NID_undef)
+#ifdef INSPIRCD_OPENSSL_GET_GROUPS
+					if (sk_OPENSSL_CSTRING_find(implemented_groups, group.c_str()) == -1)
+#else
+					if (!SSL_CTX_set1_groups_list(ctx, group.c_str()))
+#endif
 						continue;
-
 					grouplist.append(grouplist.empty() ? "" : ":");
 					grouplist.append(group);
 				}
-
-				ServerInstance->Logs.Debug(MODNAME, "Relaxed groups from {} to {}",
-					groups, grouplist);
+				if (groups != grouplist)
+					ServerInstance->Logs.Debug(MODNAME, "Relaxed groups from {} to {}",
+						groups, grouplist);
 			}
 
 			ERR_clear_error();


### PR DESCRIPTION
## Summary
Similar to Sadie's fix but with a tidier solution for OpenSSL >= 3.5 (which will likely be the lowest supported version by the time insp5 is ready, allowing the ifdefs to be cleaned up.)

## Rationale

Valid groups were being deleted when strictgroups was disabled.

## Testing Environment

I have tested this pull request on:

**Operating system name and version:** Ubuntu 24.04 with OpenSSL 3.x
**Compiler name and version:** GCC 13.3.0

## Checks

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
- [X] If the pull request contains a security fix I have followed the reporting rules mentioned in [the security policy](https://github.com/inspircd/inspircd/security/policy) (delete if not applicable).
