### PR TITLE
Fix remote overwrite of extended swhois with same tag

### DIFF
--- a/modules/swhois.cpp
+++ b/modules/swhois.cpp
@@ -332,7 +332,7 @@ private:
 			tag.erase(0, 1);
 			DelSWhois(cmdswhois.swhoisext, user, [&tag](const SWhois& swhois) {
 				return swhois.tag == tag;
-			});
+			}, true);
 		}
 
 		auto& swhois = AddSWhois(cmdswhois.swhoisext, user, ConvToNum<time_t>(priority), message);


### PR DESCRIPTION
## Summary
Set "from_network" for remote add-overwrites of existing SWHOIS values.
<!--
Briefly describe what this pull request changes.
-->

## Rationale
A user noticed that services bounces were adding extra lines to /whois.
<!--
Describe why you have made this change.
-->

## Testing Environment
Insp 4.10.1 with the contrib version of this module.
<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** Ubuntu 26.04/WSL, 5.10.102.1-microsoft-standard-WSL2
**Compiler name and version:** G++ 15.2

## Checks

<!--
Tick the boxes for the checks you have made.
-->

I have ensured that:

- [X] The code I am submitting is my own work and/or I have permission from the author to share it.
- [X] Generative AI (Copilot, ChatGPT, etc) was not used to create any part of this pull request.
